### PR TITLE
Adding Central Repo requirements in pom file for the artifacts upload

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.dapr</groupId>
   <artifactId>examples</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.0-preview</version>
+  <version>0.1.0-preview01</version>
   <name>dapr-client</name>
   <url>https://dapr.io</url>
 
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>client</artifactId>
-      <version>0.1.0-preview</version>
+      <version>0.1.0-preview01</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,32 @@
   <groupId>io.dapr</groupId>
   <artifactId>client</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.0-preview</version>
+  <version>0.1.0-preview01</version>
   <name>dapr-client</name>
+  <description>gRPC client for Dapr.</description>
   <url>https://dapr.io</url>
 
   <licenses>
     <license>
       <name>MIT License</name>
       <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>Dapr</name>
+      <email>daprweb@microsoft.com</email>
+      <organization>Dapr</organization>
+      <organizationUrl>https://dapr.io</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/dapr/java-sdk.git</connection>
+    <developerConnection>scm:git:ssh://github.com:dapr/java-sdk.git</developerConnection>
+    <url>http://github.com/dapr/java-sdk</url>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,6 +100,32 @@
     <extensions>
     </extensions>
     <plugins>
-    </plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-source-plugin</artifactId>
+      <version>2.2.1</version>
+      <executions>
+        <execution>
+          <id>attach-sources</id>
+          <goals>
+            <goal>jar-no-fork</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-javadoc-plugin</artifactId>
+      <version>3.1.0</version>
+      <executions>
+        <execution>
+          <id>attach-javadocs</id>
+          <goals>
+            <goal>jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
   </build>
 </project>


### PR DESCRIPTION
To ensure a level of quality of the components available in the Nexus Central Repository , adding requirements in pom file for the artifacts

 - Noted that Signing artifacts will be offline manual process


