### PR TITLE
link maven install webpage and clarify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clone this repository including the submodules:
 git clone https://github.com/dapr/java-sdk.git
 ```
 
-Then head over to build the Maven project:
+Then head over to build the [Maven](https://maven.apache.org/install.html) (Apache Maven version 3.x) project:
 
 ```sh
 # make sure you are in the `java-sdk` directory.


### PR DESCRIPTION
# Description

Simple change, just clarifies maven location and version in front page readme.

## Issue reference


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
