### PR TITLE
Request body must be null on get for okhttp, empty body does not work…

### DIFF
--- a/sdk/src/main/java/io/dapr/actors/runtime/AbstractActor.java
+++ b/sdk/src/main/java/io/dapr/actors/runtime/AbstractActor.java
@@ -39,11 +39,6 @@ public abstract class AbstractActor {
     private final ActorId id;
 
     /**
-     * Manager for the states in Actors.
-     */
-    private final ActorStateManager actorStateManager;
-
-    /**
      * Emits trace messages for Actors.
      */
     private final ActorTrace actorTrace;
@@ -52,6 +47,11 @@ public abstract class AbstractActor {
      * Registered timers for this Actor.
      */
     private final Map<String, ActorTimer> timers;
+
+    /**
+     * Manager for the states in Actors.
+     */
+    protected final ActorStateManager actorStateManager;
 
     /**
      * Instantiates a new Actor.

--- a/sdk/src/main/java/io/dapr/actors/runtime/ActorStateManager.java
+++ b/sdk/src/main/java/io/dapr/actors/runtime/ActorStateManager.java
@@ -15,7 +15,7 @@ import java.util.*;
  * <p>
  * All changes are cached in-memory until save() is called.
  */
-class ActorStateManager {
+public class ActorStateManager {
 
     /**
      * Provides states using a state store.
@@ -44,7 +44,7 @@ class ActorStateManager {
      * @param actorTypeName Name of Actor's type.
      * @param actorId       Actor's identifier.
      */
-    ActorStateManager(DaprStateAsyncProvider stateProvider, String actorTypeName, ActorId actorId) {
+    public ActorStateManager(DaprStateAsyncProvider stateProvider, String actorTypeName, ActorId actorId) {
         this.stateProvider = stateProvider;
         this.actorTypeName = actorTypeName;
         this.actorId = actorId;
@@ -59,7 +59,7 @@ class ActorStateManager {
      * @param <T>       Type of the object being added.
      * @return Asynchronous void operation.
      */
-    <T> Mono<Void> add(String stateName, T value) {
+    public <T> Mono<Void> add(String stateName, T value) {
         try {
             if (stateName == null) {
                 throw new IllegalArgumentException("State's name cannot be null.");
@@ -98,7 +98,7 @@ class ActorStateManager {
      * @param <T>       Type being fetched.
      * @return Asynchronous response with fetched object.
      */
-    <T> Mono<T> get(String stateName, Class<T> clazz) {
+    public <T> Mono<T> get(String stateName, Class<T> clazz) {
         try {
             if (stateName == null) {
                 throw new IllegalArgumentException("State's name cannot be null.");
@@ -133,7 +133,7 @@ class ActorStateManager {
      * @param <T>       Type of the value being set.
      * @return Asynchronous void result.
      */
-    <T> Mono<Void> set(String stateName, T value) {
+    public <T> Mono<Void> set(String stateName, T value) {
         try {
             if (stateName == null) {
                 throw new IllegalArgumentException("State's name cannot be null.");
@@ -169,7 +169,7 @@ class ActorStateManager {
      * @param stateName State being stored.
      * @return Asynchronous void result.
      */
-    Mono<Void> remove(String stateName) {
+    public Mono<Void> remove(String stateName) {
         try {
             if (stateName == null) {
                 throw new IllegalArgumentException("State's name cannot be null.");
@@ -209,7 +209,7 @@ class ActorStateManager {
      * @param stateName State being checked.
      * @return Asynchronous boolean result indicating whether state is present.
      */
-    Mono<Boolean> contains(String stateName) {
+    public Mono<Boolean> contains(String stateName) {
         try {
             if (stateName == null) {
                 throw new IllegalArgumentException("State's name cannot be null.");
@@ -236,7 +236,7 @@ class ActorStateManager {
      *
      * @return Asynchronous void result.
      */
-    Mono<Void> save() {
+    public Mono<Void> save() {
         if (this.stateChangeTracker.isEmpty()) {
             return Mono.empty();
         }
@@ -264,7 +264,7 @@ class ActorStateManager {
      *
      * @return
      */
-    Mono<Void> clear() {
+    public Mono<Void> clear() {
         this.stateChangeTracker.clear();
         return Mono.empty();
     }

--- a/sdk/src/main/java/io/dapr/actors/runtime/ActorStateManager.java
+++ b/sdk/src/main/java/io/dapr/actors/runtime/ActorStateManager.java
@@ -44,7 +44,7 @@ public class ActorStateManager {
      * @param actorTypeName Name of Actor's type.
      * @param actorId       Actor's identifier.
      */
-    public ActorStateManager(DaprStateAsyncProvider stateProvider, String actorTypeName, ActorId actorId) {
+    ActorStateManager(DaprStateAsyncProvider stateProvider, String actorTypeName, ActorId actorId) {
         this.stateProvider = stateProvider;
         this.actorTypeName = actorTypeName;
         this.actorId = actorId;

--- a/sdk/src/main/java/io/dapr/client/AbstractDaprHttpClient.java
+++ b/sdk/src/main/java/io/dapr/client/AbstractDaprHttpClient.java
@@ -105,7 +105,7 @@ public abstract class AbstractDaprHttpClient {
 
                         Request request = new Request.Builder()
                                 .url(new URL(this.baseUrl + urlString))
-                                .method(method, body)
+                                .method(method, (json == null && method == "GET") ? null : body)
                                 .addHeader(Constants.HEADER_DAPR_REQUEST_ID, requestId)
                                 .build();
 

--- a/sdk/src/main/java/io/dapr/client/AbstractDaprHttpClient.java
+++ b/sdk/src/main/java/io/dapr/client/AbstractDaprHttpClient.java
@@ -105,7 +105,7 @@ public abstract class AbstractDaprHttpClient {
 
                         Request request = new Request.Builder()
                                 .url(new URL(this.baseUrl + urlString))
-                                .method(method, (json == null && method == "GET") ? null : body)
+                                .method(method, (json == null && method.equals("GET")) ? null : body)
                                 .addHeader(Constants.HEADER_DAPR_REQUEST_ID, requestId)
                                 .build();
 


### PR DESCRIPTION

# Description

This fixes errors on http get calls.  Request body must be null on get for okhttp, empty body does not work. Also, expose the ActorStateManager methods that ought to be exposed to user.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_29_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
