### PR TITLE
Fix arg parsing

### DIFF
--- a/sdk/src/test/java/io/dapr/it/DaprIntegrationTestingRunner.java
+++ b/sdk/src/test/java/io/dapr/it/DaprIntegrationTestingRunner.java
@@ -78,16 +78,14 @@ public class DaprIntegrationTestingRunner {
   }
 
   private static final String DAPR_RUN = "dapr run --app-id %s ";
-  private static final String DAPR_COMMAND = " -- mvn exec:java -D exec.mainClass=%s -D exec.classpathScope=\"test\" -Dexec.args=\"-p %d -grpcPort %d -httpPort %d\"";
+
+  // the arg in -Dexec.args is the app's port
+  private static final String DAPR_COMMAND = " -- mvn exec:java -Dexec.mainClass=%s -Dexec.classpathScope=test -Dexec.args=\"%d\"";
 
   private String buildDaprCommand(){
     StringBuilder stringBuilder= new StringBuilder(String.format(DAPR_RUN, this.appName))
       .append(this.useAppPort ? "--app-port " + this.DAPR_FREEPORTS.appPort : "")
-      .append(" --grpc-port ")
-      .append(this.DAPR_FREEPORTS.grpcPort)
-      .append(" --port ")
-      .append(this.DAPR_FREEPORTS.httpPort)
-      .append(String.format(DAPR_COMMAND, this.serviceClass.getCanonicalName(),this.DAPR_FREEPORTS.appPort, this.DAPR_FREEPORTS.grpcPort, this.DAPR_FREEPORTS.httpPort));
+      .append(String.format(DAPR_COMMAND, this.serviceClass.getCanonicalName(),this.DAPR_FREEPORTS.appPort));
     return stringBuilder.toString();
   }
 

--- a/sdk/src/test/java/io/dapr/it/services/EmptyService.java
+++ b/sdk/src/test/java/io/dapr/it/services/EmptyService.java
@@ -7,9 +7,13 @@ package io.dapr.it.services;
 
 /**
  * Use this class in order to run DAPR with any needed services, like states.
+ *
+ * To run manually, from repo root:
+ * 1. mvn clean install
+ * 2. dapr run --grpc-port 41707 --port 32851 -- mvn exec:java -Dexec.mainClass=io.dapr.it.services.EmptyService -Dexec.classpathScope="test" -Dexec.args="-p 44511 -grpcPort 41707 -httpPort 32851" -pl=sdk
  */
 public class EmptyService {
     public static void main(String[] args) {
-
+        System.out.println("Hello from EmptyService");
     }
 }

--- a/sdk/src/test/java/io/dapr/it/services/HelloWorldGrpcStateService.java
+++ b/sdk/src/test/java/io/dapr/it/services/HelloWorldGrpcStateService.java
@@ -17,24 +17,19 @@ import org.apache.commons.cli.*;
 
 
 /**
- * Simple example, to run:
- * mvn clean install
- * dapr run --grpc-port 50001 -- mvn exec:java -pl=examples -Dexec.mainClass=io.dapr.examples.Example
+ * Simple example.
+ * To run manually, from repo root:
+ * 1. mvn clean install
+ * 2. dapr run --grpc-port 50001 -- mvn exec:java -Dexec.mainClass=io.dapr.it.services.HelloWorldGrpcStateService -Dexec.classpathScope="test"  -pl=sdk
  */
 public class HelloWorldGrpcStateService {
 
     public static void main(String[] args) throws ParseException {
-        Options options = new Options();
-        options.addRequiredOption("grpcPort", "grpcPort", true, "Dapr GRPC.");
-        options.addRequiredOption("httpPort", "httpPort", true, "Dapr HTTP port.");
-        options.addRequiredOption("p", "port", true, "Port Dapr will listen to.");
-
-        CommandLineParser parser = new DefaultParser();
-        CommandLine cmd = parser.parse(options, args);
+        String grpcPort = System.getenv("DAPR_GRPC_PORT");
 
         // If port string is not valid, it will throw an exception.
-        int port = Integer.parseInt(cmd.getOptionValue("grpcPort"));
-        ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+        int grpcPortInt = Integer.parseInt(grpcPort);
+        ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", grpcPortInt).usePlaintext().build();
         DaprBlockingStub client = DaprGrpc.newBlockingStub(channel);
 
         String key = "mykey";


### PR DESCRIPTION
# Description

This fixes parsing during integration tests.  It seems -Dexec.args= cannot contain hyphens.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
