### PR TITLE
Locking not needed for timer map

### DIFF
--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/AbstractActor.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/AbstractActor.java
@@ -72,7 +72,7 @@ public abstract class AbstractActor {
           runtimeContext.getActorTypeInformation().getName(),
           id);
     this.actorTrace = runtimeContext.getActorTrace();
-    this.timers = Collections.synchronizedMap(new HashMap<>());
+    this.timers = new HashMap<>();
     this.started = false;
   }
 


### PR DESCRIPTION
# Description

Upon reviewing locking there's only one that isn't lock isn't needed - timers for an actor should not get updated concurrency.  

Other locking in the sdk today look ok.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_82_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
