### PR TITLE
Renaming Adapters, to be just Clients for GRPC and HTTP

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/state/GRPCStateClientIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/state/GRPCStateClientIT.java
@@ -7,13 +7,12 @@ package io.dapr.it.state;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.DaprClientGrpcAdapter;
+import io.dapr.client.DaprClientGrpc;
 import io.dapr.client.domain.State;
 import io.dapr.client.domain.StateOptions;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
 import io.dapr.it.services.EmptyService;
-import io.dapr.serializer.DefaultObjectSerializer;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,7 +43,7 @@ public class GRPCStateClientIT extends BaseIT {
     daprRun.switchToGRPC();
     daprClient = new DaprClientBuilder().build();
 
-    assertTrue(daprClient instanceof DaprClientGrpcAdapter);
+    assertTrue(daprClient instanceof DaprClientGrpc);
   }
 
 

--- a/sdk/src/main/java/io/dapr/client/DaprClientBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientBuilder.java
@@ -105,7 +105,7 @@ public class DaprClientBuilder {
       throw new IllegalStateException("Invalid port.");
     }
     ManagedChannel channel = ManagedChannelBuilder.forAddress(Constants.DEFAULT_HOSTNAME, port).usePlaintext().build();
-    return new DaprClientGrpcAdapter(DaprGrpc.newFutureStub(channel), this.objectSerializer, this.stateSerializer);
+    return new DaprClientGrpc(DaprGrpc.newFutureStub(channel), this.objectSerializer, this.stateSerializer);
   }
 
   /**
@@ -120,6 +120,6 @@ public class DaprClientBuilder {
     }
     OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
     DaprHttp daprHttp = new DaprHttp(port, okHttpClient);
-    return new DaprClientHttpAdapter(daprHttp, this.objectSerializer, this.stateSerializer);
+    return new DaprClientHttp(daprHttp, this.objectSerializer, this.stateSerializer);
   }
 }

--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Mono;
  * @see io.dapr.DaprGrpc
  * @see io.dapr.client.DaprClient
  */
-public class DaprClientGrpcAdapter implements DaprClient {
+public class DaprClientGrpc implements DaprClient {
 
   /**
    * The GRPC client to be used.
@@ -57,7 +57,7 @@ public class DaprClientGrpcAdapter implements DaprClient {
    * @param stateSerializer  Serializer for state objects.
    * @see DaprClientBuilder
    */
-  DaprClientGrpcAdapter(
+  DaprClientGrpc(
       DaprGrpc.DaprFutureStub futureClient,
       DaprObjectSerializer objectSerializer,
       DaprObjectSerializer stateSerializer) {

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
  * @see io.dapr.client.DaprHttp
  * @see io.dapr.client.DaprClient
  */
-public class DaprClientHttpAdapter implements DaprClient {
+public class DaprClientHttp implements DaprClient {
 
   /**
    * Serializer for internal objects.
@@ -67,7 +67,7 @@ public class DaprClientHttpAdapter implements DaprClient {
    * @see DaprClientBuilder
    * @see DefaultObjectSerializer
    */
-  DaprClientHttpAdapter(DaprHttp client, DaprObjectSerializer objectSerializer, DaprObjectSerializer stateSerializer) {
+  DaprClientHttp(DaprHttp client, DaprObjectSerializer objectSerializer, DaprObjectSerializer stateSerializer) {
     this.client = client;
     this.objectSerializer = objectSerializer;
     this.stateSerializer = stateSerializer;
@@ -81,7 +81,7 @@ public class DaprClientHttpAdapter implements DaprClient {
    * @see io.dapr.client.DaprClientBuilder
    * @see DefaultObjectSerializer
    */
-  DaprClientHttpAdapter(DaprHttp client) {
+  DaprClientHttp(DaprHttp client) {
     this(client, new DefaultObjectSerializer(), new DefaultObjectSerializer());
   }
 

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -28,16 +28,16 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class DaprClientGrpcAdapterTest {
+public class DaprClientGrpcTest {
 
   private DaprGrpc.DaprFutureStub client;
-  private DaprClientGrpcAdapter adapter;
+  private DaprClientGrpc adapter;
   private ObjectSerializer serializer;
 
   @Before
   public void setup() {
     client = mock(DaprGrpc.DaprFutureStub.class);
-    adapter = new DaprClientGrpcAdapter(client, new DefaultObjectSerializer(), new DefaultObjectSerializer());
+    adapter = new DaprClientGrpc(client, new DefaultObjectSerializer(), new DefaultObjectSerializer());
     serializer = new ObjectSerializer();
   }
 

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-public class DaprClientHttpAdapterTest {
+public class DaprClientHttpTest {
 
-  private DaprClientHttpAdapter daprClientHttpAdapter;
+  private DaprClientHttp daprClientHttp;
 
   private DaprHttp daprHttp;
 
@@ -45,8 +45,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    DaprClientHttpAdapter daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.publishEvent("A", event, null);
+    DaprClientHttp daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.publishEvent("A", event, null);
     assertNull(mono.block());
   }
 
@@ -57,8 +57,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.publishEvent("A", event);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.publishEvent("A", event);
     assertNull(mono.block());
   }
 
@@ -69,8 +69,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.publishEvent("", event);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.publishEvent("", event);
     assertNull(mono.block());
   }
 
@@ -81,8 +81,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeService(null, "", "", null, null, null);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeService(null, "", "", null, null, null);
     assertNull(mono.block());
   }
 
@@ -93,21 +93,21 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
+    daprClientHttp = new DaprClientHttp(daprHttp);
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.invokeService(null, "", "", null, null, null).block();
+      daprClientHttp.invokeService(null, "", "", null, null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.invokeService(Verb.POST, null, "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, null, "", null, null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.invokeService(Verb.POST, "", "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "", "", null, null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.invokeService(Verb.POST, "1", null, null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "1", null, null, null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.invokeService(Verb.POST, "1", "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "1", "", null, null, null).block();
     });
   }
 
@@ -119,8 +119,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeService(Verb.POST, "1", "", null, null, null);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeService(Verb.POST, "1", "", null, null, null);
     assertNull(mono.block());
   }
 
@@ -130,8 +130,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
       .respond("hello world");
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<String> mono = daprClientHttpAdapter.invokeService(Verb.GET, "41", "neworder", null, null, String.class);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<String> mono = daprClientHttp.invokeService(Verb.GET, "41", "neworder", null, null, String.class);
     assertEquals("hello world", mono.block());
   }
 
@@ -142,8 +142,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<byte[]> mono = daprClientHttpAdapter.invokeService(Verb.GET, "41", "neworder", null, byte[].class);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<byte[]> mono = daprClientHttp.invokeService(Verb.GET, "41", "neworder", null, byte[].class);
     assertEquals(new String(mono.block()), EXPECTED_RESULT);
   }
 
@@ -154,8 +154,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<byte[]> mono = daprClientHttpAdapter.invokeService(Verb.GET, "41", "neworder", (byte[]) null, map);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<byte[]> mono = daprClientHttp.invokeService(Verb.GET, "41", "neworder", (byte[]) null, map);
     String monoString = new String(mono.block());
     assertEquals(monoString, EXPECTED_RESULT);
   }
@@ -167,8 +167,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeService(Verb.GET, "41", "neworder", map);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeService(Verb.GET, "41", "neworder", map);
     assertNull(mono.block());
   }
 
@@ -179,8 +179,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeService(Verb.GET, "41", "neworder", "", map);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeService(Verb.GET, "41", "neworder", "", map);
     assertNull(mono.block());
   }
 
@@ -191,8 +191,8 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/bindings/sample-topic")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeBinding("sample-topic", "");
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeBinding("sample-topic", "");
     assertNull(mono.block());
   }
 
@@ -203,8 +203,8 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/bindings/sample-topic")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.invokeBinding(null, "");
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeBinding(null, "");
     assertNull(mono.block());
   }
 
@@ -218,11 +218,11 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
+    daprClientHttp = new DaprClientHttp(daprHttp);
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.getState(stateKeyNull, String.class).block();
+      daprClientHttp.getState(stateKeyNull, String.class).block();
     });
-    Mono<State<String>> mono = daprClientHttpAdapter.getState(stateKeyValue, String.class);
+    Mono<State<String>> mono = daprClientHttp.getState(stateKeyValue, String.class);
     assertEquals(mono.block().getKey(), "key");
   }
 
@@ -233,8 +233,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<State<String>> monoEmptyEtag = daprClientHttpAdapter.getState(stateEmptyEtag, String.class);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<State<String>> monoEmptyEtag = daprClientHttp.getState(stateEmptyEtag, String.class);
     assertEquals(monoEmptyEtag.block().getKey(), "key");
   }
 
@@ -245,8 +245,8 @@ public class DaprClientHttpAdapterTest {
       .get("http://localhost:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<State<String>> monoNullEtag = daprClientHttpAdapter.getState(stateNullEtag, String.class);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<State<String>> monoNullEtag = daprClientHttp.getState(stateNullEtag, String.class);
     assertEquals(monoNullEtag.block().getKey(), "key");
   }
 
@@ -258,8 +258,8 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.saveStates(stateKeyValueList);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.saveStates(stateKeyValueList);
     assertNull(mono.block());
   }
 
@@ -271,10 +271,10 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.saveStates(null);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.saveStates(null);
     assertNull(mono.block());
-    Mono<Void> mono1 = daprClientHttpAdapter.saveStates(stateKeyValueList);
+    Mono<Void> mono1 = daprClientHttp.saveStates(stateKeyValueList);
     assertNull(mono1.block());
   }
 
@@ -286,8 +286,8 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.saveStates(stateKeyValueList);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.saveStates(stateKeyValueList);
     assertNull(mono.block());
   }
 
@@ -299,8 +299,8 @@ public class DaprClientHttpAdapterTest {
       .post("http://localhost:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.saveStates(stateKeyValueList);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.saveStates(stateKeyValueList);
     assertNull(mono.block());
   }
 
@@ -311,8 +311,8 @@ public class DaprClientHttpAdapterTest {
       .respond(EXPECTED_RESULT);
     StateOptions stateOptions = mock(StateOptions.class);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.saveState("key", "etag", "value", stateOptions);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.saveState("key", "etag", "value", stateOptions);
     assertNull(mono.block());
   }
 
@@ -325,8 +325,8 @@ public class DaprClientHttpAdapterTest {
       .delete("http://localhost:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), stateOptions);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), stateOptions);
     assertNull(mono.block());
   }
 
@@ -337,8 +337,8 @@ public class DaprClientHttpAdapterTest {
       .delete("http://localhost:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), null);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), null);
     assertNull(mono.block());
   }
 
@@ -349,8 +349,8 @@ public class DaprClientHttpAdapterTest {
       .delete("http://localhost:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
-    Mono<Void> mono = daprClientHttpAdapter.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), null);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.deleteState(stateKeyValue.getKey(), stateKeyValue.getEtag(), null);
     assertNull(mono.block());
   }
 
@@ -362,15 +362,15 @@ public class DaprClientHttpAdapterTest {
       .delete("http://localhost:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
-    daprClientHttpAdapter = new DaprClientHttpAdapter(daprHttp);
+    daprClientHttp = new DaprClientHttp(daprHttp);
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.deleteState(null, null, null).block();
+      daprClientHttp.deleteState(null, null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.deleteState("", null, null).block();
+      daprClientHttp.deleteState("", null, null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttpAdapter.deleteState(" ", null, null).block();
+      daprClientHttp.deleteState(" ", null, null).block();
     });
   }
 }

--- a/sdk/src/test/java/io/dapr/client/DaprClientTestBuilder.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientTestBuilder.java
@@ -16,6 +16,6 @@ public class DaprClientTestBuilder {
      * @return New instance of DaprClient.
      */
     public static DaprClient buildHttpClient(DaprHttp client) {
-        return new DaprClientHttpAdapter(client);
+        return new DaprClientHttp(client);
     }
 }


### PR DESCRIPTION
# Description

Renaming Adapters, to be just Clients for GRPC and HTTP

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
