### PR TITLE
Fix issue where http client builder was always using default timeout.

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
@@ -52,7 +52,7 @@ public class DaprHttpBuilder {
    */
   private DaprHttp buildDaprHttp() {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
-    builder.readTimeout(DEFAULT_READ_TIMEOUT);
+    builder.readTimeout(this.readTimeout);
     OkHttpClient okHttpClient = builder.build();
     return new DaprHttp(Properties.HTTP_PORT.get(), okHttpClient);
   }

--- a/sdk/src/test/java/io/dapr/client/DaprHttpBuilderTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprHttpBuilderTest.java
@@ -1,7 +1,12 @@
 package io.dapr.client;
 
+import okhttp3.OkHttpClient;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
 import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
@@ -10,10 +15,27 @@ public class DaprHttpBuilderTest {
   @Test
   public void withReadTimeout() throws Exception {
     DaprHttpBuilder daprHttpBuilder = new DaprHttpBuilder();
-    Duration duration = mock(Duration.class);
+    Duration duration = Duration.ofSeconds(999);
     daprHttpBuilder.build();
     DaprHttpBuilder dapr = daprHttpBuilder.withReadTimeout(duration);
     assertNotNull(dapr);
+
+    DaprHttp daprHttp = daprHttpBuilder.build();
+    assertOKHttpPropertyValue(daprHttp, "readTimeoutMillis", (int)duration.toMillis());
+  }
+
+  private static final void assertOKHttpPropertyValue(DaprHttp daprHttp, String propertyName, Object expectedValue) throws Exception {
+    // First, get okHttpClient.
+    Field httpClientField = DaprHttp.class.getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+    OkHttpClient okHttpClient = (OkHttpClient) httpClientField.get(daprHttp);
+    assertNotNull(okHttpClient);
+
+    Field propertyField = OkHttpClient.class.getDeclaredField(propertyName);
+    propertyField.setAccessible(true);
+    Object value = propertyField.get(okHttpClient);
+    assertNotNull(value);
+    assertEquals(expectedValue, value);
   }
 
 }


### PR DESCRIPTION
# Description

Fix issue where http client builder was always using default timeout.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #21 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
