### PR TITLE
Fix release due to missing javadocs + fix headers.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  ~ Copyright (c) Microsoft Corporation.
+  ~ Licensed under the MIT License.
+  -->
+
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -36,6 +41,11 @@
     <property name="fileExtensions" value="java"/>
     <property name="max" value="120"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <module name="Header">
+    <property name="fileExtensions" value="java"/>
+    <property name="header"  value="/*\n * Copyright (c) Microsoft Corporation.\n * Licensed under the MIT License.\n */"/>
   </module>
 
   <module name="TreeWalker">

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -127,6 +127,13 @@
           <release>11</release>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/examples/src/main/java/io/dapr/examples/state/StateClient.java
+++ b/examples/src/main/java/io/dapr/examples/state/StateClient.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.examples.state;
 
 import io.dapr.client.DaprClient;

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.runtime;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorMethodInfoMap.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorMethodInfoMap.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.runtime;
 
 import java.lang.reflect.Method;

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorReminderParams.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorReminderParams.java
@@ -1,7 +1,7 @@
-// ------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
 
 package io.dapr.actors.runtime;
 

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorReminderParamsTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorReminderParamsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.runtime;
 
 import org.junit.Assert;

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorTimerTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorTimerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.actors.runtime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -104,6 +104,19 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>

--- a/sdk/src/main/java/io/dapr/utils/DurationUtils.java
+++ b/sdk/src/main/java/io/dapr/utils/DurationUtils.java
@@ -1,7 +1,7 @@
-// ------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
 
 package io.dapr.utils;
 

--- a/sdk/src/test/java/io/dapr/client/DaprClientBuilderTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientBuilderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.client;
 
 import io.dapr.serializer.DaprObjectSerializer;

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.client;
 
 import com.google.common.util.concurrent.FutureCallback;

--- a/sdk/src/test/java/io/dapr/client/DaprHttpBuilderTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprHttpBuilderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.client;
 
 import okhttp3.OkHttpClient;

--- a/sdk/src/test/java/io/dapr/utils/DurationUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/DurationUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
 package io.dapr.utils;
 
 import org.junit.Assert;


### PR DESCRIPTION
# Description

Removes examples from deployment.
Adds javadocs to autogen.
Adds license headers to missing files.
Changes checkstyle to enforce license headers.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
