### PR TITLE
Adding link to Javadocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Try the following examples to learn more about Dapr's Java SDK:
 * [Binding with input over Http](./examples/src/main/java/io/dapr/examples/bindings/http)
 * [Actors over Http](./examples/src/main/java/io/dapr/examples/actors/http)
 
+#### API Documentation
+
+Please, refer to our [Javadoc](https://dapr.github.io/java-sdk/) website.
+
 #### Debug Java application or Dapr's Java SDK
 
 If you have a Java application or an issue on this SDK that needs to be debugged, run Dapr using a dummy command and start the application from your IDE (IntelliJ, for example).


### PR DESCRIPTION
# Description

Adding link to Javadocs.

Note: Javadocs is the right casing now - it used to be JavaDoc (https://en.wikipedia.org/wiki/Javadoc).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #177 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
