### PR TITLE
Use 127.0.0.1 instead of localhost for daprd endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ DAPR_GRPC_PORT=5001
 
 Now you can go to your IDE (like IntelliJ, for example) and debug your Java application, using port `3500` to call Dapr while also listening to port `3000` to expose Dapr's callback endpoint.
 
-Calls to Dapr's APIs on `http://localhost:3500/*` should work now and trigger breakpoints in your code.
+Calls to Dapr's APIs on `http://127.0.0.1:3500/*` should work now and trigger breakpoints in your code.
 
 **If your application needs to subscribe to topics or register Actors in Dapr, for example, then start debugging your app first and run dapr with dummy command last.**
 

--- a/sdk-actors/src/test/java/io/dapr/actors/client/DaprHttpClientTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/DaprHttpClientTest.java
@@ -36,7 +36,7 @@ public class DaprHttpClientTest {
   public void invokeActorMethod() {
     DaprHttp daprHttpMock = mock(DaprHttp.class);
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/actors/DemoActor/1/method/Payment")
+      .post("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/method/Payment")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprHttpClientTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprHttpClientTest.java
@@ -35,7 +35,7 @@ public class DaprHttpClientTest {
   @Test
   public void getActorState() {
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/actors/DemoActor/1/state/order")
+      .get("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/state/order")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);
@@ -47,7 +47,7 @@ public class DaprHttpClientTest {
   @Test
   public void saveActorStateTransactionally() {
     mockInterceptor.addRule()
-      .put("http://localhost:3000/v1.0/actors/DemoActor/1/state")
+      .put("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/state")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);
@@ -59,7 +59,7 @@ public class DaprHttpClientTest {
   @Test
   public void registerActorReminder() {
     mockInterceptor.addRule()
-      .put("http://localhost:3000/v1.0/actors/DemoActor/1/reminders/reminder")
+      .put("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/reminders/reminder")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);
@@ -71,7 +71,7 @@ public class DaprHttpClientTest {
   @Test
   public void unregisterActorReminder() {
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/actors/DemoActor/1/reminders/reminder")
+      .delete("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/reminders/reminder")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);
@@ -82,7 +82,7 @@ public class DaprHttpClientTest {
   @Test
   public void registerActorTimer() {
     mockInterceptor.addRule()
-      .put("http://localhost:3000/v1.0/actors/DemoActor/1/timers/timer")
+      .put("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/timers/timer")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);
@@ -94,7 +94,7 @@ public class DaprHttpClientTest {
   @Test
   public void unregisterActorTimer() {
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/actors/DemoActor/1/timers/timer")
+      .delete("http://127.0.0.1:3000/v1.0/actors/DemoActor/1/timers/timer")
       .respond(EXPECTED_RESULT);
     DaprHttp daprHttp = new DaprHttpProxy(3000, okHttpClient);
     DaprHttpClient = new DaprHttpClient(daprHttp);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
@@ -45,7 +45,7 @@ public class ActorTurnBasedConcurrencyIT extends BaseIT {
   @After
   public void cleanUpTestCase() {
     // Delete the reminder in case the test failed, otherwise it may interfere with future tests since it is persisted.
-    // It'll have this structure with different values: http://localhost:33997/v1.0/actors/MyActorTest/1/reminders/588e4adc-f902-4596-b12e-3d2955db68b6
+    // It'll have this structure with different values: http://127.0.0.1:33997/v1.0/actors/MyActorTest/1/reminders/588e4adc-f902-4596-b12e-3d2955db68b6
     DaprHttp client = new DaprHttpBuilder().build();
     String url = String.format(Constants.ACTOR_REMINDER_RELATIVE_URL_FORMAT, ACTOR_TYPE, ACTOR_ID, REMINDER_NAME);
 

--- a/sdk-tests/src/test/java/io/dapr/it/state/HelloWorldClientIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/state/HelloWorldClientIT.java
@@ -26,7 +26,7 @@ public class HelloWorldClientIT extends BaseIT {
         2000
     );
     ManagedChannel channel =
-      ManagedChannelBuilder.forAddress("localhost", daprRun.getGrpcPort()).usePlaintext().build();
+      ManagedChannelBuilder.forAddress("127.0.0.1", daprRun.getGrpcPort()).usePlaintext().build();
     DaprGrpc.DaprBlockingStub client = DaprGrpc.newBlockingStub(channel);
 
     String key = "mykey";

--- a/sdk-tests/src/test/java/io/dapr/it/state/HelloWorldGrpcStateService.java
+++ b/sdk-tests/src/test/java/io/dapr/it/state/HelloWorldGrpcStateService.java
@@ -30,7 +30,7 @@ public class HelloWorldGrpcStateService {
 
     // If port string is not valid, it will throw an exception.
     int grpcPortInt = Integer.parseInt(grpcPort);
-    ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", grpcPortInt).usePlaintext().build();
+    ManagedChannel channel = ManagedChannelBuilder.forAddress("127.0.0.1", grpcPortInt).usePlaintext().build();
     DaprBlockingStub client = DaprGrpc.newBlockingStub(channel);
 
     String key = "mykey";

--- a/sdk/src/main/java/io/dapr/utils/Constants.java
+++ b/sdk/src/main/java/io/dapr/utils/Constants.java
@@ -18,7 +18,7 @@ public final class Constants {
   /**
    * Dapr's default hostname.
    */
-  public static final String DEFAULT_HOSTNAME = "localhost";
+  public static final String DEFAULT_HOSTNAME = "127.0.0.1";
 
   /**
    * Header used for request id in Dapr.

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -41,7 +41,7 @@ public class DaprClientHttpTest {
   @Test
   public void publishEventInvokation() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -53,7 +53,7 @@ public class DaprClientHttpTest {
   @Test
   public void publishEvent() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -65,7 +65,7 @@ public class DaprClientHttpTest {
   @Test(expected = IllegalArgumentException.class)
   public void publishEventIfTopicIsNull() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -77,7 +77,7 @@ public class DaprClientHttpTest {
   @Test(expected = IllegalArgumentException.class)
   public void invokeServiceVerbNull() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -89,7 +89,7 @@ public class DaprClientHttpTest {
   @Test
   public void invokeServiceIllegalArgumentException() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -115,7 +115,7 @@ public class DaprClientHttpTest {
   @Test(expected = IllegalArgumentException.class)
   public void invokeServiceMethodNull() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/publish/A")
+      .post("http://127.0.0.1:3000/v1.0/publish/A")
       .respond(EXPECTED_RESULT);
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -127,7 +127,7 @@ public class DaprClientHttpTest {
   @Test
   public void invokeService() {
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
+      .get("http://127.0.0.1:3000/v1.0/invoke/41/method/neworder")
       .respond("hello world");
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -139,7 +139,7 @@ public class DaprClientHttpTest {
   public void simpleInvokeService() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
+      .get("http://127.0.0.1:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -151,7 +151,7 @@ public class DaprClientHttpTest {
   public void invokeServiceWithMaps() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
+      .get("http://127.0.0.1:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -164,7 +164,7 @@ public class DaprClientHttpTest {
   public void invokeServiceWithOutRequest() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
+      .get("http://127.0.0.1:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -176,7 +176,7 @@ public class DaprClientHttpTest {
   public void invokeServiceWithRequest() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/invoke/41/method/neworder")
+      .get("http://127.0.0.1:3000/v1.0/invoke/41/method/neworder")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -188,7 +188,7 @@ public class DaprClientHttpTest {
   public void invokeBinding() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/bindings/sample-topic")
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -200,7 +200,7 @@ public class DaprClientHttpTest {
   public void invokeBindingNullName() {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/bindings/sample-topic")
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -215,7 +215,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValue = new State("value", "key", "etag", stateOptions);
     State<String> stateKeyNull = new State("value", null, "etag", stateOptions);
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/state/key")
+      .get("http://127.0.0.1:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -230,7 +230,7 @@ public class DaprClientHttpTest {
   public void getStatesEmptyEtag() {
     State<String> stateEmptyEtag = new State("value", "key", "", null);
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/state/key")
+      .get("http://127.0.0.1:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -242,7 +242,7 @@ public class DaprClientHttpTest {
   public void getStatesNullEtag() {
     State<String> stateNullEtag = new State("value", "key", null, null);
     mockInterceptor.addRule()
-      .get("http://localhost:3000/v1.0/state/key")
+      .get("http://127.0.0.1:3000/v1.0/state/key")
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -255,7 +255,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValue = new State("value", "key", "etag", null);
     List<State<?>> stateKeyValueList = Arrays.asList(stateKeyValue);
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/state")
+      .post("http://127.0.0.1:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -268,7 +268,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValue = new State("value", "key", "", null);
     List<State<?>> stateKeyValueList = new ArrayList();
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/state")
+      .post("http://127.0.0.1:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -283,7 +283,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValue = new State("value", "key", null, null);
     List<State<?>> stateKeyValueList = Arrays.asList(stateKeyValue);
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/state")
+      .post("http://127.0.0.1:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -296,7 +296,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValue = new State("value", "key", "", null);
     List<State<?>> stateKeyValueList = Arrays.asList(stateKeyValue);
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/state")
+      .post("http://127.0.0.1:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -307,7 +307,7 @@ public class DaprClientHttpTest {
   @Test
   public void simpleSaveStates() {
     mockInterceptor.addRule()
-      .post("http://localhost:3000/v1.0/state")
+      .post("http://127.0.0.1:3000/v1.0/state")
       .respond(EXPECTED_RESULT);
     StateOptions stateOptions = mock(StateOptions.class);
     daprHttp = new DaprHttp(3000, okHttpClient);
@@ -322,7 +322,7 @@ public class DaprClientHttpTest {
     StateOptions stateOptions = mock(StateOptions.class);
     State<String> stateKeyValue = new State("value", "key", "etag", stateOptions);
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/state/key")
+      .delete("http://127.0.0.1:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -334,7 +334,7 @@ public class DaprClientHttpTest {
   public void deleteStateNullEtag() {
     State<String> stateKeyValue = new State("value", "key", null, null);
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/state/key")
+      .delete("http://127.0.0.1:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -346,7 +346,7 @@ public class DaprClientHttpTest {
   public void deleteStateEmptyEtag() {
     State<String> stateKeyValue = new State("value", "key", "", null);
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/state/key")
+      .delete("http://127.0.0.1:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
@@ -359,7 +359,7 @@ public class DaprClientHttpTest {
     State<String> stateKeyValueNull = new State("value", null, "etag", null);
     State<String> stateKeyValueEmpty = new State("value", "", "etag", null);
     mockInterceptor.addRule()
-      .delete("http://localhost:3000/v1.0/state/key")
+      .delete("http://127.0.0.1:3000/v1.0/state/key")
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);

--- a/sdk/src/test/java/io/dapr/client/DaprHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprHttpTest.java
@@ -42,7 +42,7 @@ public class DaprHttpTest {
     headers.put("content-type", "text/html");
     headers.put("header1", "value1");
     mockInterceptor.addRule()
-      .post("http://localhost:3500/v1.0/state")
+      .post("http://127.0.0.1:3500/v1.0/state")
       .respond(serializer.serialize(EXPECTED_RESULT));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
     Mono<DaprHttp.Response> mono = daprHttp.invokeApi("POST", "v1.0/state", null, (byte[]) null, headers);
@@ -54,7 +54,7 @@ public class DaprHttpTest {
   @Test
   public void invokePostMethod() throws IOException {
     mockInterceptor.addRule()
-      .post("http://localhost:3500/v1.0/state")
+      .post("http://127.0.0.1:3500/v1.0/state")
       .respond(serializer.serialize(EXPECTED_RESULT))
       .addHeader("Header", "Value");
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
@@ -67,7 +67,7 @@ public class DaprHttpTest {
   @Test
   public void invokeDeleteMethod() throws IOException {
     mockInterceptor.addRule()
-      .delete("http://localhost:3500/v1.0/state")
+      .delete("http://127.0.0.1:3500/v1.0/state")
       .respond(serializer.serialize(EXPECTED_RESULT));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
     Mono<DaprHttp.Response> mono = daprHttp.invokeApi("DELETE", "v1.0/state", null, (String) null, null);
@@ -79,7 +79,7 @@ public class DaprHttpTest {
   @Test
   public void invokeGetMethod() throws IOException {
     mockInterceptor.addRule()
-      .get("http://localhost:3500/v1.0/get")
+      .get("http://127.0.0.1:3500/v1.0/get")
       .respond(serializer.serialize(EXPECTED_RESULT));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
     Mono<DaprHttp.Response> mono = daprHttp.invokeApi("GET", "v1.0/get", null, null);
@@ -96,7 +96,7 @@ public class DaprHttpTest {
     Map<String, String> urlParameters = new HashMap<>();
     urlParameters.put("orderId", "41");
     mockInterceptor.addRule()
-      .get("http://localhost:3500/v1.0/state/order?orderId=41")
+      .get("http://127.0.0.1:3500/v1.0/state/order?orderId=41")
       .respond(serializer.serialize(EXPECTED_RESULT));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
     Mono<DaprHttp.Response> mono = daprHttp.invokeApi("GET", "v1.0/state/order", urlParameters, headers);
@@ -108,7 +108,7 @@ public class DaprHttpTest {
   @Test(expected = RuntimeException.class)
   public void invokePostMethodRuntime() throws IOException {
     mockInterceptor.addRule()
-      .post("http://localhost:3500/v1.0/state")
+      .post("http://127.0.0.1:3500/v1.0/state")
       .respond(500);
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
     Mono<DaprHttp.Response> mono = daprHttp.invokeApi("POST", "v1.0/state", null, null);
@@ -120,7 +120,7 @@ public class DaprHttpTest {
   @Test(expected = RuntimeException.class)
   public void invokePostDaprError() throws IOException {
     mockInterceptor.addRule()
-      .post("http://localhost:3500/v1.0/state")
+      .post("http://127.0.0.1:3500/v1.0/state")
       .respond(500, ResponseBody.create(MediaType.parse("text"),
         "{\"errorCode\":null,\"message\":null}"));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
@@ -133,7 +133,7 @@ public class DaprHttpTest {
   @Test(expected = RuntimeException.class)
   public void invokePostMethodUnknownError() throws IOException {
     mockInterceptor.addRule()
-      .post("http://localhost:3500/v1.0/state")
+      .post("http://127.0.0.1:3500/v1.0/state")
       .respond(500, ResponseBody.create(MediaType.parse("application/json"),
         "{\"errorCode\":\"null\",\"message\":\"null\"}"));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
@@ -169,14 +169,14 @@ public class DaprHttpTest {
     String urlDeleteState = Constants.STATE_PATH + "/" + deletedStateKey;
     String urlExistingState = Constants.STATE_PATH + "/" + existingState;
     mockInterceptor.addRule()
-      .get("http://localhost:3500/" + urlDeleteState)
+      .get("http://127.0.0.1:3500/" + urlDeleteState)
       .respond(200, ResponseBody.create(MediaType.parse("application/json"),
         deletedStateKey));
     mockInterceptor.addRule()
-      .delete("http://localhost:3500/" + urlDeleteState)
+      .delete("http://127.0.0.1:3500/" + urlDeleteState)
       .respond(204);
     mockInterceptor.addRule()
-      .get("http://localhost:3500/" + urlExistingState)
+      .get("http://127.0.0.1:3500/" + urlExistingState)
       .respond(200, ResponseBody.create(MediaType.parse("application/json"),
         serializer.serialize(existingState)));
     DaprHttp daprHttp = new DaprHttp(3500, okHttpClient);
@@ -187,7 +187,7 @@ public class DaprHttpTest {
     assertEquals("", serializer.deserialize(responseDeleteKey.block().getBody(), String.class));
     mockInterceptor.reset();
     mockInterceptor.addRule()
-      .get("http://localhost:3500/" + urlDeleteState)
+      .get("http://127.0.0.1:3500/" + urlDeleteState)
       .respond(404, ResponseBody.create(MediaType.parse("application/json"),
         "{\"errorCode\":\"404\",\"message\":\"State Not Fuund\"}"));
     try {


### PR DESCRIPTION
# Description

Use 127.0.0.1 instead of localhost for daprd endpoint.
> cherry-pick from master conflicted with release branch. 

## Issue reference

#210 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
