### PR TITLE
[Master] Fixing bug in exception handling from actor impl.

### DIFF
--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
@@ -285,8 +285,10 @@ class ActorManager<T extends AbstractActor> {
           // Actor methods must have a one or no parameter, which is guaranteed at this point.
           return method.invoke(actor, input);
         }
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
-        return Mono.error(e);
+        throw new RuntimeException(e);
       }
     });
   }


### PR DESCRIPTION
# Description

Fixing bug in exception handling from actor impl: exception was wrongly wrapped in Mono.error() and returned instead of being thrown.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #245 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
