### PR TITLE
Fix ITs due to race condition on stop

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
@@ -49,16 +49,6 @@ public abstract class BaseIT {
     return run;
   }
 
-  protected static DaprRun restartDaprApp(DaprRun run) throws Exception {
-    DaprRun.Builder builder = DAPR_RUN_BUILDERS.get(run.getAppName());
-    run.stop();
-    DaprRun newRun = builder.build();
-    DAPR_RUNS.add(newRun);
-    newRun.start();
-    newRun.use();
-    return newRun;
-  }
-
   @AfterClass
   public static void cleanUp() throws Exception {
     for (DaprRun app : DAPR_RUNS) {

--- a/sdk-tests/src/test/java/io/dapr/it/Command.java
+++ b/sdk-tests/src/test/java/io/dapr/it/Command.java
@@ -63,7 +63,7 @@ public class Command {
     // Waits for success to happen within 1 minute.
     finished.tryAcquire(SUCCESS_WAIT_TIMEOUT_MINUTES, TimeUnit.MINUTES);
     if (!success.get()) {
-      System.out.println("TEST WARNING: Could find success criteria for command: " + command);
+      throw new IllegalStateException("Could not find success criteria for command: " + command);
     }
   }
 }

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
@@ -77,9 +77,9 @@ public class ActorTurnBasedConcurrencyIT extends BaseIT {
       MyActorService.SUCCESS_MESSAGE,
       MyActorService.class,
       true,
-      10000);
+      60000);
 
-    Thread.sleep(2000);
+    Thread.sleep(3000);
     String actorType="MyActorTest";
     logger.debug("Creating proxy builder");
 

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
@@ -36,44 +36,25 @@ public class MethodInvokeIT extends BaseIT {
     /**
      * Run of a Dapr application.
      */
-    private static DaprRun daprRun = null;
-
-    /**
-     * Flag to determine if there is a context change based on parameters.
-     */
-    private static Boolean wasGrpc;
+    private DaprRun daprRun = null;
 
     @Parameter
     public boolean useGrpc;
 
-    @BeforeClass
-    public static void initClass() throws Exception {
-        System.out.println("Working Directory = " + System.getProperty("user.dir"));
-
-        daprRun = startDaprApp(
-                MethodInvokeIT.class.getSimpleName(),
-                MethodInvokeService.SUCCESS_MESSAGE,
-                MethodInvokeService.class,
-                true,
-                60000);
-    }
-
     @Before
     public void init() throws Exception {
-        if (wasGrpc != null) {
-            if (wasGrpc.booleanValue() != this.useGrpc) {
-                // Context change.
-                daprRun = super.restartDaprApp(daprRun);
-            }
-        }
+        daprRun = startDaprApp(
+          MethodInvokeIT.class.getSimpleName(),
+          MethodInvokeService.SUCCESS_MESSAGE,
+          MethodInvokeService.class,
+          true,
+          60000);
 
         if (this.useGrpc) {
             daprRun.switchToGRPC();
         } else {
             daprRun.switchToHTTP();
         }
-
-        wasGrpc = this.useGrpc;
     }
 
     @Test


### PR DESCRIPTION
# Description

There is a race condition where an app starts prior to the previous instance could be stopped since the app name is not available on `dapr list`. So, this fix will wait for `dapr list` to list the app that just started before running the tests. This way, the app will be correctly stopped between test cases.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
