### PR TITLE
Bi-directional output binding + 'data' to refer to PubSub event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       GOPROXY: https://proxy.golang.org
       JDK_VER: 13.0.x
       DAPR_RUNTIME_VER: 0.7.1
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/98f8818260d941c2662908f686395f8480dabd64/install/install.sh
-      DAPR_CLI_REF: 98f8818260d941c2662908f686395f8480dabd64
-      DAPR_REF: 610b92568b1add897ba3e6938a711c0821833966
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/e498de9f7dd92c30aa592d6e6761dc924bb53cc2/install/install.sh
+      DAPR_CLI_REF: e498de9f7dd92c30aa592d6e6761dc924bb53cc2
+      DAPR_REF: 4d3945364d89aae045a05b1d611458abedf1a1ff
       OSSRH_USER_TOKEN: ${{ secrets.OSSRH_USER_TOKEN }}
       OSSRH_PWD_TOKEN: ${{ secrets.OSSRH_PWD_TOKEN }}
       GPG_KEY: ${{ secrets.GPG_KEY }}

--- a/examples/src/main/java/io/dapr/examples/bindings/http/InputBindingController.java
+++ b/examples/src/main/java/io/dapr/examples/bindings/http/InputBindingController.java
@@ -16,8 +16,13 @@ import reactor.core.publisher.Mono;
 @RestController
 public class InputBindingController {
 
+  /**
+   * Handles input binding from Dapr.
+   * @param body Content from Dapr's sidecar.
+   * @return Empty Mono.
+   */
   @PostMapping(path = "/sample123")
-  public Mono<Void> handleInputBinding(@RequestBody(required = false) byte[] body) {
+  public Mono<String> handleInputBinding(@RequestBody(required = false) byte[] body) {
     return Mono.fromRunnable(() ->
             System.out.println("Received message through binding: " + (body == null ? "" : new String(body))));
   }

--- a/examples/src/main/java/io/dapr/examples/bindings/http/OutputBindingExample.java
+++ b/examples/src/main/java/io/dapr/examples/bindings/http/OutputBindingExample.java
@@ -28,6 +28,8 @@ public class OutputBindingExample {
 
   static final String BINDING_NAME = "sample123";
 
+  static final String BINDING_OPERATION = "create";
+
   /**
    * The main method of this app.
    *
@@ -49,10 +51,10 @@ public class OutputBindingExample {
         myClass.message = message;
 
         System.out.println("sending a class with message: " + myClass.message);
-        client.invokeBinding(BINDING_NAME, myClass).block();
+        client.invokeBinding(BINDING_NAME, BINDING_OPERATION, myClass).block();
       } else {
         System.out.println("sending a plain string: " + message);
-        client.invokeBinding(BINDING_NAME, message).block();
+        client.invokeBinding(BINDING_NAME, BINDING_OPERATION, message).block();
       }
 
       try {

--- a/examples/src/main/java/io/dapr/examples/bindings/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/bindings/http/README.md
@@ -40,8 +40,8 @@ mvn install
 
 Before getting into the application code, follow these steps in order to setup a local instance of Kafka. This is needed for the local instances. Steps are:
 
-1. navigate to the [repo-root]/examples/src/main/java/io/dapr/examples/bindings/http
-2. Run `docker-compose -f ./docker-compose-single-kafka.yml up -d` to run the container locally
+1. Navigate to the root directory for the git repository.
+2. Run `docker-compose -f ./examples/src/main/java/io/dapr/examples/bindings/http/docker-compose-single-kafka.yml up -d` to run the container locally
 3. Run `docker ps` to see the container running locally: 
 
 ```bash
@@ -100,18 +100,21 @@ In the `OutputBindingExample.java` file, you will find the `OutputBindingExample
 ```java
 public class OutputBindingExample {
 ///...
-  public static void main(String[] args) throws Exception {
+  static final String BINDING_NAME = "sample123";
+
+  static final String BINDING_OPERATION = "create";
+///...
+  public static void main(String[] args) {
     DaprClient client = new DaprClientBuilder().build();
-    final String BINDING_NAME = "bindingSample";
     ///...
     MyClass myClass = new MyClass();
     myClass.message = message;
 
     System.out.println("sending an object instance with message: " + myClass.message);
-    client.invokeBinding(BINDING_NAME, myClass); //Binding a data object
+    client.invokeBinding(BINDING_NAME, BINDING_OPERATION, myClass); //Binding a data object
     ///...
     System.out.println("sending a plain string: " + m);
-    client.invokeBinding(BINDING_NAME, message); //Binding a plain string text
+    client.invokeBinding(BINDING_NAME, BINDING_OPERATION, message); //Binding a plain string text
     }
 ///...
 }

--- a/examples/src/main/java/io/dapr/examples/pubsub/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/pubsub/http/README.md
@@ -59,7 +59,7 @@ public class SubscriberController {
         // Dapr's event is compliant to CloudEvent.
         CloudEventEnvelope envelope = SERIALIZER.deserialize(body, CloudEventEnvelope.class);
 
-        String message = envelope.getData() == null ? "" : new String(envelope.getData());
+        String message = envelope.getData() == null ? "" : envelope.getData();
         System.out.println("Subscriber got message: " + message);
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/examples/src/main/java/io/dapr/examples/pubsub/http/SubscriberController.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/http/SubscriberController.java
@@ -37,7 +37,7 @@ public class SubscriberController {
         // Dapr's event is compliant to CloudEvent.
         CloudEvent envelope = CloudEvent.deserialize(body);
 
-        String message = envelope.getData() == null ? "" : new String(envelope.getData());
+        String message = envelope.getData() == null ? "" : envelope.getData();
         System.out.println("Subscriber got message: " + message);
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <grpc.version>1.25.0</grpc.version>
     <protobuf.version>3.11.0</protobuf.version>
     <protoc.version>3.10.0</protoc.version>
-    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/610b92568b1add897ba3e6938a711c0821833966/dapr/proto</dapr.proto.baseurl>
+    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/9bf8de18aead509f08075318cb7fa198ed25f354/dapr/proto</dapr.proto.baseurl>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>

--- a/sdk-tests/src/test/java/io/dapr/it/binding/http/BindingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/binding/http/BindingIT.java
@@ -34,6 +34,10 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class BindingIT extends BaseIT {
 
+  private static final String BINDING_NAME = "sample123";
+
+  private static final String BINDING_OPERATION = "create";
+
   public static class MyClass {
     public MyClass() {
     }
@@ -75,21 +79,21 @@ public class BindingIT extends BaseIT {
 
     DaprClient client = new DaprClientBuilder().build();
 
-    final String BINDING_NAME = "sample123";
-
     // This is an example of sending data in a user-defined object.  The input binding will receive:
     //   {"message":"hello"}
     MyClass myClass = new MyClass();
     myClass.message = "hello";
 
     System.out.println("sending first message");
-    client.invokeBinding(BINDING_NAME, myClass, Collections.singletonMap("MyMetadata", "MyValue")).block();
+    client.invokeBinding(
+      BINDING_NAME, BINDING_OPERATION, myClass, Collections.singletonMap("MyMetadata", "MyValue"), Void.class).block();
 
     // This is an example of sending a plain string.  The input binding will receive
     //   cat
     final String m = "cat";
     System.out.println("sending " + m);
-    client.invokeBinding(BINDING_NAME, m, Collections.singletonMap("MyMetadata", "MyValue")).block();
+    client.invokeBinding(
+      BINDING_NAME, BINDING_OPERATION, m, Collections.singletonMap("MyMetadata", "MyValue"), Void.class).block();
 
     // Metadata is not used by Kafka component, so it is not possible to validate.
     callWithRetry(() -> {

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -5,9 +5,12 @@
 
 package io.dapr.client;
 
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
 import io.dapr.client.domain.State;
 import io.dapr.client.domain.StateOptions;
 import io.dapr.client.domain.Verb;
+import io.dapr.v1.DaprProtos;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -127,23 +130,50 @@ public interface DaprClient {
   Mono<byte[]> invokeService(Verb verb, String appId, String method, byte[] request, Map<String, String> metadata);
 
   /**
-   * Invokes a Binding.
+   * Invokes a Binding operation.
    *
-   * @param name    The name of the biding to call.
-   * @param request The request needed for the binding, use byte[] to skip serialization.
-   * @return a Mono plan of type Void.
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, use byte[] to skip serialization.
+   * @return an empty Mono.
    */
-  Mono<Void> invokeBinding(String name, Object request);
+  Mono<Void> invokeBinding(String name, String operation, Object data);
 
   /**
-   * Invokes a Binding with metadata.
+   * Invokes a Binding operation, skipping serialization.
    *
-   * @param name     The name of the biding to call.
-   * @param request  The request needed for the binding, use byte[] to skip serialization.
-   * @param metadata The metadata map.
-   * @return a Mono plan of type Void.
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, skipping serialization.
+   * @param metadata  The metadata map.
+   * @return a Mono plan of type byte[].
    */
-  Mono<Void> invokeBinding(String name, Object request, Map<String, String> metadata);
+  Mono<byte[]> invokeBinding(String name, String operation, byte[] data, Map<String, String> metadata);
+
+  /**
+   * Invokes a Binding operation.
+   *
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, use byte[] to skip serialization.
+   * @param clazz     The type being returned.
+   * @param <T>       The type of the return
+   * @return a Mono plan of type T.
+   */
+  <T> Mono<T> invokeBinding(String name, String operation, Object data, Class<T> clazz);
+
+  /**
+   * Invokes a Binding operation.
+   *
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, use byte[] to skip serialization.
+   * @param metadata  The metadata map.
+   * @param clazz     The type being returned.
+   * @param <T>       The type of the return
+   * @return a Mono plan of type T.
+   */
+  <T> Mono<T> invokeBinding(String name, String operation, Object data, Map<String, String> metadata, Class<T> clazz);
 
   /**
    * Retrieve a State based on their key.

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -24,20 +24,20 @@ public interface DaprClient {
    * Publish an event.
    *
    * @param topic the topic where the event will be published.
-   * @param event the event to be published, use byte[] for skipping serialization.
+   * @param data the event's data to be published, use byte[] for skipping serialization.
    * @return a Mono plan of type Void.
    */
-  Mono<Void> publishEvent(String topic, Object event);
+  Mono<Void> publishEvent(String topic, Object data);
 
   /**
    * Publish an event.
    *
    * @param topic    the topic where the event will be published.
-   * @param event    the event to be published, use byte[] for skipping serialization.
+   * @param data    the event's data to be published, use byte[] for skipping serialization.
    * @param metadata The metadata for the published event.
    * @return a Mono plan of type Void.
    */
-  Mono<Void> publishEvent(String topic, Object event, Map<String, String> metadata);
+  Mono<Void> publishEvent(String topic, Object data, Map<String, String> metadata);
 
   /**
    * Invoke a service with all possible parameters, using serialization.

--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -209,30 +209,54 @@ public class DaprClientGrpc implements DaprClient {
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> invokeBinding(String name, Object request) {
-    return this.invokeBinding(name, request, null);
+  public Mono<Void> invokeBinding(String name, String operation, Object data) {
+    return this.invokeBinding(name, operation, data, null, byte[].class).then();
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> invokeBinding(String name, Object request, Map<String, String> metadata) {
+  public Mono<byte[]> invokeBinding(String name, String operation, byte[] data, Map<String, String> metadata) {
+    return this.invokeBinding(name, operation, data, metadata, byte[].class);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeBinding(String name, String operation, Object data, Class<T> clazz) {
+    return this.invokeBinding(name, operation, data, null, clazz);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeBinding(
+      String name, String operation, Object data, Map<String, String> metadata, Class<T> clazz) {
     try {
-      byte[] byteRequest = objectSerializer.serialize(request);
+      if (name == null || name.trim().isEmpty()) {
+        throw new IllegalArgumentException("Binding name cannot be null or empty.");
+      }
+
+      if (operation == null || operation.trim().isEmpty()) {
+        throw new IllegalArgumentException("Binding operation cannot be null or empty.");
+      }
+
+      byte[] byteData = objectSerializer.serialize(data);
       DaprProtos.InvokeBindingRequest.Builder builder = DaprProtos.InvokeBindingRequest.newBuilder()
-          .setName(name);
-      if (byteRequest != null) {
-        builder.setData(ByteString.copyFrom(byteRequest));
+          .setName(name).setOperation(operation);
+      if (byteData != null) {
+        builder.setData(ByteString.copyFrom(byteData));
       }
       if (metadata != null) {
         builder.putAllMetadata(metadata);
       }
       DaprProtos.InvokeBindingRequest envelope = builder.build();
       return Mono.fromCallable(() -> {
-        ListenableFuture<Empty> futureEmpty = client.invokeBinding(envelope);
-        futureEmpty.get();
-        return null;
+        ListenableFuture<DaprProtos.InvokeBindingResponse> futureResponse = client.invokeBinding(envelope);
+        return objectSerializer.deserialize(futureResponse.get().getData().toByteArray(), clazz);
       });
     } catch (Exception ex) {
       return Mono.error(ex);

--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -105,19 +105,19 @@ public class DaprClientGrpc implements DaprClient {
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> publishEvent(String topic, Object event) {
-    return this.publishEvent(topic, event, null);
+  public Mono<Void> publishEvent(String topic, Object data) {
+    return this.publishEvent(topic, data, null);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> publishEvent(String topic, Object event, Map<String, String> metadata) {
+  public Mono<Void> publishEvent(String topic, Object data, Map<String, String> metadata) {
     try {
       // TODO: handle metadata.
       DaprProtos.PublishEventRequest envelope = DaprProtos.PublishEventRequest.newBuilder()
-          .setTopic(topic).setData(ByteString.copyFrom(objectSerializer.serialize(event))).build();
+          .setTopic(topic).setData(ByteString.copyFrom(objectSerializer.serialize(data))).build();
 
       return Mono.fromCallable(() -> {
         ListenableFuture<Empty> futureEmpty = client.publishEvent(envelope);

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -95,21 +95,21 @@ public class DaprClientHttp implements DaprClient {
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> publishEvent(String topic, Object event) {
-    return this.publishEvent(topic, event, null);
+  public Mono<Void> publishEvent(String topic, Object data) {
+    return this.publishEvent(topic, data, null);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> publishEvent(String topic, Object event, Map<String, String> metadata) {
+  public Mono<Void> publishEvent(String topic, Object data, Map<String, String> metadata) {
     try {
       if (topic == null || topic.trim().isEmpty()) {
         throw new IllegalArgumentException("Topic name cannot be null or empty.");
       }
 
-      byte[] serializedEvent = objectSerializer.serialize(event);
+      byte[] serializedEvent = objectSerializer.serialize(data);
       StringBuilder url = new StringBuilder(Constants.PUBLISH_PATH).append("/").append(topic);
       return this.client.invokeApi(
           DaprHttp.HttpMethods.POST.name(), url.toString(), null, serializedEvent, metadata).then();

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -218,11 +218,23 @@ public class DaprClientHttpTest {
     Map<String, String> map = new HashMap<>();
     mockInterceptor.addRule()
       .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
-      .respond(EXPECTED_RESULT);
+      .respond("");
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<Void> mono = daprClientHttp.invokeBinding("sample-topic", "");
+    Mono<Void> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "");
     assertNull(mono.block());
+  }
+
+  @Test
+  public void invokeBindingResponseObject() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("\"OK\"");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<String> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, String.class);
+    assertEquals("OK", mono.block());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -233,7 +245,19 @@ public class DaprClientHttpTest {
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<Void> mono = daprClientHttp.invokeBinding(null, "");
+    Mono<Void> mono = daprClientHttp.invokeBinding(null, "myoperation", "");
+    assertNull(mono.block());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invokeBindingNullOpName() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond(EXPECTED_RESULT);
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Void> mono = daprClientHttp.invokeBinding("sample-topic", null, "");
     assertNull(mono.block());
   }
 
@@ -245,7 +269,7 @@ public class DaprClientHttpTest {
         .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    daprClientHttp.invokeBinding(null, "");
+    daprClientHttp.invokeBinding(null, "", "");
     // No exception is thrown because did not call block() on mono above.
   }
 


### PR DESCRIPTION
# Description

Bi-directional output binding.
Use 'data' to refer to PubSub event

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #288 and https://github.com/dapr/dapr/issues/1370

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
