### PR TITLE
Use TypeRef for deserialization and client APIs.

### DIFF
--- a/examples/src/main/java/io/dapr/examples/actors/http/DemoActorImpl.java
+++ b/examples/src/main/java/io/dapr/examples/actors/http/DemoActorImpl.java
@@ -9,6 +9,7 @@ import io.dapr.actors.ActorId;
 import io.dapr.actors.runtime.AbstractActor;
 import io.dapr.actors.runtime.ActorRuntimeContext;
 import io.dapr.actors.runtime.Remindable;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.text.DateFormat;
@@ -121,8 +122,8 @@ public class DemoActorImpl extends AbstractActor implements DemoActor, Remindabl
    * @return Class for reminder's state.
    */
   @Override
-  public Class<Integer> getStateType() {
-    return Integer.class;
+  public TypeRef<Integer> getStateType() {
+    return TypeRef.INT;
   }
 
   /**

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
@@ -6,6 +6,7 @@
 package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 /**
@@ -31,11 +32,32 @@ public interface ActorProxy {
    * Invokes an Actor method on Dapr.
    *
    * @param methodName Method name to invoke.
+   * @param type       The type of the return class.
+   * @param <T>        The type to be returned.
+   * @return Asynchronous result with the Actor's response.
+   */
+  <T> Mono<T> invokeActorMethod(String methodName, TypeRef<T> type);
+
+  /**
+   * Invokes an Actor method on Dapr.
+   *
+   * @param methodName Method name to invoke.
    * @param clazz      The type of the return class.
    * @param <T>        The type to be returned.
    * @return Asynchronous result with the Actor's response.
    */
   <T> Mono<T> invokeActorMethod(String methodName, Class<T> clazz);
+
+  /**
+   * Invokes an Actor method on Dapr.
+   *
+   * @param methodName Method name to invoke.
+   * @param data       Object with the data.
+   * @param type       The type of the return class.
+   * @param <T>        The type to be returned.
+   * @return Asynchronous result with the Actor's response.
+   */
+  <T> Mono<T> invokeActorMethod(String methodName, Object data, TypeRef<T> type);
 
   /**
    * Invokes an Actor method on Dapr.

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorManager.java
@@ -6,6 +6,7 @@
 package io.dapr.actors.runtime;
 
 import io.dapr.actors.ActorId;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -253,7 +254,7 @@ class ActorManager<T extends AbstractActor> {
         if (method.getParameterCount() == 1) {
           // Actor methods must have a one or no parameter, which is guaranteed at this point.
           Class<?> inputClass = method.getParameterTypes()[0];
-          input = this.runtimeContext.getObjectSerializer().deserialize(request, inputClass);
+          input = this.runtimeContext.getObjectSerializer().deserialize(request, TypeRef.get(inputClass));
         }
 
         if (method.getReturnType().equals(Mono.class)) {

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/DaprStateAsyncProvider.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/DaprStateAsyncProvider.java
@@ -11,6 +11,7 @@ import io.dapr.actors.ActorId;
 import io.dapr.serializer.DaprObjectSerializer;
 import io.dapr.serializer.DefaultObjectSerializer;
 import io.dapr.utils.Properties;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayOutputStream;
@@ -59,12 +60,12 @@ class DaprStateAsyncProvider {
     this.isStateSerializerDefault = stateSerializer.getClass() == DefaultObjectSerializer.class;
   }
 
-  <T> Mono<T> load(String actorType, ActorId actorId, String stateName, Class<T> clazz) {
+  <T> Mono<T> load(String actorType, ActorId actorId, String stateName, TypeRef<T> type) {
     Mono<byte[]> result = this.daprClient.getActorState(actorType, actorId.toString(), stateName);
 
     return result.flatMap(s -> {
       try {
-        T response = this.stateSerializer.deserialize(s, clazz);
+        T response = this.stateSerializer.deserialize(s, type);
         if (response == null) {
           return Mono.empty();
         }

--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/Remindable.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/Remindable.java
@@ -5,6 +5,7 @@
 
 package io.dapr.actors.runtime;
 
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -15,11 +16,11 @@ import java.time.Duration;
 public interface Remindable<T> {
 
   /**
-   * Gets the class for state object.
+   * Gets the type for state object.
    *
    * @return Class for state object.
    */
-  Class<T> getStateType();
+  TypeRef<T> getStateType();
 
   /**
    * The reminder call back invoked when an actor reminder is triggered.

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorManagerTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorManagerTest.java
@@ -11,6 +11,8 @@ import io.dapr.serializer.DefaultObjectSerializer;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import io.dapr.utils.TypeRef;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -96,8 +98,8 @@ public class ActorManagerTest {
     }
 
     @Override
-    public Class<String> getStateType() {
-      return String.class;
+    public TypeRef<String> getStateType() {
+      return TypeRef.STRING;
     }
 
     @Override
@@ -124,8 +126,8 @@ public class ActorManagerTest {
     this.manager.activateActor(actorId).block();
     byte[] response = this.manager.invokeMethod(actorId, "say", message).block();
     Assert.assertEquals(executeSayMethod(
-      this.context.getObjectSerializer().deserialize(message, String.class)),
-      this.context.getObjectSerializer().deserialize(response, String.class));
+      this.context.getObjectSerializer().deserialize(message, TypeRef.STRING)),
+      this.context.getObjectSerializer().deserialize(response, TypeRef.STRING));
   }
 
   @Test
@@ -192,8 +194,8 @@ public class ActorManagerTest {
     this.manager.activateActor(actorId).block();
     byte[] response = this.manager.invokeMethod(actorId, "say", message).block();
     Assert.assertEquals(executeSayMethod(
-      this.context.getObjectSerializer().deserialize(message, String.class)),
-      this.context.getObjectSerializer().deserialize(response, String.class));
+      this.context.getObjectSerializer().deserialize(message, TypeRef.STRING)),
+      this.context.getObjectSerializer().deserialize(response, TypeRef.STRING));
 
     this.manager.deactivateActor(actorId).block();
     this.manager.invokeMethod(actorId, "say", message).block();

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
@@ -11,6 +11,7 @@ import io.dapr.actors.client.ActorProxy;
 import io.dapr.actors.client.ActorProxyForTestsImpl;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DefaultObjectSerializer;
+import io.dapr.utils.TypeRef;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
@@ -247,9 +248,9 @@ public class ActorStatefulTest {
     }
 
     @Override
-    public Class<String> getStateType() {
+    public TypeRef<String> getStateType() {
       // Remindable type.
-      return String.class;
+      return TypeRef.STRING;
     }
 
     @Override

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorTypeInformationTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorTypeInformationTest.java
@@ -6,6 +6,7 @@
 package io.dapr.actors.runtime;
 
 import io.dapr.actors.ActorType;
+import io.dapr.utils.TypeRef;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
@@ -64,7 +65,7 @@ public class ActorTypeInformationTest {
       }
 
       @Override
-      public Class getStateType() {
+      public TypeRef getStateType() {
         return null;
       }
 

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprInMemoryStateProvider.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprInMemoryStateProvider.java
@@ -7,6 +7,7 @@ package io.dapr.actors.runtime;
 
 import io.dapr.actors.ActorId;
 import io.dapr.serializer.DaprObjectSerializer;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ public class DaprInMemoryStateProvider extends DaprStateAsyncProvider {
   }
 
   @Override
-  <T> Mono<T> load(String actorType, ActorId actorId, String stateName, Class<T> clazz) {
+  <T> Mono<T> load(String actorType, ActorId actorId, String stateName, TypeRef<T> type) {
     return Mono.fromSupplier(() -> {
       try {
         String stateId = this.buildId(actorType, actorId, stateName);
@@ -36,7 +37,7 @@ public class DaprInMemoryStateProvider extends DaprStateAsyncProvider {
           throw new IllegalStateException("State not found.");
         }
 
-        return this.serializer.deserialize(this.stateStore.get(stateId), clazz);
+        return this.serializer.deserialize(this.stateStore.get(stateId), type);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprStateAsyncProviderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprStateAsyncProviderTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dapr.actors.ActorId;
 import io.dapr.serializer.DaprObjectSerializer;
 import io.dapr.serializer.DefaultObjectSerializer;
+import io.dapr.utils.TypeRef;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
@@ -170,23 +171,24 @@ public class DaprStateAsyncProviderTest {
     DaprStateAsyncProvider provider = new DaprStateAsyncProvider(daprClient, SERIALIZER);
 
     Assert.assertEquals("Jon Doe",
-      provider.load("MyActor", new ActorId("123"), "name", String.class).block());
+      provider.load("MyActor", new ActorId("123"), "name", TypeRef.STRING).block());
     Assert.assertEquals(98021,
-      (int)provider.load("MyActor", new ActorId("123"), "zipcode", int.class).block());
+      (int)provider.load("MyActor", new ActorId("123"), "zipcode", TypeRef.INT).block());
     Assert.assertEquals(98,
-      (int) provider.load("MyActor", new ActorId("123"), "goals", int.class).block());
+      (int) provider.load("MyActor", new ActorId("123"), "goals", TypeRef.INT).block());
     Assert.assertEquals(98,
-      (int) provider.load("MyActor", new ActorId("123"), "goals", int.class).block());
+      (int) provider.load("MyActor", new ActorId("123"), "goals", TypeRef.INT).block());
     Assert.assertEquals(46.55,
-      (double) provider.load("MyActor", new ActorId("123"), "balance", double.class).block(),
+      (double) provider.load("MyActor", new ActorId("123"), "balance", TypeRef.DOUBLE).block(),
       EPSILON);
     Assert.assertEquals(true,
-      (boolean) provider.load("MyActor", new ActorId("123"), "active", boolean.class).block());
+      (boolean) provider.load("MyActor", new ActorId("123"), "active", TypeRef.BOOLEAN).block());
     Assert.assertEquals(new Customer().setId(1000).setName("Roxane"),
-      provider.load("MyActor", new ActorId("123"), "customer", Customer.class).block());
+      provider.load("MyActor", new ActorId("123"), "customer", TypeRef.get(Customer.class)).block());
     Assert.assertNotEquals(new Customer().setId(1000).setName("Roxane"),
-      provider.load("MyActor", new ActorId("123"), "anotherCustomer", Customer.class).block());
-    Assert.assertNull(provider.load("MyActor", new ActorId("123"), "nullCustomer", Customer.class).block());
+      provider.load("MyActor", new ActorId("123"), "anotherCustomer", TypeRef.get(Customer.class)).block());
+    Assert.assertNull(
+      provider.load("MyActor", new ActorId("123"), "nullCustomer", TypeRef.get(Customer.class)).block());
   }
 
   @Test

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/JavaSerializer.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/JavaSerializer.java
@@ -6,6 +6,7 @@
 package io.dapr.actors.runtime;
 
 import io.dapr.serializer.DaprObjectSerializer;
+import io.dapr.utils.TypeRef;
 
 import java.io.*;
 
@@ -32,7 +33,7 @@ public class JavaSerializer implements DaprObjectSerializer {
    * {@inheritDoc}
    */
   @Override
-  public <T> T deserialize(byte[] data, Class<T> clazz) throws IOException {
+  public <T> T deserialize(byte[] data, TypeRef<T> type) throws IOException {
     try (ByteArrayInputStream bis = new ByteArrayInputStream(data)) {
       try (ObjectInputStream ois = new ObjectInputStream(bis)) {
         try {

--- a/sdk-tests/src/test/java/io/dapr/it/actors/app/MyActorImpl.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/app/MyActorImpl.java
@@ -11,6 +11,7 @@ import io.dapr.actors.runtime.AbstractActor;
 import io.dapr.actors.runtime.ActorRuntimeContext;
 import io.dapr.actors.runtime.Remindable;
 import io.dapr.it.actors.MethodEntryTracker;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.text.DateFormat;
@@ -146,8 +147,8 @@ public class MyActorImpl extends AbstractActor implements MyActor, Remindable<St
   }
 
   @Override
-  public Class<String> getStateType() {
-    return String.class;
+  public TypeRef<String> getStateType() {
+    return TypeRef.STRING;
   }
 
 

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -5,12 +5,10 @@
 
 package io.dapr.client;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.ByteString;
 import io.dapr.client.domain.State;
 import io.dapr.client.domain.StateOptions;
 import io.dapr.client.domain.Verb;
-import io.dapr.v1.DaprProtos;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -45,14 +43,29 @@ public interface DaprClient {
   /**
    * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
+   * @param appId    The Application ID where the service is.
+   * @param method   The actual Method to be call in the application.
+   * @param request  The request to be sent to invoke the service, use byte[] to skip serialization.
    * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param clazz   the Type needed as return for the call.
-   * @param <T>     the Type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type clazz.
+   * @param type     The Type needed as return for the call.
+   * @param <T>      The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type .
+   */
+  <T> Mono<T> invokeService(
+      Verb verb, String appId, String method, Object request, Map<String, String> metadata, TypeRef<T> type);
+
+  /**
+   * Invoke a service with all possible parameters, using serialization.
+   *
+   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
+   * @param appId    The Application ID where the service is.
+   * @param method   The actual Method to be call in the application.
+   * @param request  The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
+   * @param clazz    The type needed as return for the call.
+   * @param <T>      The type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type .
    */
   <T> Mono<T> invokeService(
       Verb verb, String appId, String method, Object request, Map<String, String> metadata, Class<T> clazz);
@@ -64,22 +77,48 @@ public interface DaprClient {
    * @param appId   The Application ID where the service is.
    * @param method  The actual Method to be call in the application.
    * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param clazz   the Type needed as return for the call.
-   * @param <T>     the Type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type clazz.
+   * @param type    The type needed as return for the call.
+   * @param <T>     The type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type .
+   */
+  <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, TypeRef<T> type);
+
+  /**
+   * Invoke a service without metadata, using serialization.
+   *
+   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
+   * @param appId   The Application ID where the service is.
+   * @param method  The actual Method to be call in the application.
+   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param clazz   The type needed as return for the call.
+   * @param <T>     The type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type .
    */
   <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, Class<T> clazz);
 
   /**
    * Invoke a service without input, using serialization for response.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
+   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
+   * @param appId    The Application ID where the service is.
+   * @param method   The actual Method to be call in the application.
    * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param clazz   the Type needed as return for the call.
-   * @param <T>     the Type of the return, use byte[] to skip serialization.
-   * @return A Mono plan of type clazz.
+   * @param type     The type needed as return for the call.
+   * @param <T>      The type of the return, use byte[] to skip serialization.
+   * @return A Mono plan of type type .
+   */
+  <T> Mono<T> invokeService(Verb verb, String appId, String method, Map<String, String> metadata, TypeRef<T> type);
+
+  /**
+   * Invoke a service without input, using serialization for response.
+   *
+   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
+   * @param appId    The Application ID where the service is.
+   * @param method   The actual Method to be call in the application.
+   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
+   * @param clazz    The type needed as return for the call.
+   * @param <T>      The type of the return, use byte[] to skip serialization.
+   * @return A Mono plan of type type .
    */
   <T> Mono<T> invokeService(Verb verb, String appId, String method, Map<String, String> metadata, Class<T> clazz);
 
@@ -156,11 +195,36 @@ public interface DaprClient {
    * @param name      The name of the biding to call.
    * @param operation The operation to be performed by the binding request processor.
    * @param data      The data to be processed, use byte[] to skip serialization.
+   * @param type      The type being returned.
+   * @param <T>       The type of the return
+   * @return a Mono plan of type T.
+   */
+  <T> Mono<T> invokeBinding(String name, String operation, Object data, TypeRef<T> type);
+
+  /**
+   * Invokes a Binding operation.
+   *
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, use byte[] to skip serialization.
    * @param clazz     The type being returned.
    * @param <T>       The type of the return
    * @return a Mono plan of type T.
    */
   <T> Mono<T> invokeBinding(String name, String operation, Object data, Class<T> clazz);
+
+  /**
+   * Invokes a Binding operation.
+   *
+   * @param name      The name of the biding to call.
+   * @param operation The operation to be performed by the binding request processor.
+   * @param data      The data to be processed, use byte[] to skip serialization.
+   * @param metadata  The metadata map.
+   * @param type      The type being returned.
+   * @param <T>       The type of the return
+   * @return a Mono plan of type T.
+   */
+  <T> Mono<T> invokeBinding(String name, String operation, Object data, Map<String, String> metadata, TypeRef<T> type);
 
   /**
    * Invokes a Binding operation.
@@ -180,8 +244,19 @@ public interface DaprClient {
    *
    * @param stateStoreName The name of the state store.
    * @param state          State to be re-retrieved.
-   * @param clazz          The Type of State needed as return.
-   * @param <T>            The Type of the return.
+   * @param type           The type of State needed as return.
+   * @param <T>            The type of the return.
+   * @return A Mono Plan for the requested State.
+   */
+  <T> Mono<State<T>> getState(String stateStoreName, State<T> state, TypeRef<T> type);
+
+  /**
+   * Retrieve a State based on their key.
+   *
+   * @param stateStoreName The name of the state store.
+   * @param state          State to be re-retrieved.
+   * @param clazz          The type of State needed as return.
+   * @param <T>            The type of the return.
    * @return A Mono Plan for the requested State.
    */
   <T> Mono<State<T>> getState(String stateStoreName, State<T> state, Class<T> clazz);
@@ -191,8 +266,19 @@ public interface DaprClient {
    *
    * @param stateStoreName The name of the state store.
    * @param key            The key of the State to be retrieved.
-   * @param clazz          The Type of State needed as return.
-   * @param <T>            The Type of the return.
+   * @param type           The type of State needed as return.
+   * @param <T>            The type of the return.
+   * @return A Mono Plan for the requested State.
+   */
+  <T> Mono<State<T>> getState(String stateStoreName, String key, TypeRef<T> type);
+
+  /**
+   * Retrieve a State based on their key.
+   *
+   * @param stateStoreName The name of the state store.
+   * @param key            The key of the State to be retrieved.
+   * @param clazz          The type of State needed as return.
+   * @param <T>            The type of the return.
    * @return A Mono Plan for the requested State.
    */
   <T> Mono<State<T>> getState(String stateStoreName, String key, Class<T> clazz);
@@ -204,8 +290,21 @@ public interface DaprClient {
    * @param key            The key of the State to be retrieved.
    * @param etag           Optional etag for conditional get
    * @param options        Optional settings for retrieve operation.
-   * @param clazz          The Type of State needed as return.
+   * @param type           The Type of State needed as return.
    * @param <T>            The Type of the return.
+   * @return A Mono Plan for the requested State.
+   */
+  <T> Mono<State<T>> getState(String stateStoreName, String key, String etag, StateOptions options, TypeRef<T> type);
+
+  /**
+   * Retrieve a State based on their key.
+   *
+   * @param stateStoreName The name of the state store.
+   * @param key            The key of the State to be retrieved.
+   * @param etag           Optional etag for conditional get
+   * @param options        Optional settings for retrieve operation.
+   * @param clazz          The type of State needed as return.
+   * @param <T>            The type of the return.
    * @return A Mono Plan for the requested State.
    */
   <T> Mono<State<T>> getState(String stateStoreName, String key, String etag, StateOptions options, Class<T> clazz);

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -11,6 +11,7 @@ import io.dapr.client.domain.Verb;
 import io.dapr.serializer.DaprObjectSerializer;
 import io.dapr.serializer.DefaultObjectSerializer;
 import io.dapr.utils.Constants;
+import io.dapr.utils.TypeRef;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -123,7 +124,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<T> invokeService(
-      Verb verb, String appId, String method, Object request, Map<String, String> metadata, Class<T> clazz) {
+      Verb verb, String appId, String method, Object request, Map<String, String> metadata, TypeRef<T> type) {
     try {
       if (verb == null) {
         throw new IllegalArgumentException("Verb cannot be null.");
@@ -140,7 +141,7 @@ public class DaprClientHttp implements DaprClient {
       Mono<DaprHttp.Response> response = this.client.invokeApi(httMethod, path, metadata, serializedRequestBody, null);
       return response.flatMap(r -> {
         try {
-          T object = objectSerializer.deserialize(r.getBody(), clazz);
+          T object = objectSerializer.deserialize(r.getBody(), type);
           if (object == null) {
             return Mono.empty();
           }
@@ -160,8 +161,39 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<T> invokeService(
+      Verb verb,
+      String appId,
+      String method,
+      Object request,
+      Map<String, String> metadata,
+      Class<T> clazz) {
+    return this.invokeService(verb, appId, method, request, metadata, TypeRef.get(clazz));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeService(
+      Verb verb, String appId, String method, Map<String, String> metadata, TypeRef<T> type) {
+    return this.invokeService(verb, appId, method, null, metadata, type);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeService(
       Verb verb, String appId, String method, Map<String, String> metadata, Class<T> clazz) {
-    return this.invokeService(verb, appId, method, null, metadata, clazz);
+    return this.invokeService(verb, appId, method, null, metadata, TypeRef.get(clazz));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, TypeRef<T> type) {
+    return this.invokeService(verb, appId, method, request, null, type);
   }
 
   /**
@@ -169,7 +201,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, Class<T> clazz) {
-    return this.invokeService(verb, appId, method, request, null, clazz);
+    return this.invokeService(verb, appId, method, request, null, TypeRef.get(clazz));
   }
 
   /**
@@ -177,7 +209,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public Mono<Void> invokeService(Verb verb, String appId, String method, Object request) {
-    return this.invokeService(verb, appId, method, request, null, byte[].class).then();
+    return this.invokeService(verb, appId, method, request, null, TypeRef.BYTE_ARRAY).then();
   }
 
   /**
@@ -186,7 +218,7 @@ public class DaprClientHttp implements DaprClient {
   @Override
   public Mono<Void> invokeService(
       Verb verb, String appId, String method, Object request, Map<String, String> metadata) {
-    return this.invokeService(verb, appId, method, request, metadata, byte[].class).then();
+    return this.invokeService(verb, appId, method, request, metadata, TypeRef.BYTE_ARRAY).then();
   }
 
   /**
@@ -195,7 +227,7 @@ public class DaprClientHttp implements DaprClient {
   @Override
   public Mono<Void> invokeService(
       Verb verb, String appId, String method, Map<String, String> metadata) {
-    return this.invokeService(verb, appId, method, null, metadata, byte[].class).then();
+    return this.invokeService(verb, appId, method, null, metadata, TypeRef.BYTE_ARRAY).then();
   }
 
   /**
@@ -204,7 +236,7 @@ public class DaprClientHttp implements DaprClient {
   @Override
   public Mono<byte[]> invokeService(
       Verb verb, String appId, String method, byte[] request, Map<String, String> metadata) {
-    return this.invokeService(verb, appId, method, request, metadata, byte[].class);
+    return this.invokeService(verb, appId, method, request, metadata, TypeRef.BYTE_ARRAY);
   }
 
   /**
@@ -212,7 +244,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public Mono<Void> invokeBinding(String name, String operation, Object data) {
-    return this.invokeBinding(name, operation, data, null, byte[].class).then();
+    return this.invokeBinding(name, operation, data, null, TypeRef.BYTE_ARRAY).then();
   }
 
   /**
@@ -220,7 +252,15 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public Mono<byte[]> invokeBinding(String name, String operation, byte[] data, Map<String, String> metadata) {
-    return this.invokeBinding(name, operation, data, metadata, byte[].class);
+    return this.invokeBinding(name, operation, data, metadata, TypeRef.BYTE_ARRAY);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeBinding(String name, String operation, Object data, TypeRef<T> type) {
+    return this.invokeBinding(name, operation, data, null, type);
   }
 
   /**
@@ -228,7 +268,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<T> invokeBinding(String name, String operation, Object data, Class<T> clazz) {
-    return this.invokeBinding(name, operation, data, null, clazz);
+    return this.invokeBinding(name, operation, data, null, TypeRef.get(clazz));
   }
 
   /**
@@ -236,7 +276,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<T> invokeBinding(
-      String name, String operation, Object data, Map<String, String> metadata, Class<T> clazz) {
+      String name, String operation, Object data, Map<String, String> metadata, TypeRef<T> type) {
     try {
       if (name == null || name.trim().isEmpty()) {
         throw new IllegalArgumentException("Binding name cannot be null or empty.");
@@ -279,7 +319,7 @@ public class DaprClientHttp implements DaprClient {
       Mono<DaprHttp.Response> response = this.client.invokeApi(httpMethod, url.toString(), null, payload, null);
       return response.flatMap(r -> {
         try {
-          T object = objectSerializer.deserialize(r.getBody(), clazz);
+          T object = objectSerializer.deserialize(r.getBody(), type);
           if (object == null) {
             return Mono.empty();
           }
@@ -294,12 +334,38 @@ public class DaprClientHttp implements DaprClient {
     }
   }
 
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<T> invokeBinding(
+      String name, String operation, Object data, Map<String, String> metadata, Class<T> clazz) {
+    return this.invokeBinding(name, operation, data, metadata, TypeRef.get(clazz));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<State<T>> getState(String stateStoreName, State<T> state, TypeRef<T> type) {
+    return this.getState(stateStoreName, state.getKey(), state.getEtag(), state.getOptions(), type);
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public <T> Mono<State<T>> getState(String stateStoreName, State<T> state, Class<T> clazz) {
-    return this.getState(stateStoreName, state.getKey(), state.getEtag(), state.getOptions(), clazz);
+    return this.getState(stateStoreName, state.getKey(), state.getEtag(), state.getOptions(), TypeRef.get(clazz));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Mono<State<T>> getState(String stateStoreName, String key, TypeRef<T> type) {
+    return this.getState(stateStoreName, key, null, null, type);
   }
 
   /**
@@ -307,7 +373,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<State<T>> getState(String stateStoreName, String key, Class<T> clazz) {
-    return this.getState(stateStoreName, key, null, null, clazz);
+    return this.getState(stateStoreName, key, null, null, TypeRef.get(clazz));
   }
 
   /**
@@ -315,7 +381,7 @@ public class DaprClientHttp implements DaprClient {
    */
   @Override
   public <T> Mono<State<T>> getState(
-      String stateStoreName, String key, String etag, StateOptions options, Class<T> clazz) {
+      String stateStoreName, String key, String etag, StateOptions options, TypeRef<T> type) {
     try {
       if ((stateStoreName == null) || (stateStoreName.trim().isEmpty())) {
         throw new IllegalArgumentException("State store name cannot be null or empty.");
@@ -341,7 +407,7 @@ public class DaprClientHttp implements DaprClient {
           .invokeApi(DaprHttp.HttpMethods.GET.name(), url.toString(), urlParameters, headers)
           .flatMap(s -> {
             try {
-              return Mono.just(buildStateKeyValue(s, key, options, clazz));
+              return Mono.just(buildStateKeyValue(s, key, options, type));
             } catch (Exception ex) {
               return Mono.error(ex);
             }
@@ -349,6 +415,12 @@ public class DaprClientHttp implements DaprClient {
     } catch (Exception ex) {
       return Mono.error(ex);
     }
+  }
+
+  @Override
+  public <T> Mono<State<T>> getState(
+      String stateStoreName, String key, String etag, StateOptions options, Class<T> clazz) {
+    return null;
   }
 
   /**
@@ -453,15 +525,15 @@ public class DaprClientHttp implements DaprClient {
    *
    * @param response     The response of the HTTP Call
    * @param requestedKey The Key Requested.
-   * @param clazz        The Class of the Value of the state
+   * @param type        The Class of the Value of the state
    * @param <T>          The Type of the Value of the state
    * @return A StateKeyValue instance
    * @throws IOException If there's a issue deserialzing the response.
    */
   private <T> State<T> buildStateKeyValue(
-      DaprHttp.Response response, String requestedKey, StateOptions stateOptions, Class<T> clazz) throws IOException {
+      DaprHttp.Response response, String requestedKey, StateOptions stateOptions, TypeRef<T> type) throws IOException {
     // The state is in the body directly, so we use the state serializer here.
-    T value = stateSerializer.deserialize(response.getBody(), clazz);
+    T value = stateSerializer.deserialize(response.getBody(), type);
     String key = requestedKey;
     String etag = null;
     if (response.getHeaders() != null && response.getHeaders().containsKey("Etag")) {

--- a/sdk/src/main/java/io/dapr/serializer/DaprObjectSerializer.java
+++ b/sdk/src/main/java/io/dapr/serializer/DaprObjectSerializer.java
@@ -5,6 +5,8 @@
 
 package io.dapr.serializer;
 
+import io.dapr.utils.TypeRef;
+
 import java.io.IOException;
 
 /**
@@ -13,7 +15,7 @@ import java.io.IOException;
 public interface DaprObjectSerializer {
 
   /**
-   * Serializes the given object as a String to be saved.
+   * Serializes the given object as byte[].
    *
    * @param o Object to be serialized.
    * @return Serialized object.
@@ -22,13 +24,13 @@ public interface DaprObjectSerializer {
   byte[] serialize(Object o) throws IOException;
 
   /**
-   * Deserializes the given String into a object.
+   * Deserializes the given byte[] into a object.
    *
    * @param data Data to be deserialized.
-   * @param clazz Class of object to be deserialized.
+   * @param type Type of object to be deserialized.
    * @param <T> Type of object to be deserialized.
    * @return Deserialized object.
    * @throws IOException If cannot deserialize object.
    */
-  <T> T deserialize(byte[] data, Class<T> clazz) throws IOException;
+  <T> T deserialize(byte[] data, TypeRef<T> type) throws IOException;
 }

--- a/sdk/src/main/java/io/dapr/serializer/DefaultObjectSerializer.java
+++ b/sdk/src/main/java/io/dapr/serializer/DefaultObjectSerializer.java
@@ -6,8 +6,10 @@
 package io.dapr.serializer;
 
 import io.dapr.client.ObjectSerializer;
+import io.dapr.utils.TypeRef;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * Default serializer/deserializer for request/response objects and for state objects too.
@@ -26,7 +28,7 @@ public class DefaultObjectSerializer extends ObjectSerializer implements DaprObj
    * {@inheritDoc}
    */
   @Override
-  public <T> T deserialize(byte[] data, Class<T> clazz) throws IOException {
-    return super.deserialize(data, clazz);
+  public <T> T deserialize(byte[] data, TypeRef<T> type) throws IOException {
+    return super.deserialize(data, type);
   }
 }

--- a/sdk/src/main/java/io/dapr/utils/TypeRef.java
+++ b/sdk/src/main/java/io/dapr/utils/TypeRef.java
@@ -59,7 +59,7 @@ public abstract class TypeRef<T> {
    *
    * @param clazz Class type to be referenced.
    */
-  public TypeRef(Class<T> clazz) {
+  private TypeRef(Class<T> clazz) {
     this.type = clazz;
   }
 

--- a/sdk/src/main/java/io/dapr/utils/TypeRef.java
+++ b/sdk/src/main/java/io/dapr/utils/TypeRef.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+package io.dapr.utils;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Used to reference a type.
+ *
+ * <p>Usage: new TypeRef&lt;MyClass&gt;(){}</p>
+ * @param <T> Type to be deserialized.
+ */
+public abstract class TypeRef<T> {
+
+  public static final TypeRef<String> STRING = new TypeRef<String>() {};
+
+  public static final TypeRef<Boolean> BOOLEAN = new TypeRef(boolean.class) {};
+
+  public static final TypeRef<Integer> INT = new TypeRef(int.class) {};
+
+  public static final TypeRef<Long> LONG = new TypeRef(long.class) {};
+
+  public static final TypeRef<Character> CHAR = new TypeRef(char.class) {};
+
+  public static final TypeRef<Byte> BYTE = new TypeRef(byte.class) {};
+
+  public static final TypeRef<Void> VOID = new TypeRef(void.class) {};
+
+  public static final TypeRef<Float> FLOAT = new TypeRef(float.class) {};
+
+  public static final TypeRef<Double> DOUBLE = new TypeRef(double.class) {};
+
+  public static final TypeRef<byte[]> BYTE_ARRAY = new TypeRef<byte[]>() {};
+
+  public static final TypeRef<int[]> INT_ARRAY = new TypeRef<int[]>() {};
+
+  public static final TypeRef<String[]> STRING_ARRAY = new TypeRef<String[]>() {};
+
+  private final Type type;
+
+  /**
+   * Constructor.
+   */
+  public TypeRef() {
+    Type superClass = this.getClass().getGenericSuperclass();
+    if (superClass instanceof Class) {
+      throw new IllegalArgumentException("TypeReference requires type.");
+    }
+
+    this.type = ((ParameterizedType)superClass).getActualTypeArguments()[0];
+  }
+
+  /**
+   * Constructor for reflection.
+   *
+   * @param clazz Class type to be referenced.
+   */
+  public TypeRef(Class<T> clazz) {
+    this.type = clazz;
+  }
+
+  /**
+   * Gets the type referenced.
+   *
+   * @return type referenced.
+   */
+  public Type getType() {
+    return this.type;
+  }
+
+  /**
+   * Creates a reference to a given class type.
+   * @param clazz Class type to be referenced.
+   * @param <T> Type to be referenced.
+   * @return Class type reference.
+   */
+  public static <T> TypeRef<T> get(Class<T> clazz) {
+    if (clazz == String.class) {
+      return (TypeRef<T>) STRING;
+    }
+    if (clazz == boolean.class) {
+      return (TypeRef<T>) BOOLEAN;
+    }
+    if (clazz == int.class) {
+      return (TypeRef<T>) INT;
+    }
+    if (clazz == long.class) {
+      return (TypeRef<T>) LONG;
+    }
+    if (clazz == char.class) {
+      return (TypeRef<T>) CHAR;
+    }
+    if (clazz == byte.class) {
+      return (TypeRef<T>) BYTE;
+    }
+    if (clazz == void.class) {
+      return (TypeRef<T>) VOID;
+    }
+    if (clazz == float.class) {
+      return (TypeRef<T>) FLOAT;
+    }
+    if (clazz == double.class) {
+      return (TypeRef<T>) DOUBLE;
+    }
+    if (clazz == byte[].class) {
+      return (TypeRef<T>) BYTE_ARRAY;
+    }
+    if (clazz == int[].class) {
+      return (TypeRef<T>) INT_ARRAY;
+    }
+    if (clazz == String[].class) {
+      return (TypeRef<T>) STRING_ARRAY;
+    }
+
+    return new TypeRef<T>(clazz) {};
+  }
+}

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -99,7 +99,7 @@ public class DaprClientHttpTest {
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<Void> mono = daprClientHttp.invokeService(null, "", "", null, null, null);
+    Mono<Void> mono = daprClientHttp.invokeService(null, "", "", null, null, (Class)null);
     assertNull(mono.block());
   }
 
@@ -112,19 +112,19 @@ public class DaprClientHttpTest {
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttp.invokeService(null, "", "", null, null, null).block();
+      daprClientHttp.invokeService(null, "", "", null, null, (Class)null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttp.invokeService(Verb.POST, null, "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, null, "", null, null, (Class)null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttp.invokeService(Verb.POST, "", "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "", "", null, null, (Class)null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttp.invokeService(Verb.POST, "1", null, null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "1", null, null, null, (Class)null).block();
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      daprClientHttp.invokeService(Verb.POST, "1", "", null, null, null).block();
+      daprClientHttp.invokeService(Verb.POST, "1", "", null, null, (Class)null).block();
     });
   }
 
@@ -137,7 +137,7 @@ public class DaprClientHttpTest {
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<Void> mono = daprClientHttp.invokeService(Verb.POST, "1", "", null, null, null);
+    Mono<Void> mono = daprClientHttp.invokeService(Verb.POST, "1", "", null, null, (Class)null);
     assertNull(mono.block());
   }
 
@@ -235,6 +235,78 @@ public class DaprClientHttpTest {
     daprClientHttp = new DaprClientHttp(daprHttp);
     Mono<String> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, String.class);
     assertEquals("OK", mono.block());
+  }
+
+  @Test
+  public void invokeBindingResponseDouble() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("1.5");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Double> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, double.class);
+    assertEquals(1.5, mono.block(), 0.0001);
+  }
+
+  @Test
+  public void invokeBindingResponseFloat() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("1.5");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Float> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, float.class);
+    assertEquals(1.5, mono.block(), 0.0001);
+  }
+
+  @Test
+  public void invokeBindingResponseChar() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("\"a\"");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Character> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, char.class);
+    assertEquals('a', (char)mono.block());
+  }
+
+  @Test
+  public void invokeBindingResponseByte() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("\"2\"");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Byte> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, byte.class);
+    assertEquals((byte)0x2, (byte)mono.block());
+  }
+
+  @Test
+  public void invokeBindingResponseLong() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("1");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Long> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, long.class);
+    assertEquals(1, (long)mono.block());
+  }
+
+  @Test
+  public void invokeBindingResponseInt() {
+    Map<String, String> map = new HashMap<>();
+    mockInterceptor.addRule()
+      .post("http://127.0.0.1:3000/v1.0/bindings/sample-topic")
+      .respond("1");
+    daprHttp = new DaprHttp(3000, okHttpClient);
+    daprClientHttp = new DaprClientHttp(daprHttp);
+    Mono<Integer> mono = daprClientHttp.invokeBinding("sample-topic", "myoperation", "", null, int.class);
+    assertEquals(1, (int)mono.block());
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
# Description

Refactor all of the SDK to use TypeRef<T> *in addition* of Class<T>. This is a breaking change in two public methods: getStateType() for Actors and deserialize() in the ObjectSerializer interface. Private and protected methods are changed to use TypeRef only.

Inspiration: http://fasterxml.github.io/jackson-core/javadoc/2.7/com/fasterxml/jackson/core/type/TypeReference.html?is-external=true


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #293 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
