### PR TITLE
Change Service Invocation API. Fix metadata bug.

### DIFF
--- a/examples/src/main/java/io/dapr/examples/invoke/grpc/HelloWorldClient.java
+++ b/examples/src/main/java/io/dapr/examples/invoke/grpc/HelloWorldClient.java
@@ -7,7 +7,7 @@ package io.dapr.examples.invoke.grpc;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.Verb;
+import io.dapr.client.HttpExtension;
 
 /**
  * 1. Build and install jars:
@@ -33,7 +33,7 @@ public class HelloWorldClient {
     while (true) {
       String message = "Message #" + (count++);
       System.out.println("Sending message: " + message);
-      client.invokeService(Verb.POST, serviceAppId, method, message).block();
+      client.invokeService(serviceAppId, method, message, HttpExtension.NONE).block();
       System.out.println("Message sent: " + message);
 
       Thread.sleep(1000);

--- a/examples/src/main/java/io/dapr/examples/invoke/grpc/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/grpc/README.md
@@ -96,7 +96,7 @@ private static class HelloWorldClient {
     while (true) {
       String message = "Message #" + (count++);
       System.out.println("Sending message: " + message);
-      client.invokeService(Verb.POST, serviceAppId, method, message).block();
+      client.invokeService(serviceAppId, method, message, HttpExtension.NONE).block();
       System.out.println("Message sent: " + message);
 
       Thread.sleep(1000);

--- a/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
@@ -7,7 +7,7 @@ package io.dapr.examples.invoke.http;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.Verb;
+import io.dapr.client.HttpExtension;
 
 /**
  * 1. Build and install jars:
@@ -32,8 +32,8 @@ public class InvokeClient {
   public static void main(String[] args) {
     DaprClient client = (new DaprClientBuilder()).build();
     for (String message : args) {
-      byte[] response = client.invokeService(
-          Verb.POST, SERVICE_APP_ID, "say", message, null, byte[].class).block();
+      byte[] response = client.invokeService(SERVICE_APP_ID, "say", message, HttpExtension.POST, null,
+          byte[].class).block();
       System.out.println(new String(response));
     }
 

--- a/examples/src/main/java/io/dapr/examples/invoke/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/README.md
@@ -113,8 +113,8 @@ private static final String SERVICE_APP_ID = "invokedemo";
   public static void main(String[] args) {
     DaprClient client = (new DaprClientBuilder()).build();
     for (String message : args) {
-      byte[] response = client.invokeService(
-          Verb.POST, SERVICE_APP_ID, "say", message, null, byte[].class).block();
+      byte[] response = client.invokeService(SERVICE_APP_ID, "say", 
+        message, HttpExtension.POST, null, byte[].class).block();
       System.out.println(new String(response));
     }
   }

--- a/sdk-tests/src/test/java/io/dapr/it/binding/http/BindingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/binding/http/BindingIT.java
@@ -8,21 +8,17 @@ package io.dapr.it.binding.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.Verb;
+import io.dapr.client.HttpExtension;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
-import io.dapr.it.services.EmptyService;
-import io.dapr.serializer.DefaultObjectSerializer;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static io.dapr.it.Retry.callWithRetry;
 import static org.junit.Assert.assertEquals;
@@ -100,10 +96,10 @@ public class BindingIT extends BaseIT {
       System.out.println("Checking results ...");
       final List<String> messages =
           client.invokeService(
-              Verb.GET,
               daprRun.getAppName(),
               "messages",
               null,
+              HttpExtension.GET,
               List.class).block();
       assertEquals(2, messages.size());
 

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
@@ -2,20 +2,20 @@ package io.dapr.it.methodinvoke.http;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.Verb;
+import io.dapr.client.DaprHttp;
+import io.dapr.client.HttpExtension;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.runners.Parameterized.*;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class MethodInvokeIT extends BaseIT {
@@ -66,20 +66,21 @@ public class MethodInvokeIT extends BaseIT {
         for (int i = 0; i < NUM_MESSAGES; i++) {
             String message = String.format("This is message #%d", i);
             //Publishing messages
-            client.invokeService(Verb.POST, daprRun.getAppName(), "messages", message.getBytes()).block();
+            client.invokeService(daprRun.getAppName(), "messages", message.getBytes(), HttpExtension.POST).block();
             System.out.println("Invoke method messages : " + message);
         }
 
-        Map<Integer,String> messages = client.invokeService(Verb.GET, daprRun.getAppName(), "messages", null, Map.class).block();
+        Map<Integer,String> messages = client.invokeService(daprRun.getAppName(), "messages", null,
+            HttpExtension.GET, Map.class).block();
         assertEquals(10, messages.size());
 
-        client.invokeService(Verb.DELETE,daprRun.getAppName(),"messages/1",null).block();
+        client.invokeService(daprRun.getAppName(),"messages/1",null, HttpExtension.DELETE).block();
 
-        messages = client.invokeService(Verb.GET, daprRun.getAppName(), "messages", null, Map.class).block();
+        messages = client.invokeService(daprRun.getAppName(), "messages", null, HttpExtension.GET, Map.class).block();
         assertEquals(9, messages.size());
 
-        client.invokeService(Verb.PUT, daprRun.getAppName(), "messages/2", "updated message".getBytes()).block();
-        messages = client.invokeService(Verb.GET, daprRun.getAppName(), "messages", null, Map.class).block();
+        client.invokeService(daprRun.getAppName(), "messages/2", "updated message".getBytes(), HttpExtension.PUT).block();
+        messages = client.invokeService(daprRun.getAppName(), "messages", null, HttpExtension.GET, Map.class).block();
         assertEquals("updated message", messages.get("2"));
 
     }
@@ -94,16 +95,16 @@ public class MethodInvokeIT extends BaseIT {
             person.setLastName(String.format("Last Name %d", i));
             person.setBirthDate(new Date());
             //Publishing messages
-            client.invokeService(Verb.POST, daprRun.getAppName(), "persons", person).block();
+            client.invokeService(daprRun.getAppName(), "persons", person, HttpExtension.POST).block();
             System.out.println("Invoke method persons with parameter : " + person);
         }
 
-        List<Person> persons = Arrays.asList(client.invokeService(Verb.GET, daprRun.getAppName(), "persons", null, Person[].class).block());
+        List<Person> persons = Arrays.asList(client.invokeService(daprRun.getAppName(), "persons", null, HttpExtension.GET, Person[].class).block());
         assertEquals(10, persons.size());
 
-        client.invokeService(Verb.DELETE,daprRun.getAppName(),"persons/1",null).block();
+        client.invokeService(daprRun.getAppName(),"persons/1",null, HttpExtension.DELETE).block();
 
-        persons = Arrays.asList(client.invokeService(Verb.GET, daprRun.getAppName(), "persons", null, Person[].class).block());
+        persons = Arrays.asList(client.invokeService(daprRun.getAppName(), "persons", null, HttpExtension.GET, Person[].class).block());
         assertEquals(9, persons.size());
 
         Person person= new Person();
@@ -111,9 +112,9 @@ public class MethodInvokeIT extends BaseIT {
         person.setLastName("Smith");
         person.setBirthDate(Calendar.getInstance().getTime());
 
-        client.invokeService(Verb.PUT, daprRun.getAppName(), "persons/2", person).block();
+        client.invokeService(daprRun.getAppName(), "persons/2", person, HttpExtension.PUT).block();
 
-        persons = Arrays.asList(client.invokeService(Verb.GET, daprRun.getAppName(), "persons", null, Person[].class).block());
+        persons = Arrays.asList(client.invokeService(daprRun.getAppName(), "persons", null, HttpExtension.GET, Person[].class).block());
         Person resultPerson= persons.get(1);
         assertEquals("John", resultPerson.getName());
         assertEquals("Smith", resultPerson.getLastName());

--- a/sdk-tests/src/test/java/io/dapr/it/pubsub/http/PubSubIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/pubsub/http/PubSubIT.java
@@ -7,17 +7,18 @@ package io.dapr.it.pubsub.http;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.Verb;
+import io.dapr.client.DaprHttp;
+import io.dapr.client.HttpExtension;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static io.dapr.it.Retry.callWithRetry;
 import static org.junit.Assert.assertEquals;
@@ -91,7 +92,7 @@ public class PubSubIT extends BaseIT {
 
         callWithRetry(() -> {
             System.out.println("Checking results for topic " + TOPIC_NAME);
-            final List<String> messages = client.invokeService(Verb.GET, daprRun.getAppName(), "messages/testingtopic", null, List.class).block();
+            final List<String> messages = client.invokeService(daprRun.getAppName(), "messages/testingtopic", null, HttpExtension.GET, List.class).block();
             assertEquals(11, messages.size());
 
             for (int i = 0; i < NUM_MESSAGES; i++) {
@@ -110,7 +111,7 @@ public class PubSubIT extends BaseIT {
 
         callWithRetry(() -> {
             System.out.println("Checking results for topic " + ANOTHER_TOPIC_NAME);
-            final List<String> messages = client.invokeService(Verb.GET, daprRun.getAppName(), "messages/anothertopic", null, List.class).block();
+            final List<String> messages = client.invokeService(daprRun.getAppName(), "messages/anothertopic", null, HttpExtension.GET, List.class).block();
             assertEquals(10, messages.size());
 
             for (int i = 0; i < NUM_MESSAGES; i++) {

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -46,7 +46,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @param type          The Type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
@@ -61,7 +62,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @param clazz         The type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
@@ -76,7 +78,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param type          The Type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
    * @return A Mono Plan of type type.
@@ -89,7 +92,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param clazz         The type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
    * @return A Mono Plan of type type.
@@ -101,7 +105,8 @@ public interface DaprClient {
    *
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @param type          The Type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
@@ -115,7 +120,8 @@ public interface DaprClient {
    *
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @param clazz         The type needed as return for the call.
    * @param <T>           The Type of the return, use byte[] to skip serialization.
@@ -130,7 +136,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @return A Mono Plan of type type.
    */
@@ -143,7 +150,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @return A Mono Plan of type type.
    */
   Mono<Void> invokeService(String appId, String method, Object request, HttpExtension httpExtension);
@@ -153,7 +161,8 @@ public interface DaprClient {
    *
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @return A Mono Plan of type type.
    */
@@ -165,7 +174,8 @@ public interface DaprClient {
    * @param appId         The Application ID where the service is.
    * @param method        The actual Method to be call in the application.
    * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on
+   *                      HTTP, {@link HttpExtension#NONE} otherwise.
    * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
    * @return A Mono Plan of type type.
    */

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -43,130 +43,134 @@ public interface DaprClient {
   /**
    * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId    The Application ID where the service is.
-   * @param method   The actual Method to be call in the application.
-   * @param request  The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param type     The Type needed as return for the call.
-   * @param <T>      The Type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @param type          The Type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(
-      Verb verb, String appId, String method, Object request, Map<String, String> metadata, TypeRef<T> type);
+  <T> Mono<T> invokeService(String appId, String method, Object request, HttpExtension httpExtension,
+                            Map<String, String> metadata, TypeRef<T> type);
 
   /**
    * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId    The Application ID where the service is.
-   * @param method   The actual Method to be call in the application.
-   * @param request  The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param clazz    The type needed as return for the call.
-   * @param <T>      The type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @param clazz         The type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(
-      Verb verb, String appId, String method, Object request, Map<String, String> metadata, Class<T> clazz);
+  <T> Mono<T> invokeService(String appId, String method, Object request, HttpExtension httpExtension,
+                            Map<String, String> metadata, Class<T> clazz);
 
   /**
-   * Invoke a service without metadata, using serialization.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param type    The type needed as return for the call.
-   * @param <T>     The type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param type          The Type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, TypeRef<T> type);
+  <T> Mono<T> invokeService(String appId, String method, Object request, HttpExtension httpExtension, TypeRef<T> type);
 
   /**
-   * Invoke a service without metadata, using serialization.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param clazz   The type needed as return for the call.
-   * @param <T>     The type of the return, use byte[] to skip serialization.
-   * @return A Mono Plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param clazz         The type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(Verb verb, String appId, String method, Object request, Class<T> clazz);
+  <T> Mono<T> invokeService(String appId, String method, Object request, HttpExtension httpExtension, Class<T> clazz);
 
   /**
-   * Invoke a service without input, using serialization for response.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId    The Application ID where the service is.
-   * @param method   The actual Method to be call in the application.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param type     The type needed as return for the call.
-   * @param <T>      The type of the return, use byte[] to skip serialization.
-   * @return A Mono plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @param type          The Type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(Verb verb, String appId, String method, Map<String, String> metadata, TypeRef<T> type);
+  <T> Mono<T> invokeService(String appId, String method, HttpExtension httpExtension, Map<String, String> metadata,
+                            TypeRef<T> type);
 
   /**
-   * Invoke a service without input, using serialization for response.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb     The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId    The Application ID where the service is.
-   * @param method   The actual Method to be call in the application.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @param clazz    The type needed as return for the call.
-   * @param <T>      The type of the return, use byte[] to skip serialization.
-   * @return A Mono plan of type type .
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @param clazz         The type needed as return for the call.
+   * @param <T>           The Type of the return, use byte[] to skip serialization.
+   * @return A Mono Plan of type type.
    */
-  <T> Mono<T> invokeService(Verb verb, String appId, String method, Map<String, String> metadata, Class<T> clazz);
+  <T> Mono<T> invokeService(String appId, String method, HttpExtension httpExtension, Map<String, String> metadata,
+                            Class<T> clazz);
 
   /**
-   * Invoke a service with void response, using serialization.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @return A Mono plan for Void.
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @return A Mono Plan of type type.
    */
-  Mono<Void> invokeService(Verb verb, String appId, String method, Object request, Map<String, String> metadata);
+  Mono<Void> invokeService(String appId, String method, Object request, HttpExtension httpExtension,
+                            Map<String, String> metadata);
 
   /**
-   * Invoke a service with void response, no metadata and using serialization.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service, use byte[] to skip serialization.
-   * @return A Mono plan for Void.
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @return A Mono Plan of type type.
    */
-  Mono<Void> invokeService(Verb verb, String appId, String method, Object request);
+  Mono<Void> invokeService(String appId, String method, Object request, HttpExtension httpExtension);
 
   /**
-   * Invoke a service without input and void response.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @return A Mono plan for Void.
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @return A Mono Plan of type type.
    */
-  Mono<Void> invokeService(Verb verb, String appId, String method, Map<String, String> metadata);
+  Mono<Void> invokeService(String appId, String method, HttpExtension httpExtension, Map<String, String> metadata);
 
   /**
-   * Invoke a service without serialization.
+   * Invoke a service with all possible parameters, using serialization.
    *
-   * @param verb    The Verb to be used for HTTP will be the HTTP Verb, for GRPC is just a metadata value.
-   * @param appId   The Application ID where the service is.
-   * @param method  The actual Method to be call in the application.
-   * @param request The request to be sent to invoke the service
-   * @param metadata Metadata (in GRPC) or headers (in HTTP) to be send in request.
-   * @return A Mono plan of byte[].
+   * @param appId         The Application ID where the service is.
+   * @param method        The actual Method to be call in the application.
+   * @param request       The request to be sent to invoke the service, use byte[] to skip serialization.
+   * @param httpExtension Additional fields that are needed if the receiving app is listening on HTTP.
+   * @param metadata      Metadata (in GRPC) or headers (in HTTP) to be sent in request.
+   * @return A Mono Plan of type type.
    */
-  Mono<byte[]> invokeService(Verb verb, String appId, String method, byte[] request, Map<String, String> metadata);
+  Mono<byte[]> invokeService(String appId, String method, byte[] request, HttpExtension httpExtension,
+                           Map<String, String> metadata);
 
   /**
    * Invokes a Binding operation.

--- a/sdk/src/main/java/io/dapr/client/DaprHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttp.java
@@ -31,10 +31,15 @@ public class DaprHttp {
    * HTTP Methods supported.
    */
   public enum HttpMethods {
+    NONE,
     GET,
     PUT,
     POST,
-    DELETE
+    DELETE,
+    HEAD,
+    CONNECT,
+    OPTIONS,
+    TRACE
   }
 
   public static class Response {
@@ -171,7 +176,10 @@ public class DaprHttp {
             body = RequestBody.Companion.create(content, mediaType);
           }
           HttpUrl.Builder urlBuilder = new HttpUrl.Builder();
-          urlBuilder.scheme("http").host(Constants.DEFAULT_HOSTNAME).port(this.port).addPathSegments(urlString);
+          urlBuilder.scheme(Constants.DEFAULT_PROTOCOL)
+              .host(Constants.DEFAULT_HOSTNAME)
+              .port(this.port)
+              .addPathSegments(urlString);
           Optional.ofNullable(urlParameters).orElse(Collections.emptyMap()).entrySet().stream()
               .forEach(urlParameter -> urlBuilder.addQueryParameter(urlParameter.getKey(), urlParameter.getValue()));
 

--- a/sdk/src/main/java/io/dapr/client/DaprHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttp.java
@@ -26,6 +26,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class DaprHttp {
+  /**
+   * Dapr's http default scheme.
+   */
+  private static final String DEFAULT_HTTP_SCHEME = "http";
 
   /**
    * HTTP Methods supported.
@@ -176,7 +180,7 @@ public class DaprHttp {
             body = RequestBody.Companion.create(content, mediaType);
           }
           HttpUrl.Builder urlBuilder = new HttpUrl.Builder();
-          urlBuilder.scheme(Constants.DEFAULT_PROTOCOL)
+          urlBuilder.scheme(DEFAULT_HTTP_SCHEME)
               .host(Constants.DEFAULT_HOSTNAME)
               .port(this.port)
               .addPathSegments(urlString);

--- a/sdk/src/main/java/io/dapr/client/HttpExtension.java
+++ b/sdk/src/main/java/io/dapr/client/HttpExtension.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+package io.dapr.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * HTTP Extension class.
+ * This class is only needed if the app you are calling is listening on HTTP.
+ * It contains properties that represent data that may be populated for an HTTP receiver.
+ */
+
+public class HttpExtension {
+  /**
+   * HTTP verb.
+   */
+  private DaprHttp.HttpMethods method;
+
+  /**
+   * HTTP querystring.
+   */
+  private Map<String, String> queryString;
+
+  /**
+   * Convenience HttpExtension object for the NONE Verb with empty queryStreing.
+   */
+  public static final HttpExtension NONE = new HttpExtension(DaprHttp.HttpMethods.NONE, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the GET Verb with empty queryStreing.
+   */
+  public static final HttpExtension GET = new HttpExtension(DaprHttp.HttpMethods.GET, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the PUT Verb with empty queryStreing.
+   */
+  public static final HttpExtension PUT = new HttpExtension(DaprHttp.HttpMethods.PUT, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the POST Verb with empty queryStreing.
+   */
+  public static final HttpExtension POST = new HttpExtension(DaprHttp.HttpMethods.POST, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the DELETE Verb with empty queryStreing.
+   */
+  public static final HttpExtension DELETE = new HttpExtension(DaprHttp.HttpMethods.DELETE, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the HEAD Verb with empty queryStreing.
+   */
+  public static final HttpExtension HEAD = new HttpExtension(DaprHttp.HttpMethods.HEAD, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the CONNECT Verb with empty queryStreing.
+   */
+  public static final HttpExtension CONNECT = new HttpExtension(DaprHttp.HttpMethods.CONNECT, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the OPTIONS Verb with empty queryStreing.
+   */
+  public static final HttpExtension OPTIONS = new HttpExtension(DaprHttp.HttpMethods.OPTIONS, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the TRACE Verb with empty queryStreing.
+   */
+  public static final HttpExtension TRACE = new HttpExtension(DaprHttp.HttpMethods.TRACE, new HashMap<>());
+
+  /**
+   * Default no-op constructor.
+   */
+  private HttpExtension() {
+    // No-Op
+  }
+
+  /**
+   * Construct a HttpExtension object.
+   * @param method      Required value denoting the HttpMethod.
+   * @param queryString Non-null map value for the queryString for a HTTP listener.
+   * @see io.dapr.client.DaprHttp.HttpMethods for supported methods.
+   * @throws IllegalArgumentException on null method or queryString.
+   */
+  public HttpExtension(DaprHttp.HttpMethods method, Map<String, String> queryString) {
+    if (method == null) {
+      throw new IllegalArgumentException("HttpExtension method cannot be null");
+    } else if (queryString == null) {
+      throw new IllegalArgumentException("HttpExtension queryString map cannot be null");
+    }
+    this.method = method;
+    this.queryString = Collections.unmodifiableMap(queryString);
+  }
+
+  public DaprHttp.HttpMethods getMethod() {
+    return method;
+  }
+
+  public Map<String, String> getQueryString() {
+    return queryString;
+  }
+}

--- a/sdk/src/main/java/io/dapr/client/HttpExtension.java
+++ b/sdk/src/main/java/io/dapr/client/HttpExtension.java
@@ -15,7 +15,44 @@ import java.util.Map;
  * It contains properties that represent data that may be populated for an HTTP receiver.
  */
 
-public class HttpExtension {
+public final class HttpExtension {
+  /**
+   * Convenience HttpExtension object for {@link DaprHttp.HttpMethods#NONE} with empty queryString.
+   */
+  public static final HttpExtension NONE = new HttpExtension(DaprHttp.HttpMethods.NONE, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#GET} Verb with empty queryString.
+   */
+  public static final HttpExtension GET = new HttpExtension(DaprHttp.HttpMethods.GET, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#PUT} Verb with empty queryString.
+   */
+  public static final HttpExtension PUT = new HttpExtension(DaprHttp.HttpMethods.PUT, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#POST} Verb with empty queryString.
+   */
+  public static final HttpExtension POST = new HttpExtension(DaprHttp.HttpMethods.POST, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#DELETE} Verb with empty queryString.
+   */
+  public static final HttpExtension DELETE = new HttpExtension(DaprHttp.HttpMethods.DELETE, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#HEAD} Verb with empty queryString.
+   */
+  public static final HttpExtension HEAD = new HttpExtension(DaprHttp.HttpMethods.HEAD, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#CONNECT} Verb with empty queryString.
+   */
+  public static final HttpExtension CONNECT = new HttpExtension(DaprHttp.HttpMethods.CONNECT, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#OPTIONS} Verb with empty queryString.
+   */
+  public static final HttpExtension OPTIONS = new HttpExtension(DaprHttp.HttpMethods.OPTIONS, new HashMap<>());
+  /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#TRACE} Verb with empty queryString.
+   */
+  public static final HttpExtension TRACE = new HttpExtension(DaprHttp.HttpMethods.TRACE, new HashMap<>());
+
   /**
    * HTTP verb.
    */
@@ -25,50 +62,6 @@ public class HttpExtension {
    * HTTP querystring.
    */
   private Map<String, String> queryString;
-
-  /**
-   * Convenience HttpExtension object for the NONE Verb with empty queryStreing.
-   */
-  public static final HttpExtension NONE = new HttpExtension(DaprHttp.HttpMethods.NONE, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the GET Verb with empty queryStreing.
-   */
-  public static final HttpExtension GET = new HttpExtension(DaprHttp.HttpMethods.GET, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the PUT Verb with empty queryStreing.
-   */
-  public static final HttpExtension PUT = new HttpExtension(DaprHttp.HttpMethods.PUT, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the POST Verb with empty queryStreing.
-   */
-  public static final HttpExtension POST = new HttpExtension(DaprHttp.HttpMethods.POST, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the DELETE Verb with empty queryStreing.
-   */
-  public static final HttpExtension DELETE = new HttpExtension(DaprHttp.HttpMethods.DELETE, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the HEAD Verb with empty queryStreing.
-   */
-  public static final HttpExtension HEAD = new HttpExtension(DaprHttp.HttpMethods.HEAD, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the CONNECT Verb with empty queryStreing.
-   */
-  public static final HttpExtension CONNECT = new HttpExtension(DaprHttp.HttpMethods.CONNECT, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the OPTIONS Verb with empty queryStreing.
-   */
-  public static final HttpExtension OPTIONS = new HttpExtension(DaprHttp.HttpMethods.OPTIONS, new HashMap<>());
-  /**
-   * Convenience HttpExtension object for the TRACE Verb with empty queryStreing.
-   */
-  public static final HttpExtension TRACE = new HttpExtension(DaprHttp.HttpMethods.TRACE, new HashMap<>());
-
-  /**
-   * Default no-op constructor.
-   */
-  private HttpExtension() {
-    // No-Op
-  }
 
   /**
    * Construct a HttpExtension object.

--- a/sdk/src/main/java/io/dapr/utils/Constants.java
+++ b/sdk/src/main/java/io/dapr/utils/Constants.java
@@ -16,11 +16,6 @@ public final class Constants {
   public static final String API_VERSION = "v1.0";
 
   /**
-   * Dapr's default protocol.
-   */
-  public static final String DEFAULT_PROTOCOL = "http";
-
-  /**
    * Dapr's default hostname.
    */
   public static final String DEFAULT_HOSTNAME = "127.0.0.1";

--- a/sdk/src/main/java/io/dapr/utils/Constants.java
+++ b/sdk/src/main/java/io/dapr/utils/Constants.java
@@ -16,6 +16,11 @@ public final class Constants {
   public static final String API_VERSION = "v1.0";
 
   /**
+   * Dapr's default protocol.
+   */
+  public static final String DEFAULT_PROTOCOL = "http";
+
+  /**
    * Dapr's default hostname.
    */
   public static final String DEFAULT_HOSTNAME = "127.0.0.1";

--- a/sdk/src/test/java/io/dapr/runtime/DaprRuntimeTest.java
+++ b/sdk/src/test/java/io/dapr/runtime/DaprRuntimeTest.java
@@ -202,15 +202,15 @@ public class DaprRuntimeTest {
           eq(Constants.INVOKE_PATH + "/" + APP_ID + "/method/" + METHOD_NAME),
           any(),
           eq(serializer.serialize(message.data)),
-          eq(null)))
+          any()))
           .thenAnswer(x ->
               this.daprRuntime.handleInvocation(
               METHOD_NAME,
               serializer.serialize(message.data),
               message.metadata)
           .map(r -> new DaprHttpStub.ResponseStub(r, null, 200)));
-
-      Mono<byte[]> response = client.invokeService(Verb.POST, APP_ID, METHOD_NAME, message.data, message.metadata, byte[].class);
+      Mono<byte[]> response = client.invokeService(APP_ID, METHOD_NAME, message.data, HttpExtension.POST,
+          message.metadata, byte[].class);
       Assert.assertArrayEquals(expectedResponse, response.block());
 
       verify(listener, times(1))


### PR DESCRIPTION
# Description

Change Service Invocation API to accept HttpExtension object.

Fix the bug where metadata passed in is used as urlParameters, instead use queryString from HttpExtension object.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #242 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
