### PR TITLE
Fix port collision in java ITs

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/DaprPorts.java
+++ b/sdk-tests/src/test/java/io/dapr/it/DaprPorts.java
@@ -8,7 +8,10 @@ package io.dapr.it;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class DaprPorts {
 
@@ -26,7 +29,7 @@ public class DaprPorts {
 
   public static DaprPorts build(boolean appPort, boolean httpPort, boolean grpcPort) {
     try {
-      List<Integer> freePorts = findFreePorts(3);
+      List<Integer> freePorts = new ArrayList<>(findFreePorts(3));
       return new DaprPorts(
           appPort ? freePorts.get(0) : null,
           httpPort ? freePorts.get(1) : null,
@@ -48,18 +51,18 @@ public class DaprPorts {
     return appPort;
   }
 
-  private static List<Integer> findFreePorts(int n) throws IOException {
-    if (n <= 0) {
-      return new ArrayList<>();
+  private static Set<Integer> findFreePorts(int n) throws IOException {
+    Set<Integer> output = new HashSet<>();
+    for (int i = 0; i < n;) {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        socket.setReuseAddress(true);
+        int port = socket.getLocalPort();
+        if (!output.contains(port)) {
+          output.add(port);
+          i++;
+        }
+      }
     }
-    try (
-      ServerSocket socket = new ServerSocket(0)
-    ) {
-      socket.setReuseAddress(true);
-      int port = socket.getLocalPort();
-      List<Integer> output = findFreePorts(n - 1);
-      output.add(port);
-      return output;
-    }
+    return output;
   }
 }


### PR DESCRIPTION
# Description

Fix Port collisions in Java ITs. 

Due to previous logic, there was a possibility that a free port that was selected previously was selected again for use. 

Ex:
```
== DAPR == time="2020-09-21T22:19:37.465255014Z" level=info msg="application discovered on port 44687" app_id=MethodInvokeIT_MethodInvokeService instance=fv-az176 scope=dapr.runtime type=log ver=edge

== DAPR == time="2020-09-21T22:19:37.732200928Z" level=fatal msg="failed to start internal gRPC server: listen tcp :44687: bind: address already in use" app_id=MethodInvokeIT_MethodInvokeService instance=fv-az176 scope=dapr.runtime type=log ver=edge
```

The same port was used for gRPC API port and for gRPC internal port. 


The fixed logic now selects 3 unique ports. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
