### PR TITLE
Remove set-env usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,13 +117,15 @@ jobs:
     - name: Get pom parent version
       run: |
         PARENT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-        echo "##[set-env name=PARENT_VERSION;]$PARENT_VERSION"
+        echo "PARENT_VERSION=$PARENT_VERSION" >> $GITHUB_ENV
     - name: Is SNAPSHOT release ?
       if: contains(github.ref, 'master') && contains(env.PARENT_VERSION, '-SNAPSHOT')
-      run: echo "##[set-env name=DEPLOY_OSSRH;]true"
+      run: |
+        echo "DEPLOY_OSSRH=true" >> $GITHUB_ENV
     - name: Is Release or RC version ?
       if: startswith(github.ref, 'refs/tags/v') && !contains(env.PARENT_VERSION, '-SNAPSHOT')
-      run: echo "##[set-env name=DEPLOY_OSSRH;]true"
+      run: |
+        echo "DEPLOY_OSSRH=true" >> $GITHUB_ENV
     - name: Publish to ossrh
       if: env.DEPLOY_OSSRH == 'true'
       run: |


### PR DESCRIPTION
# Description

https://nvd.nist.gov/vuln/detail/CVE-2020-15228 advises that setenv and add-path are not secure, so they will be disabled very shortly on workflows. This changes set-env to the recommended upgrade.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: Part of dapr/dapr#2202

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
