### PR TITLE
Fix build due to deprecated maven repo, using jcenter now.

### DIFF
--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -21,9 +21,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>spring</id>
-      <name>libs-release</name>
-      <url>https://repo.spring.io/libs-release</url>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com/</url>
     </repository>
   </repositories>
 

--- a/sdk-springboot/pom.xml
+++ b/sdk-springboot/pom.xml
@@ -21,9 +21,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>spring</id>
-      <name>libs-release</name>
-      <url>https://repo.spring.io/libs-release</url>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com/</url>
     </repository>
   </repositories>
 

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -15,9 +15,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>spring</id>
-      <name>libs-release</name>
-      <url>https://repo.spring.io/libs-release</url>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com/</url>
     </repository>
   </repositories>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -21,9 +21,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>spring</id>
-      <name>libs-release</name>
-      <url>https://repo.spring.io/libs-release</url>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
# Description

Fix build due to deprecated maven repo, using jcenter now.

https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: End game

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
