### PR TITLE
support metadata in get state and bulk get state response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.33.1</grpc.version>
     <protobuf.version>3.13.0</protobuf.version>
-    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/83f5c45362b0c577139b1887276d7cf1b7308506/dapr/proto</dapr.proto.baseurl>
+    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/a67a76d468c748c76122b04f28d8181a1170249c/dapr/proto</dapr.proto.baseurl>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>

--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -331,7 +331,7 @@ public class DaprClientGrpc extends AbstractDaprClient {
     byte[] data = payload == null ? null : payload.toByteArray();
     T value = stateSerializer.deserialize(data, type);
     String etag = item.getEtag();
-    return new State<>(value, key, etag);
+    return new State<>(value, key, etag, item.getMetadataMap(), null);
   }
 
   private <T> State<T> buildStateKeyValue(
@@ -343,7 +343,7 @@ public class DaprClientGrpc extends AbstractDaprClient {
     byte[] data = payload == null ? null : payload.toByteArray();
     T value = stateSerializer.deserialize(data, type);
     String etag = response.getEtag();
-    return new State<>(value, requestedKey, etag, stateOptions);
+    return new State<>(value, requestedKey, etag, response.getMetadataMap(), stateOptions);
   }
 
   /**

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -716,7 +716,7 @@ public class DaprClientGrpcTest {
     String etag = "ETag1";
     String key = "key1";
     String expectedValue = "Expected state";
-    State<String> expectedState = buildStateKey(expectedValue, key, etag, null);
+    State<String> expectedState = buildStateKey(expectedValue, key, etag, new HashMap<>(), null);
     DaprProtos.GetStateResponse responseEnvelope = buildGetStateResponse(expectedValue, etag);
     SettableFuture<DaprProtos.GetStateResponse> settableFuture = SettableFuture.create();
     MockCallback<DaprProtos.GetStateResponse> callback = new MockCallback<>(responseEnvelope);
@@ -758,12 +758,12 @@ public class DaprClientGrpcTest {
     String key = "key1";
     MyObject expectedValue = new MyObject(1, "The Value");
     StateOptions options = buildStateOptions(StateOptions.Consistency.STRONG, StateOptions.Concurrency.FIRST_WRITE);
-    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, options);
+    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, new HashMap<>(), options);
     DaprProtos.GetStateResponse responseEnvelope = DaprProtos.GetStateResponse.newBuilder()
         .setData(serialize(expectedValue))
         .setEtag(etag)
         .build();
-    State<MyObject> keyRequest = buildStateKey(null, key, etag, options);
+    State<MyObject> keyRequest = buildStateKey(null, key, etag, new HashMap<>(), options);
     SettableFuture<DaprProtos.GetStateResponse> settableFuture = SettableFuture.create();
     MockCallback<DaprProtos.GetStateResponse> callback = new MockCallback<>(responseEnvelope);
     addCallback(settableFuture, callback, directExecutor());
@@ -784,7 +784,7 @@ public class DaprClientGrpcTest {
     StateOptions options = buildStateOptions(StateOptions.Consistency.STRONG, StateOptions.Concurrency.FIRST_WRITE);
     Map<String, String> metadata = new HashMap<>();
     metadata.put("key_1", "val_1");
-    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, options);
+    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, new HashMap<>(), options);
     DaprProtos.GetStateResponse responseEnvelope = DaprProtos.GetStateResponse.newBuilder()
         .setData(serialize(expectedValue))
         .setEtag(etag)
@@ -810,12 +810,12 @@ public class DaprClientGrpcTest {
     String key = "key1";
     MyObject expectedValue = new MyObject(1, "The Value");
     StateOptions options = new StateOptions(null, StateOptions.Concurrency.FIRST_WRITE);
-    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, options);
+    State<MyObject> expectedState = buildStateKey(expectedValue, key, etag, new HashMap<>(), options);
     DaprProtos.GetStateResponse responseEnvelope = DaprProtos.GetStateResponse.newBuilder()
         .setData(serialize(expectedValue))
         .setEtag(etag)
         .build();
-    State<MyObject> keyRequest = buildStateKey(null, key, etag, options);
+    State<MyObject> keyRequest = buildStateKey(null, key, etag, new HashMap<>(), options);
     SettableFuture<DaprProtos.GetStateResponse> settableFuture = SettableFuture.create();
     MockCallback<DaprProtos.GetStateResponse> callback = new MockCallback<>(responseEnvelope);
     addCallback(settableFuture, callback, directExecutor());
@@ -1453,6 +1453,10 @@ public class DaprClientGrpcTest {
     return new State<>(value, key, etag, options);
   }
 
+  private <T> State<T> buildStateKey(T value, String key, String etag, Map<String, String> metadata, StateOptions options) {
+    return new State<>(value, key, etag, metadata, options);
+  }
+
   /**
    * The purpose of this test is to show that it doesn't matter when the client is called, the actual coll to DAPR
    * will be done when the output Mono response call the Mono.block method.
@@ -1480,7 +1484,7 @@ public class DaprClientGrpcTest {
     String expectedValue1 = "Expected state 1";
     String key2 = "key2";
     String expectedValue2 = "Expected state 2";
-    State<String> expectedState1 = buildStateKey(expectedValue1, key1, etag, null);
+    State<String> expectedState1 = buildStateKey(expectedValue1, key1, etag, new HashMap<>(), null);
     Map<String, SettableFuture<DaprProtos.GetStateResponse>> futuresMap = new HashMap<>();
     futuresMap.put(key1, buildFutureGetStateEnvelop(expectedValue1, etag));
     futuresMap.put(key2, buildFutureGetStateEnvelop(expectedValue2, etag));


### PR DESCRIPTION
# Description

Support metadata in get state response and bulk get state response.

## Issue reference

Issue discussed here:  https://github.com/dapr/dapr/issues/2498 and https://github.com/dapr/java-sdk/issues/396

The PR to add metadata fields in proto had been merged in this PR:  https://github.com/dapr/dapr/pull/2506/files

Now we continue to update java-sdk.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
