### PR TITLE
Set etag to be null if it's empty

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/state/AbstractStateClientIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/state/AbstractStateClientIT.java
@@ -74,13 +74,11 @@ public abstract class AbstractStateClientIT extends BaseIT {
     Assert.assertNotNull(state);
     Assert.assertEquals("unknownKey", state.getKey());
     Assert.assertNull(state.getValue());
-    // gRPC returns empty eTag while HTTP returns null.
-    // TODO(artursouza): https://github.com/dapr/java-sdk/issues/405
-    Assert.assertTrue(state.getEtag() == null || state.getEtag().isEmpty());
+    Assert.assertNull(state.getEtag());
   }
 
   @Test
-  public void saveAndGetBulkStates() {
+  public void saveAndGetBulkState() {
     final String stateKeyOne = UUID.randomUUID().toString();
     final String stateKeyTwo = UUID.randomUUID().toString();
     final String stateKeyThree = "NotFound";
@@ -114,8 +112,8 @@ public abstract class AbstractStateClientIT extends BaseIT {
 
     assertEquals(stateKeyThree, result.stream().skip(2).findFirst().get().getKey());
     assertNull(result.stream().skip(2).findFirst().get().getValue());
-    assertEquals("", result.stream().skip(2).findFirst().get().getEtag());
-    assertNull("not found", result.stream().skip(2).findFirst().get().getError());
+    assertNull(result.stream().skip(2).findFirst().get().getEtag());
+    assertNull(result.stream().skip(2).findFirst().get().getError());
   }
 
   @Test

--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -320,6 +320,9 @@ public class DaprClientGrpc extends AbstractDaprClient {
     byte[] data = payload == null ? null : payload.toByteArray();
     T value = stateSerializer.deserialize(data, type);
     String etag = item.getEtag();
+    if (etag.equals("")) {
+      etag = null;
+    }
     return new State<>(value, key, etag, item.getMetadataMap(), null);
   }
 
@@ -332,6 +335,9 @@ public class DaprClientGrpc extends AbstractDaprClient {
     byte[] data = payload == null ? null : payload.toByteArray();
     T value = stateSerializer.deserialize(data, type);
     String etag = response.getEtag();
+    if (etag.equals("")) {
+      etag = null;
+    }
     return new State<>(value, requestedKey, etag, response.getMetadataMap(), stateOptions);
   }
 

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -542,6 +542,9 @@ public class DaprClientHttp extends AbstractDaprClient {
       }
 
       String etag = node.path("etag").asText();
+      if (etag.equals("")) {
+        etag = null;
+      }
       // TODO(artursouza): JSON cannot differentiate if data returned is String or byte[], it is ambiguous.
       // This is not a high priority since GRPC is the default (and recommended) client implementation.
       byte[] data = node.path("data").toString().getBytes(Properties.STRING_CHARSET.get());

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -640,8 +640,9 @@ public class DaprClientHttpTest {
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<State<String>> monoEmptyEtag = daprClientHttp.getState(STATE_STORE_NAME, stateEmptyEtag, String.class);
-    assertEquals(monoEmptyEtag.block().getKey(), "key");
+    State<String> monoEmptyEtag = daprClientHttp.getState(STATE_STORE_NAME, stateEmptyEtag, String.class).block();
+    assertEquals(monoEmptyEtag.getKey(), "key");
+    assertNull(monoEmptyEtag.getEtag());
   }
 
   @Test
@@ -667,8 +668,9 @@ public class DaprClientHttpTest {
       .respond("\"" + EXPECTED_RESULT + "\"");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    Mono<State<String>> monoNullEtag = daprClientHttp.getState(STATE_STORE_NAME, stateNullEtag, String.class);
-    assertEquals(monoNullEtag.block().getKey(), "key");
+    State<String> monoNullEtag = daprClientHttp.getState(STATE_STORE_NAME, stateNullEtag, String.class).block();
+    assertEquals(monoNullEtag.getKey(), "key");
+    assertNull(monoNullEtag.getEtag());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>

# Description

Convert empty string to null for GRPC implementation to keep it consistent with HTTP implementation

## Issue reference

Fixes #405

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
