### PR TITLE
Rename ActorProxy invoke to invokeMethod.

### DIFF
--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxy.java
@@ -36,7 +36,7 @@ public interface ActorProxy {
    * @param <T>        The type to be returned.
    * @return Asynchronous result with the Actor's response.
    */
-  <T> Mono<T> invoke(String methodName, TypeRef<T> type);
+  <T> Mono<T> invokeMethod(String methodName, TypeRef<T> type);
 
   /**
    * Invokes an Actor method on Dapr.
@@ -46,7 +46,7 @@ public interface ActorProxy {
    * @param <T>        The type to be returned.
    * @return Asynchronous result with the Actor's response.
    */
-  <T> Mono<T> invoke(String methodName, Class<T> clazz);
+  <T> Mono<T> invokeMethod(String methodName, Class<T> clazz);
 
   /**
    * Invokes an Actor method on Dapr.
@@ -57,7 +57,7 @@ public interface ActorProxy {
    * @param <T>        The type to be returned.
    * @return Asynchronous result with the Actor's response.
    */
-  <T> Mono<T> invoke(String methodName, Object data, TypeRef<T> type);
+  <T> Mono<T> invokeMethod(String methodName, Object data, TypeRef<T> type);
 
   /**
    * Invokes an Actor method on Dapr.
@@ -68,7 +68,7 @@ public interface ActorProxy {
    * @param <T>        The type to be returned.
    * @return Asynchronous result with the Actor's response.
    */
-  <T> Mono<T> invoke(String methodName, Object data, Class<T> clazz);
+  <T> Mono<T> invokeMethod(String methodName, Object data, Class<T> clazz);
 
   /**
    * Invokes an Actor method on Dapr.
@@ -76,7 +76,7 @@ public interface ActorProxy {
    * @param methodName Method name to invoke.
    * @return Asynchronous result with the Actor's response.
    */
-  Mono<Void> invoke(String methodName);
+  Mono<Void> invokeMethod(String methodName);
 
   /**
    * Invokes an Actor method on Dapr.
@@ -85,6 +85,6 @@ public interface ActorProxy {
    * @param data       Object with the data.
    * @return Asynchronous result with the Actor's response.
    */
-  Mono<Void> invoke(String methodName, Object data);
+  Mono<Void> invokeMethod(String methodName, Object data);
 
 }

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
@@ -74,7 +74,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    * {@inheritDoc}
    */
   @Override
-  public <T> Mono<T> invoke(String methodName, Object data, TypeRef<T> type) {
+  public <T> Mono<T> invokeMethod(String methodName, Object data, TypeRef<T> type) {
     return this.daprClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data))
           .filter(s -> s.length > 0)
           .map(s -> deserialize(s, type));
@@ -84,15 +84,15 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    * {@inheritDoc}
    */
   @Override
-  public <T> Mono<T> invoke(String methodName, Object data, Class<T> clazz) {
-    return this.invoke(methodName, data, TypeRef.get(clazz));
+  public <T> Mono<T> invokeMethod(String methodName, Object data, Class<T> clazz) {
+    return this.invokeMethod(methodName, data, TypeRef.get(clazz));
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public <T> Mono<T> invoke(String methodName, TypeRef<T> type) {
+  public <T> Mono<T> invokeMethod(String methodName, TypeRef<T> type) {
     return this.daprClient.invoke(actorType, actorId.toString(), methodName, null)
           .filter(s -> s.length > 0)
           .map(s -> deserialize(s, type));
@@ -102,15 +102,15 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    * {@inheritDoc}
    */
   @Override
-  public <T> Mono<T> invoke(String methodName, Class<T> clazz) {
-    return this.invoke(methodName, TypeRef.get(clazz));
+  public <T> Mono<T> invokeMethod(String methodName, Class<T> clazz) {
+    return this.invokeMethod(methodName, TypeRef.get(clazz));
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> invoke(String methodName) {
+  public Mono<Void> invokeMethod(String methodName) {
     return this.daprClient.invoke(actorType, actorId.toString(), methodName, null).then();
   }
 
@@ -118,7 +118,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    * {@inheritDoc}
    */
   @Override
-  public Mono<Void> invoke(String methodName, Object data) {
+  public Mono<Void> invokeMethod(String methodName, Object data) {
     return this.daprClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data)).then();
   }
 
@@ -140,25 +140,25 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
       if (method.getReturnType().equals(Mono.class)) {
         ActorMethod actorMethodAnnotation = method.getDeclaredAnnotation(ActorMethod.class);
         if (actorMethodAnnotation == null) {
-          return invoke(method.getName());
+          return invokeMethod(method.getName());
         }
 
-        return invoke(method.getName(), actorMethodAnnotation.returns());
+        return invokeMethod(method.getName(), actorMethodAnnotation.returns());
       }
 
-      return invoke(method.getName(), method.getReturnType()).block();
+      return invokeMethod(method.getName(), method.getReturnType()).block();
     }
 
     if (method.getReturnType().equals(Mono.class)) {
       ActorMethod actorMethodAnnotation = method.getDeclaredAnnotation(ActorMethod.class);
       if (actorMethodAnnotation == null) {
-        return invoke(method.getName(), args[0]);
+        return invokeMethod(method.getName(), args[0]);
       }
 
-      return invoke(method.getName(), args[0], actorMethodAnnotation.returns());
+      return invokeMethod(method.getName(), args[0], actorMethodAnnotation.returns());
     }
 
-    return invoke(method.getName(), args[0], method.getReturnType()).block();
+    return invokeMethod(method.getName(), args[0], method.getReturnType()).block();
   }
 
   /**

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
@@ -49,7 +49,7 @@ public class ActorProxyImplTest {
             new DefaultObjectSerializer(),
             daprClient);
 
-    Mono<MyData> result = actorProxy.invoke("getData", MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", MyData.class);
     MyData myData = result.block();
     Assert.assertNotNull(myData);
     Assert.assertEquals("valueA", myData.getPropertyA());
@@ -260,7 +260,7 @@ public class ActorProxyImplTest {
         new DefaultObjectSerializer(),
         daprClient);
 
-    Mono<MyData> result = actorProxy.invoke("getData", MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", MyData.class);
     MyData myData = result.block();
     Assert.assertNull(myData);
   }
@@ -277,7 +277,7 @@ public class ActorProxyImplTest {
         new DefaultObjectSerializer(),
         daprClient);
 
-    Mono<MyData> result = actorProxy.invoke("getData", MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", MyData.class);
 
     result.doOnSuccess(x ->
         Assert.fail("Not exception was throw"))
@@ -302,7 +302,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyA("valueA");
     saveData.setPropertyB("valueB");
 
-    Mono<MyData> result = actorProxy.invoke("getData", saveData, MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", saveData, MyData.class);
     MyData myData = result.block();
     Assert.assertNotNull(myData);
     Assert.assertEquals("valueA", myData.getPropertyA());
@@ -326,7 +326,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyA("valueA");
     saveData.setPropertyB("valueB");
 
-    Mono<MyData> result = actorProxy.invoke("getData", saveData, MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", saveData, MyData.class);
     result.doOnSuccess(x ->
         Assert.fail("Not exception was throw"))
         .doOnError(Throwable::printStackTrace
@@ -350,7 +350,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyA("valueA");
     saveData.setPropertyB("valueB");
 
-    Mono<MyData> result = actorProxy.invoke("getData", saveData, MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", saveData, MyData.class);
     MyData myData = result.block();
     Assert.assertNull(myData);
   }
@@ -373,7 +373,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyB("valueB");
     saveData.setMyData(saveData);
 
-    Mono<MyData> result = actorProxy.invoke("getData", saveData, MyData.class);
+    Mono<MyData> result = actorProxy.invokeMethod("getData", saveData, MyData.class);
     result.doOnSuccess(x ->
         Assert.fail("Not exception was throw"))
         .doOnError(Throwable::printStackTrace
@@ -397,7 +397,7 @@ public class ActorProxyImplTest {
         new DefaultObjectSerializer(),
         daprClient);
 
-    Mono<Void> result = actorProxy.invoke("getData", saveData);
+    Mono<Void> result = actorProxy.invokeMethod("getData", saveData);
     Void emptyResponse = result.block();
     Assert.assertNull(emptyResponse);
   }
@@ -420,7 +420,7 @@ public class ActorProxyImplTest {
         new DefaultObjectSerializer(),
         daprClient);
 
-    Mono<Void> result = actorProxy.invoke("getData", saveData);
+    Mono<Void> result = actorProxy.invokeMethod("getData", saveData);
     Void emptyResponse = result.doOnError(Throwable::printStackTrace).block();
     Assert.assertNull(emptyResponse);
   }
@@ -437,7 +437,7 @@ public class ActorProxyImplTest {
         new DefaultObjectSerializer(),
         daprClient);
 
-    Mono<Void> result = actorProxy.invoke("getData");
+    Mono<Void> result = actorProxy.invokeMethod("getData");
     Void emptyResponse = result.block();
     Assert.assertNull(emptyResponse);
   }

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorCustomSerializerTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorCustomSerializerTest.java
@@ -98,7 +98,7 @@ public class ActorCustomSerializerTest {
     ActorProxy actorProxy = createActorProxy();
     MyData d = new MyData("hi", 3);
 
-    MyData response = actorProxy.invoke("classInClassOut", d, MyData.class).block();
+    MyData response = actorProxy.invokeMethod("classInClassOut", d, MyData.class).block();
 
     Assert.assertEquals("hihi", response.getName());
     Assert.assertEquals(6, response.getNum());
@@ -107,7 +107,7 @@ public class ActorCustomSerializerTest {
   @Test
   public void stringInStringOut() {
     ActorProxy actorProxy = createActorProxy();
-    String response = actorProxy.invoke("stringInStringOut", "oi", String.class).block();
+    String response = actorProxy.invokeMethod("stringInStringOut", "oi", String.class).block();
 
     Assert.assertEquals("oioi", response);
   }
@@ -115,7 +115,7 @@ public class ActorCustomSerializerTest {
   @Test
   public void intInIntOut() {
     ActorProxy actorProxy = createActorProxy();
-    int response = actorProxy.invoke("intInIntOut", 2, int.class).block();
+    int response = actorProxy.invokeMethod("intInIntOut", 2, int.class).block();
 
     Assert.assertEquals(4, response);
   }

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorNoStateTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorNoStateTest.java
@@ -139,7 +139,7 @@ public class ActorNoStateTest {
 
     Assert.assertEquals(
             proxy.getActorId().toString(),
-            proxy.invoke("getMyId", String.class).block());
+            proxy.invokeMethod("getMyId", String.class).block());
   }
 
   @Test
@@ -149,7 +149,7 @@ public class ActorNoStateTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       "abcabc",
-      proxy.invoke("stringInStringOut", "abc", String.class).block());
+      proxy.invokeMethod("stringInStringOut", "abc", String.class).block());
   }
 
   @Test
@@ -159,11 +159,11 @@ public class ActorNoStateTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       false,
-      proxy.invoke("stringInBooleanOut", "hello world", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "hello world", Boolean.class).block());
 
     Assert.assertEquals(
       true,
-      proxy.invoke("stringInBooleanOut", "true", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "true", Boolean.class).block());
   }
 
   @Test(expected = IllegalMonitorStateException.class)
@@ -171,7 +171,7 @@ public class ActorNoStateTest {
     ActorProxy actorProxy = createActorProxy();
 
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
-    actorProxy.invoke("stringInVoidOutIntentionallyThrows", "hello world").block();
+    actorProxy.invokeMethod("stringInVoidOutIntentionallyThrows", "hello world").block();
   }
 
   @Test
@@ -180,7 +180,7 @@ public class ActorNoStateTest {
     MyData d = new MyData("hi", 3);
 
     // this should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
-    MyData response = actorProxy.invoke("classInClassOut", d, MyData.class).block();
+    MyData response = actorProxy.invokeMethod("classInClassOut", d, MyData.class).block();
 
     Assert.assertEquals(
       "hihi",

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
@@ -289,33 +289,33 @@ public class ActorStatefulTest {
   public void happyGetSetDeleteContains() {
     ActorProxy proxy = newActorProxy();
     Assert.assertEquals(
-      proxy.getActorId().toString(), proxy.invoke("getIdString", String.class).block());
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+      proxy.getActorId().toString(), proxy.invokeMethod("getIdString", String.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
-    proxy.invoke("setMessage", "hello world").block();
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    proxy.invokeMethod("setMessage", "hello world").block();
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     Assert.assertEquals(
-      "hello world", proxy.invoke("getMessage", String.class).block());
+      "hello world", proxy.invokeMethod("getMessage", String.class).block());
 
     Assert.assertEquals(
       executeSayMethod("hello world"),
-      proxy.invoke("setMessage", "hello world", String.class).block());
+      proxy.invokeMethod("setMessage", "hello world", String.class).block());
 
-    proxy.invoke("deleteMessage").block();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    proxy.invokeMethod("deleteMessage").block();
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test(expected = IllegalStateException.class)
   public void lazyGet() {
     ActorProxy proxy = newActorProxy();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
-    proxy.invoke("setMessage", "first message").block();
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
+    proxy.invokeMethod("setMessage", "first message").block();
 
     // Creates the mono plan but does not call it yet.
-    Mono<String> getMessageCall = proxy.invoke("getMessage", String.class);
+    Mono<String> getMessageCall = proxy.invokeMethod("getMessage", String.class);
 
-    proxy.invoke("deleteMessage").block();
+    proxy.invokeMethod("deleteMessage").block();
 
     // Call should fail because the message was deleted.
     getMessageCall.block();
@@ -324,96 +324,96 @@ public class ActorStatefulTest {
   @Test
   public void lazySet() {
     ActorProxy proxy = newActorProxy();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Creates the mono plan but does not call it yet.
-    Mono<Void> setMessageCall = proxy.invoke("setMessage", "first message");
+    Mono<Void> setMessageCall = proxy.invokeMethod("setMessage", "first message");
 
     // No call executed yet, so message should not be set.
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     setMessageCall.block();
 
     // Now the message has been set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test
   public void lazyContains() {
     ActorProxy proxy = newActorProxy();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Creates the mono plan but does not call it yet.
-    Mono<Boolean> hasMessageCall = proxy.invoke("hasMessage", Boolean.class);
+    Mono<Boolean> hasMessageCall = proxy.invokeMethod("hasMessage", Boolean.class);
 
     // Sets the message.
-    proxy.invoke("setMessage", "hello world").block();
+    proxy.invokeMethod("setMessage", "hello world").block();
 
     // Now we check if message is set.
     hasMessageCall.block();
 
     // Now the message should be set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test
   public void lazyDelete() {
     ActorProxy proxy = newActorProxy();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
-    proxy.invoke("setMessage", "first message").block();
+    proxy.invokeMethod("setMessage", "first message").block();
 
     // Message is set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Created the mono plan but does not execute it yet.
-    Mono<Void> deleteMessageCall = proxy.invoke("deleteMessage");
+    Mono<Void> deleteMessageCall = proxy.invokeMethod("deleteMessage");
 
     // Message is still set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     deleteMessageCall.block();
 
     // Now message is not set.
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test
   public void lazyAdd() {
     ActorProxy proxy = newActorProxy();
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
-    proxy.invoke("setMessage", "first message").block();
+    proxy.invokeMethod("setMessage", "first message").block();
 
     // Message is set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Created the mono plan but does not execute it yet.
-    Mono<Void> addMessageCall = proxy.invoke("addMessage", "second message");
+    Mono<Void> addMessageCall = proxy.invokeMethod("addMessage", "second message");
 
     // Message is still set.
     Assert.assertEquals("first message",
-      proxy.invoke("getMessage", String.class).block());
+      proxy.invokeMethod("getMessage", String.class).block());
 
     // Delete message
-    proxy.invoke("deleteMessage").block();
+    proxy.invokeMethod("deleteMessage").block();
 
     // Should work since previous message was deleted.
     addMessageCall.block();
 
     // New message is still set.
     Assert.assertEquals("second message",
-      proxy.invoke("getMessage", String.class).block());
+      proxy.invokeMethod("getMessage", String.class).block());
   }
 
   @Test
   public void onActivateAndOnDeactivate() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertTrue(proxy.invoke("isActive", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("isActive", Boolean.class).block());
     Assert.assertFalse(DEACTIVATED_ACTOR_IDS.contains(proxy.getActorId().toString()));
 
-    proxy.invoke("hasMessage", Boolean.class).block();
+    proxy.invokeMethod("hasMessage", Boolean.class).block();
 
     this.manager.deactivateActor(proxy.getActorId()).block();
 
@@ -424,15 +424,15 @@ public class ActorStatefulTest {
   public void onPreMethodAndOnPostMethod() {
     ActorProxy proxy = newActorProxy();
 
-    proxy.invoke("hasMessage", Boolean.class).block();
+    proxy.invokeMethod("hasMessage", Boolean.class).block();
 
     MyMethodContext preContext =
-      proxy.invoke("getPreCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPreCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("hasMessage", preContext.getName());
     Assert.assertEquals(ActorCallType.ACTOR_INTERFACE_METHOD.toString(), preContext.getType());
 
     MyMethodContext postContext =
-      proxy.invoke("getPostCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPostCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("hasMessage", postContext.getName());
     Assert.assertEquals(ActorCallType.ACTOR_INTERFACE_METHOD.toString(), postContext.getType());
   }
@@ -444,12 +444,12 @@ public class ActorStatefulTest {
     this.manager.invokeTimer(proxy.getActorId(), "mytimer", "{ \"callback\": \"hasMessage\" }".getBytes()).block();
 
     MyMethodContext preContext =
-      proxy.invoke("getPreCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPreCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("mytimer", preContext.getName());
     Assert.assertEquals(ActorCallType.TIMER_METHOD.toString(), preContext.getType());
 
     MyMethodContext postContext =
-      proxy.invoke("getPostCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPostCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("mytimer", postContext.getName());
     Assert.assertEquals(ActorCallType.TIMER_METHOD.toString(), postContext.getType());
   }
@@ -467,7 +467,7 @@ public class ActorStatefulTest {
   public void invokeTimerAfterUnregister() {
     ActorProxy proxy = newActorProxy();
 
-    proxy.invoke("unregisterTimerAndReminder").block();
+    proxy.invokeMethod("unregisterTimerAndReminder").block();
 
     // This call succeeds because the SDK does not control register/unregister timer, the Dapr runtime does.
     this.manager.invokeTimer(proxy.getActorId(), "mytimer", "{ \"callback\": \"hasMessage\" }".getBytes()).block();
@@ -490,12 +490,12 @@ public class ActorStatefulTest {
     this.manager.invokeReminder(proxy.getActorId(), "myreminder", params).block();
 
     MyMethodContext preContext =
-      proxy.invoke("getPreCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPreCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("myreminder", preContext.getName());
     Assert.assertEquals(ActorCallType.REMINDER_METHOD.toString(), preContext.getType());
 
     MyMethodContext postContext =
-      proxy.invoke("getPostCallMethodContext", MyMethodContext.class).block();
+      proxy.invokeMethod("getPostCallMethodContext", MyMethodContext.class).block();
     Assert.assertEquals("myreminder", postContext.getName());
     Assert.assertEquals(ActorCallType.REMINDER_METHOD.toString(), postContext.getType());
   }
@@ -517,8 +517,8 @@ public class ActorStatefulTest {
 
     MyMethodContext expectedContext = new MyMethodContext().setName("MyName").setType("MyType");
 
-    proxy.invoke("setMethodContext", expectedContext).block();
-    MyMethodContext context = proxy.invoke("getMethodContext", MyMethodContext.class).block();
+    proxy.invokeMethod("setMethodContext", expectedContext).block();
+    MyMethodContext context = proxy.invokeMethod("getMethodContext", MyMethodContext.class).block();
 
     Assert.assertEquals(expectedContext.getName(), context.getName());
     Assert.assertEquals(expectedContext.getType(), context.getType());
@@ -528,8 +528,8 @@ public class ActorStatefulTest {
   public void intTypeRequestResponseInStateStore() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertEquals(1, (int)proxy.invoke("incrementAndGetCount", 1, int.class).block());
-    Assert.assertEquals(6, (int)proxy.invoke("incrementAndGetCount", 5, int.class).block());
+    Assert.assertEquals(1, (int)proxy.invokeMethod("incrementAndGetCount", 1, int.class).block());
+    Assert.assertEquals(6, (int)proxy.invokeMethod("incrementAndGetCount", 5, int.class).block());
   }
 
   @Test(expected = NumberFormatException.class)
@@ -537,68 +537,68 @@ public class ActorStatefulTest {
     ActorProxy proxy = newActorProxy();
 
     // Zero is a magic input that will make method throw an exception.
-    proxy.invoke("incrementAndGetCount", 0, int.class).block();
+    proxy.invokeMethod("incrementAndGetCount", 0, int.class).block();
   }
 
   @Test(expected = IllegalStateException.class)
   public void intTypeWithRuntimeException() {
     ActorProxy proxy = newActorProxy();
 
-    proxy.invoke("getCountButThrowsException", int.class).block();
+    proxy.invokeMethod("getCountButThrowsException", int.class).block();
   }
 
   @Test(expected = IllegalStateException.class)
   public void actorRuntimeException() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
-    proxy.invoke("forceDuplicateException").block();
+    proxy.invokeMethod("forceDuplicateException").block();
   }
 
   @Test(expected = IllegalCharsetNameException.class)
   public void actorMethodException() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
-    proxy.invoke("throwsWithoutSaving").block();
+    proxy.invokeMethod("throwsWithoutSaving").block();
 
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test
   public void rollbackChanges() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Runs a method that will add one message but fail because tries to add a second one.
-    proxy.invoke("forceDuplicateException")
+    proxy.invokeMethod("forceDuplicateException")
       .onErrorResume(throwable -> Mono.empty())
       .block();
 
     // No message is set
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
   }
 
   @Test
   public void partialChanges() {
     ActorProxy proxy = newActorProxy();
 
-    Assert.assertFalse(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertFalse(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // Runs a method that will add one message, commit but fail because tries to add a second one.
-    proxy.invoke("forcePartialChange")
+    proxy.invokeMethod("forcePartialChange")
       .onErrorResume(throwable -> Mono.empty())
       .block();
 
     // Message is set.
-    Assert.assertTrue(proxy.invoke("hasMessage", Boolean.class).block());
+    Assert.assertTrue(proxy.invokeMethod("hasMessage", Boolean.class).block());
 
     // It is first message and not the second due to a save() in the middle but an exception in the end.
     Assert.assertEquals("first message",
-      proxy.invoke("getMessage", String.class).block());
+      proxy.invokeMethod("getMessage", String.class).block());
   }
 
   private ActorProxy newActorProxy() {

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DerivedActorTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DerivedActorTest.java
@@ -223,7 +223,7 @@ public class DerivedActorTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       "abcabc",
-      proxy.invoke("stringInStringOut", "abc", String.class).block());
+      proxy.invokeMethod("stringInStringOut", "abc", String.class).block());
   }
 
   @Test
@@ -233,11 +233,11 @@ public class DerivedActorTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       false,
-      proxy.invoke("stringInBooleanOut", "hello world", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "hello world", Boolean.class).block());
 
     Assert.assertEquals(
       true,
-      proxy.invoke("stringInBooleanOut", "true", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "true", Boolean.class).block());
   }
 
   @Test
@@ -247,14 +247,14 @@ public class DerivedActorTest {
     // stringInVoidOut() has not been invoked so this is false
     Assert.assertEquals(
       false,
-      actorProxy.invoke("methodReturningVoidInvoked", Boolean.class).block());
+      actorProxy.invokeMethod("methodReturningVoidInvoked", Boolean.class).block());
 
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
-    actorProxy.invoke("stringInVoidOut", "hello world").block();
+    actorProxy.invokeMethod("stringInVoidOut", "hello world").block();
 
     Assert.assertEquals(
       true,
-      actorProxy.invoke("methodReturningVoidInvoked", Boolean.class).block());
+      actorProxy.invokeMethod("methodReturningVoidInvoked", Boolean.class).block());
   }
 
   @Test(expected = IllegalMonitorStateException.class)
@@ -262,7 +262,7 @@ public class DerivedActorTest {
     ActorProxy actorProxy = createActorProxyForActorChild();
 
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
-    actorProxy.invoke("stringInVoidOutIntentionallyThrows", "hello world").block();
+    actorProxy.invokeMethod("stringInVoidOutIntentionallyThrows", "hello world").block();
   }
 
   @Test
@@ -271,7 +271,7 @@ public class DerivedActorTest {
     MyData d = new MyData("hi", 3);
 
     // this should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
-    MyData response = actorProxy.invoke("classInClassOut", d, MyData.class).block();
+    MyData response = actorProxy.invokeMethod("classInClassOut", d, MyData.class).block();
 
     Assert.assertEquals(
       "hihi",
@@ -288,26 +288,26 @@ public class DerivedActorTest {
 
     Assert.assertEquals(
       "www",
-      actorProxy.invoke("onlyImplementedInParentStringInStringOut", "w", String.class).block());
+      actorProxy.invokeMethod("onlyImplementedInParentStringInStringOut", "w", String.class).block());
 
     Assert.assertEquals(
       true,
-      actorProxy.invoke("onlyImplementedInParentStringInBooleanOut", "icecream", Boolean.class).block());
+      actorProxy.invokeMethod("onlyImplementedInParentStringInBooleanOut", "icecream", Boolean.class).block());
 
     // onlyImplementedInParentStringInVoidOut() has not been invoked so this is false
     Assert.assertEquals(
       false,
-      actorProxy.invoke("methodReturningVoidInvoked", Boolean.class).block());
+      actorProxy.invokeMethod("methodReturningVoidInvoked", Boolean.class).block());
 
-    actorProxy.invoke("onlyImplementedInParentStringInVoidOut", "icecream", Boolean.class).block();
+    actorProxy.invokeMethod("onlyImplementedInParentStringInVoidOut", "icecream", Boolean.class).block();
 
     // now it should return true.
     Assert.assertEquals(
       true,
-      actorProxy.invoke("methodReturningVoidInvoked", Boolean.class).block());
+      actorProxy.invokeMethod("methodReturningVoidInvoked", Boolean.class).block());
 
     MyData d = new MyData("hi", 3);
-    MyData response = actorProxy.invoke("onlyImplementedInParentClassInClassOut", d, MyData.class).block();
+    MyData response = actorProxy.invokeMethod("onlyImplementedInParentClassInClassOut", d, MyData.class).block();
 
     Assert.assertEquals(
       "hihihi",

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ThrowFromPreAndPostActorMethodsTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ThrowFromPreAndPostActorMethodsTest.java
@@ -121,7 +121,7 @@ public class ThrowFromPreAndPostActorMethodsTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       false,
-      proxy.invoke("stringInBooleanOut", "hello world", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "hello world", Boolean.class).block());
   }
 
   // IllegalMonitorStateException should be intentionally thrown.  This type was chosen for this test just because
@@ -133,7 +133,7 @@ public class ThrowFromPreAndPostActorMethodsTest {
     // these should only call the actor methods for ActorChild.  The implementations in ActorParent will throw.
     Assert.assertEquals(
       true,
-      proxy.invoke("stringInBooleanOut", "true", Boolean.class).block());
+      proxy.invokeMethod("stringInBooleanOut", "true", Boolean.class).block());
   }
 
   private static ActorId newActorId() {


### PR DESCRIPTION
# Description

Rename ActorProxy invoke to invokeMethod.

## Issue reference

refs:https://github.com/dapr/java-sdk/issues/418

Please reference the issue this PR will close: #_[418]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ x] Code compiles correctly
* [ x] Created/updated tests
* [ ] Extended the documentation
