### PR TITLE
Throws IllegalArgumentException without wrapping as DaprException.

### DIFF
--- a/examples/src/main/java/io/dapr/examples/exception/README.md
+++ b/examples/src/main/java/io/dapr/examples/exception/README.md
@@ -53,7 +53,7 @@ public class Client {
 
 }
 ```
-The code uses the `DaprClient` created by the `DaprClientBuilder`. It tries to get a state from state store but provides an unknown state store. It causes Dapr sidecar to return error, which is converted to a `DaprException` to the application. To be compatible with Project Reactor, `DaprException` extends from `RuntimeException` - making it an unchecked exception.
+The code uses the `DaprClient` created by the `DaprClientBuilder`. It tries to get a state from state store but provides an unknown state store. It causes Dapr sidecar to return error, which is converted to a `DaprException` to the application. To be compatible with Project Reactor, `DaprException` extends from `RuntimeException` - making it an unchecked exception. Applications might also get `IllegalArgumentException` when invoking methods with invalid input parameters that are validated at the client side.
 
 The Dapr client is also within a try-with-resource block to properly close the client at the end.
 

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
@@ -18,8 +18,6 @@ import io.grpc.ManagedChannelBuilder;
 import java.io.Closeable;
 import java.lang.reflect.Proxy;
 
-import static io.dapr.exceptions.DaprException.throwIllegalArgumentException;
-
 /**
  * Builder to generate an ActorProxy instance. Builder can be reused for multiple instances.
  */
@@ -76,10 +74,10 @@ public class ActorProxyBuilder<T> implements Closeable {
    */
   public ActorProxyBuilder(String actorType, Class<T> actorTypeClass) {
     if ((actorType == null) || actorType.isEmpty()) {
-      throwIllegalArgumentException("ActorType is required.");
+      throw new IllegalArgumentException("ActorType is required.");
     }
     if (actorTypeClass == null) {
-      throwIllegalArgumentException("ActorTypeClass is required.");
+      throw new IllegalArgumentException("ActorTypeClass is required.");
     }
 
     this.useGrpc = Properties.USE_GRPC.get();
@@ -98,7 +96,7 @@ public class ActorProxyBuilder<T> implements Closeable {
    */
   public ActorProxyBuilder<T> withObjectSerializer(DaprObjectSerializer objectSerializer) {
     if (objectSerializer == null) {
-      throwIllegalArgumentException("Serializer is required.");
+      throw new IllegalArgumentException("Serializer is required.");
     }
 
     this.objectSerializer = objectSerializer;
@@ -113,7 +111,7 @@ public class ActorProxyBuilder<T> implements Closeable {
    */
   public T build(ActorId actorId) {
     if (actorId == null) {
-      throwIllegalArgumentException("Cannot instantiate an Actor without Id.");
+      throw new IllegalArgumentException("Cannot instantiate an Actor without Id.");
     }
 
     ActorProxyImpl proxy = new ActorProxyImpl(
@@ -169,7 +167,7 @@ public class ActorProxyBuilder<T> implements Closeable {
 
     int port = Properties.GRPC_PORT.get();
     if (port <= 0) {
-      throwIllegalArgumentException("Invalid port.");
+      throw new IllegalArgumentException("Invalid port.");
     }
 
     return ManagedChannelBuilder.forAddress(Properties.SIDECAR_IP.get(), port).usePlaintext().build();

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
@@ -7,34 +7,33 @@ package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
-import io.dapr.exceptions.DaprException;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class ActorProxyBuilderTest {
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorId() {
     new ActorProxyBuilder("test", Object.class)
         .build(null);
 
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void buildWithEmptyActorType() {
     new ActorProxyBuilder("", Object.class)
         .build(new ActorId("100"));
 
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorType() {
     new ActorProxyBuilder(null, Object.class)
       .build(new ActorId("100"));
 
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void buildWithNullSerializer() {
     new ActorProxyBuilder("MyActor", Object.class)
       .withObjectSerializer(null)

--- a/sdk/src/main/java/io/dapr/client/DaprClientBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientBuilder.java
@@ -14,8 +14,6 @@ import io.grpc.ManagedChannelBuilder;
 
 import java.io.Closeable;
 
-import static io.dapr.exceptions.DaprException.throwIllegalArgumentException;
-
 /**
  * A builder for the DaprClient,
  * Currently only and HTTP Client will be supported.
@@ -65,11 +63,11 @@ public class DaprClientBuilder {
    */
   public DaprClientBuilder withObjectSerializer(DaprObjectSerializer objectSerializer) {
     if (objectSerializer == null) {
-      throwIllegalArgumentException("Object serializer is required");
+      throw new IllegalArgumentException("Object serializer is required");
     }
 
     if (objectSerializer.getContentType() == null || objectSerializer.getContentType().isEmpty()) {
-      throwIllegalArgumentException("Content Type should not be null or empty");
+      throw new IllegalArgumentException("Content Type should not be null or empty");
     }
 
     this.objectSerializer = objectSerializer;
@@ -85,7 +83,7 @@ public class DaprClientBuilder {
    */
   public DaprClientBuilder withStateSerializer(DaprObjectSerializer stateSerializer) {
     if (stateSerializer == null) {
-      throwIllegalArgumentException("State serializer is required");
+      throw new IllegalArgumentException("State serializer is required");
     }
 
     this.stateSerializer = stateSerializer;
@@ -115,7 +113,7 @@ public class DaprClientBuilder {
   private DaprClient buildDaprClientGrpc() {
     int port = Properties.GRPC_PORT.get();
     if (port <= 0) {
-      throwIllegalArgumentException("Invalid port.");
+      throw new IllegalArgumentException("Invalid port.");
     }
     ManagedChannel channel = ManagedChannelBuilder.forAddress(
         Properties.SIDECAR_IP.get(), port).usePlaintext().build();

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -596,10 +596,6 @@ public class DaprClientHttp extends AbstractDaprClient {
 
   @Override
   public void close() {
-    try {
-      client.close();
-    } catch (Exception e) {
-      DaprException.wrap(e);
-    }
+    client.close();
   }
 }

--- a/sdk/src/main/java/io/dapr/exceptions/DaprException.java
+++ b/sdk/src/main/java/io/dapr/exceptions/DaprException.java
@@ -8,9 +8,7 @@ package io.dapr.exceptions;
 import io.grpc.StatusRuntimeException;
 import reactor.core.publisher.Mono;
 
-import java.lang.reflect.Executable;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 /**
  * A Dapr's specific exception.
@@ -86,26 +84,13 @@ public class DaprException extends RuntimeException {
   }
 
   /**
-   * Convenience to throw an wrapped IllegalArgumentException.
-   * @param message Message for exception.
-   */
-  public static void throwIllegalArgumentException(String message) {
-    try {
-      throw new IllegalArgumentException(message);
-    } catch (Exception e) {
-      wrap(e);
-    }
-  }
-
-  /**
    * Wraps an exception into DaprException (if not already DaprException).
    *
    * @param exception Exception to be wrapped.
-   * @return DaprException.
    */
-  public static DaprException wrap(Exception exception) {
+  public static void wrap(Exception exception) {
     if (exception == null) {
-      return null;
+      return;
     }
 
     if (exception instanceof DaprException) {
@@ -125,6 +110,10 @@ public class DaprException extends RuntimeException {
       e = e.getCause();
     }
 
+    if (exception instanceof IllegalArgumentException) {
+      throw (IllegalArgumentException) exception;
+    }
+
     throw new DaprException(exception);
   }
 
@@ -139,7 +128,8 @@ public class DaprException extends RuntimeException {
       try {
         return callable.call();
       } catch (Exception e) {
-        return (T) wrap(e);
+        wrap(e);
+        return null;
       }
     };
   }

--- a/sdk/src/test/java/io/dapr/client/DaprClientBuilderTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientBuilderTest.java
@@ -5,7 +5,6 @@
 
 package io.dapr.client;
 
-import io.dapr.exceptions.DaprException;
 import io.dapr.serializer.DaprObjectSerializer;
 import org.junit.Test;
 
@@ -27,17 +26,17 @@ public class DaprClientBuilderTest {
     assertNotNull(daprClient);
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void noObjectSerializer() {
     new DaprClientBuilder().withObjectSerializer(null);
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void blankContentTypeInObjectSerializer() {
     new DaprClientBuilder().withObjectSerializer(mock(DaprObjectSerializer.class));
   }
 
-  @Test(expected = DaprException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void noStateSerializer() {
     new DaprClientBuilder().withStateSerializer(null);
   }

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -51,12 +51,7 @@ import java.util.concurrent.ExecutionException;
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.dapr.utils.TestUtils.assertThrowsDaprException;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doNothing;
@@ -185,19 +180,19 @@ public class DaprClientGrpcTest {
 
   @Test
   public void invokeBindingIllegalArgumentExceptionTest() {
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty binding name
       adapter.invokeBinding("", "MyOperation", "request".getBytes(), Collections.EMPTY_MAP).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null binding name
       adapter.invokeBinding(null, "MyOperation", "request".getBytes(), Collections.EMPTY_MAP).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null binding operation
       adapter.invokeBinding("BindingName", null, "request".getBytes(), Collections.EMPTY_MAP).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty binding operation
       adapter.invokeBinding("BindingName", "", "request".getBytes(), Collections.EMPTY_MAP).block();
     });
@@ -367,11 +362,7 @@ public class DaprClientGrpcTest {
     // HttpExtension cannot be null
     Mono<Void> result = adapter.invokeMethod("appId", "method", "request", null);
 
-    assertThrowsDaprException(
-        IllegalArgumentException.class,
-        "UNKNOWN",
-        "UNKNOWN: HttpExtension cannot be null. Use HttpExtension.NONE instead.",
-        () -> result.block());
+    assertThrows(IllegalArgumentException.class, () -> result.block());
   }
 
   @Test
@@ -772,19 +763,19 @@ public class DaprClientGrpcTest {
   @Test
   public void getStateIllegalArgumentExceptionTest() {
     State<String> key = buildStateKey(null, "Key1", "ETag1", null);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.getState("", key, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.getState(null, key, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null key
       adapter.getState(STATE_STORE_NAME, (String)null, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty key
       adapter.getState(STATE_STORE_NAME, "", String.class).block();
     });
@@ -941,20 +932,20 @@ public class DaprClientGrpcTest {
   @Test
   public void getStatesIllegalArgumentExceptionTest() {
     State<String> key = buildStateKey(null, "Key1", "ETag1", null);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.getBulkState("", Collections.singletonList("100"), String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.getBulkState(null, Collections.singletonList("100"), String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null key
       // null pointer exception due to keys being converted to an unmodifiable list
       adapter.getBulkState(STATE_STORE_NAME, null, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty key list
       adapter.getBulkState(STATE_STORE_NAME, Collections.emptyList(), String.class).block();
     });
@@ -962,7 +953,7 @@ public class DaprClientGrpcTest {
     GetBulkStateRequest req = new GetBulkStateRequestBuilder(STATE_STORE_NAME, Collections.singletonList("100"))
         .withParallelism(-1)
         .build();
-    assertThrowsDaprException(IllegalArgumentException.class, () -> adapter.getBulkState(req, TypeRef.BOOLEAN).block());
+    assertThrows(IllegalArgumentException.class, () -> adapter.getBulkState(req, TypeRef.BOOLEAN).block());
   }
 
   @Test
@@ -1157,19 +1148,19 @@ public class DaprClientGrpcTest {
   @Test
   public void deleteStateIllegalArgumentExceptionTest() {
     State<String> key = buildStateKey(null, "Key1", "ETag1", null);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.deleteState("", key.getKey(), "etag", null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.deleteState(null, key.getKey(), "etag", null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.deleteState(STATE_STORE_NAME, null, "etag", null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.deleteState(STATE_STORE_NAME, "", "etag", null).block();
     });
@@ -1312,11 +1303,11 @@ public class DaprClientGrpcTest {
     TransactionalStateOperation<String> upsertOperation = new TransactionalStateOperation<>(
         TransactionalStateOperation.OperationType.UPSERT,
         key);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.executeStateTransaction("", Collections.singletonList(upsertOperation)).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null state store name
       adapter.executeStateTransaction(null, Collections.singletonList(upsertOperation)).block();
     });
@@ -1454,11 +1445,11 @@ public class DaprClientGrpcTest {
 
   @Test
   public void saveStatesIllegalArgumentExceptionTest() {
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.saveBulkState("", Collections.emptyList()).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty state store name
       adapter.saveBulkState(null, Collections.emptyList()).block();
     });
@@ -1781,19 +1772,19 @@ public class DaprClientGrpcTest {
 
   @Test
   public void getSecretsIllegalArgumentException() {
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty secret store name
       adapter.getSecret("", "key").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null secret store name
       adapter.getSecret(null, "key").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty key
       adapter.getSecret(SECRET_STORE_NAME, "").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null key
       adapter.getSecret(SECRET_STORE_NAME, null).block();
     });

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -93,9 +94,9 @@ public class DaprClientHttpTest {
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.publishEvent("mypubsubname", null, event).block());
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.publishEvent("mypubsubname", "", event).block());
   }
 
@@ -119,7 +120,7 @@ public class DaprClientHttpTest {
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.invokeMethod(null, "", "", null, null, (Class)null).block());
   }
 
@@ -130,27 +131,27 @@ public class DaprClientHttpTest {
         .respond("INVALID JSON");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null HttpMethod
       daprClientHttp.invokeMethod("1", "2", "3", new HttpExtension(null, null), null, (Class)null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null HttpExtension
       daprClientHttp.invokeMethod("1", "2", "3", null, null, (Class)null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty appId
       daprClientHttp.invokeMethod("", "1", null, HttpExtension.GET, null, (Class)null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null appId, empty method
       daprClientHttp.invokeMethod(null, "", null, HttpExtension.POST, null, (Class)null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // empty method
       daprClientHttp.invokeMethod("1", "", null, HttpExtension.PUT, null, (Class)null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       // null method
       daprClientHttp.invokeMethod("1", null, null, HttpExtension.DELETE, null, (Class)null).block();
     });
@@ -169,7 +170,7 @@ public class DaprClientHttpTest {
     String event = "{ \"message\": \"This is a test\" }";
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.invokeMethod("1", "", null, HttpExtension.POST, null, (Class)null).block());
   }
 
@@ -301,16 +302,16 @@ public class DaprClientHttpTest {
         .respond("NOT VALID JSON");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.invokeBinding(null, "myoperation", "").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.invokeBinding("", "myoperation", "").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.invokeBinding("topic", null, "").block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.invokeBinding("topic", "", "").block();
     });
     assertThrowsDaprException(JsonParseException.class, () -> {
@@ -422,7 +423,7 @@ public class DaprClientHttpTest {
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.invokeBinding(null, "myoperation", "").block());
   }
 
@@ -434,7 +435,7 @@ public class DaprClientHttpTest {
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.invokeBinding("sample-topic", null, "").block());
   }
 
@@ -457,19 +458,19 @@ public class DaprClientHttpTest {
         .respond("NOT VALID JSON");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getBulkState(STATE_STORE_NAME, null, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getBulkState(STATE_STORE_NAME, new ArrayList<>(), String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getBulkState(null, Arrays.asList("100", "200"), String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getBulkState("", Arrays.asList("100", "200"), String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getBulkState(
           new GetBulkStateRequestBuilder(STATE_STORE_NAME, "100").withParallelism(-1).build(),
           TypeRef.get(String.class)).block();
@@ -611,16 +612,16 @@ public class DaprClientHttpTest {
         .respond("NOT VALID");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getState(STATE_STORE_NAME, stateKeyNull, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getState(STATE_STORE_NAME, stateKeyEmpty, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getState(null, stateKeyValue, String.class).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getState("", stateKeyValue, String.class).block();
     });
     assertThrowsDaprException(JsonParseException.class, () -> {
@@ -702,9 +703,9 @@ public class DaprClientHttpTest {
   public void saveStatesErrors() {
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.saveBulkState(null, null).block());
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.saveBulkState("", null).block());
   }
 
@@ -888,9 +889,9 @@ public class DaprClientHttpTest {
   public void executeTransactionErrors() {
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.executeStateTransaction(null,  null).block());
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.executeStateTransaction("",  null).block());
   }
 
@@ -983,22 +984,22 @@ public class DaprClientHttpTest {
       .respond(EXPECTED_RESULT);
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState(STATE_STORE_NAME, null, null, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState(STATE_STORE_NAME, "", null, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState(STATE_STORE_NAME, " ", null, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState(null, "key", null, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState("", "key", null, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.deleteState(" ", "key", null, null).block();
     });
   }
@@ -1010,7 +1011,7 @@ public class DaprClientHttpTest {
       .respond("{ \"mysecretkey\": \"mysecretvalue\"}");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getSecret(SECRET_STORE_NAME, null).block();
     });
     Map<String, String> secret = daprClientHttp.getSecret(SECRET_STORE_NAME, "key").block();
@@ -1026,7 +1027,7 @@ public class DaprClientHttpTest {
       .respond("");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getSecret(SECRET_STORE_NAME, null).block();
     });
     Map<String, String> secret = daprClientHttp.getSecret(SECRET_STORE_NAME, "key").block();
@@ -1068,14 +1069,14 @@ public class DaprClientHttpTest {
         .respond("INVALID JSON");
     daprHttp = new DaprHttp(Properties.SIDECAR_IP.get(), 3000, okHttpClient);
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.getSecret(null, "key").block());
-    assertThrowsDaprException(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         daprClientHttp.getSecret("", "key").block());
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getSecret(SECRET_STORE_NAME, null).block();
     });
-    assertThrowsDaprException(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       daprClientHttp.getSecret(SECRET_STORE_NAME, "").block();
     });
     assertThrowsDaprException(JsonParseException.class, () -> {
@@ -1117,11 +1118,11 @@ public class DaprClientHttpTest {
   @Test
   public void closeException() {
     DaprHttp daprHttp = Mockito.mock(DaprHttp.class);
-    Mockito.doThrow(new IllegalStateException()).when(daprHttp).close();
+    Mockito.doThrow(new RuntimeException()).when(daprHttp).close();
 
-    // This method does not throw DaprException because IOException is expected by the Closeable interface.
+    // This method does not throw DaprException because it already throws RuntimeException and does not call Dapr.
     daprClientHttp = new DaprClientHttp(daprHttp);
-    assertThrowsDaprException(IllegalStateException.class, () -> daprClientHttp.close());
+    assertThrows(RuntimeException.class, () -> daprClientHttp.close());
   }
 
   @Test


### PR DESCRIPTION
# Description

Throws IllegalArgumentException without wrapping as DaprException.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #424 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
