### PR TITLE
Add java.lang.reflect.Type to TypeRef per #331

### DIFF
--- a/sdk/src/main/java/io/dapr/utils/TypeRef.java
+++ b/sdk/src/main/java/io/dapr/utils/TypeRef.java
@@ -130,6 +130,7 @@ public abstract class TypeRef<T> {
       Class clazz = (Class) type;
       return get(clazz);
     }
+    
     return new TypeRef<T>(type) {};
   }
 }

--- a/sdk/src/main/java/io/dapr/utils/TypeRef.java
+++ b/sdk/src/main/java/io/dapr/utils/TypeRef.java
@@ -57,10 +57,10 @@ public abstract class TypeRef<T> {
   /**
    * Constructor for reflection.
    *
-   * @param clazz Class type to be referenced.
+   * @param type Type to be referenced.
    */
-  private TypeRef(Class<T> clazz) {
-    this.type = clazz;
+  private TypeRef(Type type) {
+    this.type = type;
   }
 
   /**
@@ -117,5 +117,19 @@ public abstract class TypeRef<T> {
     }
 
     return new TypeRef<T>(clazz) {};
+  }
+
+  /**
+   * Creates a reference to a given class type.
+   * @param type Type to be referenced.
+   * @param <T> Type to be referenced.
+   * @return Class type reference.
+   */
+  public static <T> TypeRef<T> get(Type type) {
+    if (type instanceof Class) {
+      Class clazz = (Class) type;
+      return get(clazz);
+    }
+    return new TypeRef<T>(type) {};
   }
 }

--- a/sdk/src/test/java/io/dapr/serializer/DefaultObjectSerializerTest.java
+++ b/sdk/src/test/java/io/dapr/serializer/DefaultObjectSerializerTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -230,6 +231,17 @@ public class DefaultObjectSerializerTest {
       serializedValue = SERIALIZER.serialize(obj);
       assertNotNull(serializedValue);
       MyObjectTestToSerialize deserializedValue = SERIALIZER.deserialize(serializedValue, MyObjectTestToSerialize.class);
+      assertEquals(obj, deserializedValue);
+    } catch (IOException exception) {
+      fail(exception.getMessage());
+    }
+
+    try {
+      serializedValue = SERIALIZER.serialize(obj);
+      assertNotNull(serializedValue);
+      Type t = MyObjectTestToSerialize.class;
+      TypeRef<MyObjectTestToSerialize> tr = TypeRef.get(t);
+      MyObjectTestToSerialize deserializedValue = SERIALIZER.deserialize(serializedValue, tr);
       assertEquals(obj, deserializedValue);
     } catch (IOException exception) {
       fail(exception.getMessage());

--- a/sdk/src/test/java/io/dapr/serializer/DefaultObjectSerializerTest.java
+++ b/sdk/src/test/java/io/dapr/serializer/DefaultObjectSerializerTest.java
@@ -437,6 +437,16 @@ public class DefaultObjectSerializerTest {
     } catch (IOException exception) {
       fail(exception.getMessage());
     }
+
+    try {
+      TypeRef<List<MyObjectTestToSerialize>> tr1 = new TypeRef<List<MyObjectTestToSerialize>>(){};
+      Type t = tr1.getType();
+      TypeRef<?> tr = TypeRef.get(t);
+      result = (List<MyObjectTestToSerialize>) SERIALIZER.deserialize(jsonToDeserialize.getBytes(), tr);
+      assertEquals("The expected value is different than the actual result", expectedResult, result.get(0));
+    } catch (IOException exception) {
+      fail(exception.getMessage());
+    }
   }
 
   @Test


### PR DESCRIPTION
Added `public static <T> TypeRef<T> get(Type type)` to `TypeRef`

Added bonus: Having the generic `<T>` seems to work even if it isn't passed in as an argument.

Resolves issue #331

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
