### PR TITLE
Use DaprChannel instead of closeable ActorProxyBuilder.

### DIFF
--- a/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
+++ b/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
@@ -6,8 +6,8 @@
 package io.dapr.examples.actors;
 
 import io.dapr.actors.ActorId;
+import io.dapr.actors.client.ActorClient;
 import io.dapr.actors.client.ActorProxyBuilder;
-import io.dapr.actors.client.DaprChannel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +31,8 @@ public class DemoActorClient {
    * @throws InterruptedException If program has been interrupted.
    */
   public static void main(String[] args) throws InterruptedException {
-    try (DaprChannel channel = new DaprChannel()) {
-      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, channel);
+    try (ActorClient client = new ActorClient()) {
+      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, client);
       List<Thread> threads = new ArrayList<>(NUM_ACTORS);
 
       // Creates multiple actors.

--- a/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
+++ b/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
@@ -7,6 +7,7 @@ package io.dapr.examples.actors;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxyBuilder;
+import io.dapr.actors.client.DaprChannel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,8 @@ public class DemoActorClient {
    * @throws InterruptedException If program has been interrupted.
    */
   public static void main(String[] args) throws InterruptedException {
-    try (ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class)) {
+    try (DaprChannel channel = new DaprChannel()) {
+      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, channel);
       List<Thread> threads = new ArrayList<>(NUM_ACTORS);
 
       // Creates multiple actors.

--- a/examples/src/main/java/io/dapr/examples/actors/README.md
+++ b/examples/src/main/java/io/dapr/examples/actors/README.md
@@ -149,8 +149,8 @@ public class DemoActorClient {
   private static final int NUM_ACTORS = 3;
 
   public static void main(String[] args) throws InterruptedException {
-    try (DaprChannel channel = new DaprChannel()) {
-      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, channel);
+    try (ActorClient client = new ActorClient()) {
+      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, client);
       ///...
       for (int i = 0; i < NUM_ACTORS; i++) {
         DemoActor actor = builder.build(ActorId.createRandom());
@@ -190,7 +190,7 @@ public class DemoActorClient {
 }
 ```
 
-First, the client defines how many actors it is going to create. The main method declares a `DaprChannel` and `ActorProxyBuilder` to create instances of the `DemoActor` interface, which are implemented automatically by the SDK and make remote calls to the equivalent methods in Actor runtime. `DaprChannel` is reusable for different actor types and should be instantiated only once in your code. `DaprChannel` also implements `AutoCloseable`, which means it holds resources that need to be closed. In this example, we use the "try-resource" feature in Java.
+First, the client defines how many actors it is going to create. The main method declares a `ActorClient` and `ActorProxyBuilder` to create instances of the `DemoActor` interface, which are implemented automatically by the SDK and make remote calls to the equivalent methods in Actor runtime. `ActorClient` is reusable for different actor types and should be instantiated only once in your code. `ActorClient` also implements `AutoCloseable`, which means it holds resources that need to be closed. In this example, we use the "try-resource" feature in Java.
 
 Then, the code executes the `callActorForever` private method once per actor. Initially, it will invoke `registerReminder()`, which sets the due time and period for the reminder. Then, `incrementAndGet()` increments a counter, persists it and sends it back as response. Finally `say` method which will print a message containing the received string along with the formatted server time. 
 

--- a/examples/src/main/java/io/dapr/examples/actors/README.md
+++ b/examples/src/main/java/io/dapr/examples/actors/README.md
@@ -149,7 +149,8 @@ public class DemoActorClient {
   private static final int NUM_ACTORS = 3;
 
   public static void main(String[] args) throws InterruptedException {
-    try (ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class)) {
+    try (DaprChannel channel = new DaprChannel()) {
+      ActorProxyBuilder<DemoActor> builder = new ActorProxyBuilder(DemoActor.class, channel);
       ///...
       for (int i = 0; i < NUM_ACTORS; i++) {
         DemoActor actor = builder.build(ActorId.createRandom());
@@ -189,7 +190,7 @@ public class DemoActorClient {
 }
 ```
 
-First, the client defines how many actors it is going to create. The main method declares a `ActorProxyBuilder` to create instances of the `DemoActor` interface, which are implemented automatically by the SDK and make remote calls to the equivalent methods in Actor runtime. `ActorProxyBuilder` implements `Closeable`, which means it holds resources that need to be closed. In this example, we use the "try-resource" feature in Java.
+First, the client defines how many actors it is going to create. The main method declares a `DaprChannel` and `ActorProxyBuilder` to create instances of the `DemoActor` interface, which are implemented automatically by the SDK and make remote calls to the equivalent methods in Actor runtime. `DaprChannel` is reusable for different actor types and should be instantiated only once in your code. `DaprChannel` also implements `AutoCloseable`, which means it holds resources that need to be closed. In this example, we use the "try-resource" feature in Java.
 
 Then, the code executes the `callActorForever` private method once per actor. Initially, it will invoke `registerReminder()`, which sets the due time and period for the reminder. Then, `incrementAndGet()` increments a counter, persists it and sends it back as response. Finally `say` method which will print a message containing the received string along with the formatted server time. 
 

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
@@ -17,7 +17,7 @@ import reactor.core.publisher.Mono;
 /**
  * Holds a client for Dapr sidecar communication. ActorClient should be reused.
  */
-public class ActorClient implements DaprClient, AutoCloseable {
+public class ActorClient implements AutoCloseable {
 
   /**
    * gRPC channel for communication with Dapr sidecar.
@@ -56,10 +56,15 @@ public class ActorClient implements DaprClient, AutoCloseable {
   }
 
   /**
-   * {@inheritDoc}
+   * Invokes an Actor method on Dapr.
+   *
+   * @param actorType   Type of actor.
+   * @param actorId     Actor Identifier.
+   * @param methodName  Method name to invoke.
+   * @param jsonPayload Serialized body.
+   * @return Asynchronous result with the Actor's response.
    */
-  @Override
-  public Mono<byte[]> invoke(String actorType, String actorId, String methodName, byte[] jsonPayload) {
+  Mono<byte[]> invoke(String actorType, String actorId, String methodName, byte[] jsonPayload) {
     return daprClient.invoke(actorType, actorId, methodName, jsonPayload);
   }
 

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
@@ -12,16 +12,12 @@ import io.dapr.v1.DaprGrpc;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import reactor.core.publisher.Mono;
 
 /**
- * Holds a channel for Dapr sidecar communication. Channel should be reused.
+ * Holds a client for Dapr sidecar communication. ActorClient should be reused.
  */
-public class DaprChannel implements AutoCloseable {
-
-  /**
-   * Determine if channel is for GRPC clients or HTTP clients.
-   */
-  private final DaprApiProtocol apiProtocol;
+public class ActorClient implements DaprClient, AutoCloseable {
 
   /**
    * gRPC channel for communication with Dapr sidecar.
@@ -36,7 +32,7 @@ public class DaprChannel implements AutoCloseable {
   /**
    * Instantiates a new channel for Dapr sidecar communication.
    */
-  public DaprChannel() {
+  public ActorClient() {
     this(Properties.API_PROTOCOL.get());
   }
 
@@ -45,8 +41,8 @@ public class DaprChannel implements AutoCloseable {
    *
    * @param apiProtocol    Dapr's API protocol.
    */
-  private DaprChannel(DaprApiProtocol apiProtocol) {
-    this(apiProtocol,  buildManagedChannel(apiProtocol));
+  private ActorClient(DaprApiProtocol apiProtocol) {
+    this(apiProtocol, buildManagedChannel(apiProtocol));
   }
 
   /**
@@ -54,19 +50,17 @@ public class DaprChannel implements AutoCloseable {
    *
    * @param apiProtocol    Dapr's API protocol.
    */
-  private DaprChannel(DaprApiProtocol apiProtocol, ManagedChannel grpcManagedChannel) {
-    this.apiProtocol = apiProtocol;
+  private ActorClient(DaprApiProtocol apiProtocol, ManagedChannel grpcManagedChannel) {
     this.grpcManagedChannel = grpcManagedChannel;
     this.daprClient = buildDaprClient(apiProtocol, grpcManagedChannel);
   }
 
   /**
-   * Gets the Dapr client.
-   *
-   * @return the Dapr client.
+   * {@inheritDoc}
    */
-  DaprClient getDaprClient() {
-    return this.daprClient;
+  @Override
+  public Mono<byte[]> invoke(String actorType, String actorId, String methodName, byte[] jsonPayload) {
+    return daprClient.invoke(actorType, actorId, methodName, jsonPayload);
   }
 
   /**

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
@@ -66,7 +66,7 @@ public class ActorProxyBuilder<T> {
       throw new IllegalArgumentException("ActorTypeClass is required.");
     }
     if (actorClient == null) {
-      throw new IllegalArgumentException("Channel is required.");
+      throw new IllegalArgumentException("ActorClient is required.");
     }
 
     this.actorType = actorType;

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
@@ -7,27 +7,15 @@ package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorUtils;
-import io.dapr.client.DaprApiProtocol;
-import io.dapr.client.DaprHttpBuilder;
-import io.dapr.config.Properties;
 import io.dapr.serializer.DaprObjectSerializer;
 import io.dapr.serializer.DefaultObjectSerializer;
-import io.dapr.v1.DaprGrpc;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 
-import java.io.Closeable;
 import java.lang.reflect.Proxy;
 
 /**
  * Builder to generate an ActorProxy instance. Builder can be reused for multiple instances.
  */
-public class ActorProxyBuilder<T> implements Closeable {
-
-  /**
-   * Determine if this builder will create GRPC clients instead of HTTP clients.
-   */
-  private final DaprApiProtocol apiProtocol;
+public class ActorProxyBuilder<T> {
 
   /**
    * Actor's type.
@@ -45,14 +33,9 @@ public class ActorProxyBuilder<T> implements Closeable {
   private DaprObjectSerializer objectSerializer;
 
   /**
-   * Builds Dapr HTTP client.
-   */
-  private DaprHttpBuilder daprHttpBuilder;
-
-  /**
    * Channel for communication with Dapr.
    */
-  private final ManagedChannel channel;
+  private final DaprChannel channel;
 
   /**
    * Instantiates a new builder for a given Actor type, using {@link DefaultObjectSerializer} by default.
@@ -60,9 +43,10 @@ public class ActorProxyBuilder<T> implements Closeable {
    * {@link DefaultObjectSerializer} is not recommended for production scenarios.
    *
    * @param actorTypeClass Actor's type class.
+   * @param channel        Dapr's sidecar channel.
    */
-  public ActorProxyBuilder(Class<T> actorTypeClass) {
-    this(ActorUtils.findActorTypeName(actorTypeClass), actorTypeClass);
+  public ActorProxyBuilder(Class<T> actorTypeClass, DaprChannel channel) {
+    this(ActorUtils.findActorTypeName(actorTypeClass), actorTypeClass, channel);
   }
 
   /**
@@ -72,34 +56,23 @@ public class ActorProxyBuilder<T> implements Closeable {
    *
    * @param actorType      Actor's type.
    * @param actorTypeClass Actor's type class.
+   * @param channel        Dapr's sidecar channel.
    */
-  public ActorProxyBuilder(String actorType, Class<T> actorTypeClass) {
-    this(actorType, actorTypeClass, Properties.API_PROTOCOL.get());
-  }
-
-  /**
-   * Instantiates a new builder for a given Actor type, using {@link DefaultObjectSerializer} by default.
-   *
-   * {@link DefaultObjectSerializer} is not recommended for production scenarios.
-   *
-   * @param actorType      Actor's type.
-   * @param actorTypeClass Actor's type class.
-   * @param apiProtocol    Dapr's API protocol.
-   */
-  private ActorProxyBuilder(String actorType, Class<T> actorTypeClass, DaprApiProtocol apiProtocol) {
+  public ActorProxyBuilder(String actorType, Class<T> actorTypeClass, DaprChannel channel) {
     if ((actorType == null) || actorType.isEmpty()) {
       throw new IllegalArgumentException("ActorType is required.");
     }
     if (actorTypeClass == null) {
       throw new IllegalArgumentException("ActorTypeClass is required.");
     }
+    if (channel == null) {
+      throw new IllegalArgumentException("Channel is required.");
+    }
 
-    this.apiProtocol = apiProtocol;
     this.actorType = actorType;
     this.objectSerializer = new DefaultObjectSerializer();
     this.clazz = actorTypeClass;
-    this.daprHttpBuilder = new DaprHttpBuilder();
-    this.channel = buildManagedChannel(apiProtocol);
+    this.channel = channel;
   }
 
   /**
@@ -132,7 +105,7 @@ public class ActorProxyBuilder<T> implements Closeable {
             this.actorType,
             actorId,
             this.objectSerializer,
-            buildDaprClient());
+            this.channel.getDaprClient());
 
     if (this.clazz.equals(ActorProxy.class)) {
       // If users want to use the not strongly typed API, we respect that here.
@@ -145,46 +118,4 @@ public class ActorProxyBuilder<T> implements Closeable {
             proxy);
   }
 
-  /**
-   * Build an instance of the Client based on the provided setup.
-   *
-   * @return an instance of the setup Client
-   * @throws java.lang.IllegalStateException if any required field is missing
-   */
-  private DaprClient buildDaprClient() {
-    switch (this.apiProtocol) {
-      case GRPC: return new DaprGrpcClient(DaprGrpc.newFutureStub(this.channel));
-      case HTTP: return new DaprHttpClient(daprHttpBuilder.build());
-      default: throw new IllegalStateException("Unsupported protocol: " + this.apiProtocol.name());
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void close() {
-    if (channel != null && !channel.isShutdown()) {
-      channel.shutdown();
-    }
-  }
-
-  /**
-   * Creates a GRPC managed channel (or null, if not applicable).
-   *
-   * @param apiProtocol Dapr's API protocol.
-   * @return GRPC managed channel or null.
-   */
-  private static ManagedChannel buildManagedChannel(DaprApiProtocol apiProtocol) {
-    if (apiProtocol != DaprApiProtocol.GRPC) {
-      return null;
-    }
-
-    int port = Properties.GRPC_PORT.get();
-    if (port <= 0) {
-      throw new IllegalArgumentException("Invalid port.");
-    }
-
-    return ManagedChannelBuilder.forAddress(Properties.SIDECAR_IP.get(), port).usePlaintext().build();
-  }
 }

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyBuilder.java
@@ -33,9 +33,9 @@ public class ActorProxyBuilder<T> {
   private DaprObjectSerializer objectSerializer;
 
   /**
-   * Channel for communication with Dapr.
+   * Client for communication with Dapr's Actor APIs.
    */
-  private final DaprChannel channel;
+  private final ActorClient actorClient;
 
   /**
    * Instantiates a new builder for a given Actor type, using {@link DefaultObjectSerializer} by default.
@@ -43,10 +43,10 @@ public class ActorProxyBuilder<T> {
    * {@link DefaultObjectSerializer} is not recommended for production scenarios.
    *
    * @param actorTypeClass Actor's type class.
-   * @param channel        Dapr's sidecar channel.
+   * @param actorClient    Dapr's sidecar client for Actor APIs.
    */
-  public ActorProxyBuilder(Class<T> actorTypeClass, DaprChannel channel) {
-    this(ActorUtils.findActorTypeName(actorTypeClass), actorTypeClass, channel);
+  public ActorProxyBuilder(Class<T> actorTypeClass, ActorClient actorClient) {
+    this(ActorUtils.findActorTypeName(actorTypeClass), actorTypeClass, actorClient);
   }
 
   /**
@@ -56,23 +56,23 @@ public class ActorProxyBuilder<T> {
    *
    * @param actorType      Actor's type.
    * @param actorTypeClass Actor's type class.
-   * @param channel        Dapr's sidecar channel.
+   * @param actorClient    Dapr's sidecar client for Actor APIs.
    */
-  public ActorProxyBuilder(String actorType, Class<T> actorTypeClass, DaprChannel channel) {
+  public ActorProxyBuilder(String actorType, Class<T> actorTypeClass, ActorClient actorClient) {
     if ((actorType == null) || actorType.isEmpty()) {
       throw new IllegalArgumentException("ActorType is required.");
     }
     if (actorTypeClass == null) {
       throw new IllegalArgumentException("ActorTypeClass is required.");
     }
-    if (channel == null) {
+    if (actorClient == null) {
       throw new IllegalArgumentException("Channel is required.");
     }
 
     this.actorType = actorType;
     this.objectSerializer = new DefaultObjectSerializer();
     this.clazz = actorTypeClass;
-    this.channel = channel;
+    this.actorClient = actorClient;
   }
 
   /**
@@ -105,7 +105,7 @@ public class ActorProxyBuilder<T> {
             this.actorType,
             actorId,
             this.objectSerializer,
-            this.channel.getDaprClient());
+            this.actorClient);
 
     if (this.clazz.equals(ActorProxy.class)) {
       // If users want to use the not strongly typed API, we respect that here.

--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorProxyImpl.java
@@ -41,7 +41,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
   /**
    * Client to talk to the Dapr's API.
    */
-  private final DaprClient daprClient;
+  private final ActorClient actorClient;
 
   /**
    * Creates a new instance of {@link ActorProxyImpl}.
@@ -49,12 +49,12 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    * @param actorType  actor implementation type of the actor associated with the proxy object.
    * @param actorId    The actorId associated with the proxy
    * @param serializer Serializer and deserializer for method calls.
-   * @param daprClient Dapr client.
+   * @param actorClient Dapr client for Actor APIs.
    */
-  ActorProxyImpl(String actorType, ActorId actorId, DaprObjectSerializer serializer, DaprClient daprClient) {
+  ActorProxyImpl(String actorType, ActorId actorId, DaprObjectSerializer serializer, ActorClient actorClient) {
     this.actorType = actorType;
     this.actorId = actorId;
-    this.daprClient = daprClient;
+    this.actorClient = actorClient;
     this.serializer = serializer;
   }
 
@@ -77,7 +77,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    */
   @Override
   public <T> Mono<T> invokeMethod(String methodName, Object data, TypeRef<T> type) {
-    return this.daprClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data))
+    return this.actorClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data))
           .filter(s -> s.length > 0)
           .map(s -> deserialize(s, type));
   }
@@ -95,7 +95,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    */
   @Override
   public <T> Mono<T> invokeMethod(String methodName, TypeRef<T> type) {
-    return this.daprClient.invoke(actorType, actorId.toString(), methodName, null)
+    return this.actorClient.invoke(actorType, actorId.toString(), methodName, null)
           .filter(s -> s.length > 0)
           .map(s -> deserialize(s, type));
   }
@@ -113,7 +113,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    */
   @Override
   public Mono<Void> invokeMethod(String methodName) {
-    return this.daprClient.invoke(actorType, actorId.toString(), methodName, null).then();
+    return this.actorClient.invoke(actorType, actorId.toString(), methodName, null).then();
   }
 
   /**
@@ -121,7 +121,7 @@ class ActorProxyImpl implements ActorProxy, InvocationHandler {
    */
   @Override
   public Mono<Void> invokeMethod(String methodName, Object data) {
-    return this.daprClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data)).then();
+    return this.actorClient.invoke(actorType, actorId.toString(), methodName, this.serialize(data)).then();
   }
 
   /**

--- a/sdk-actors/src/main/java/io/dapr/actors/client/DaprChannel.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/DaprChannel.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+package io.dapr.actors.client;
+
+import io.dapr.actors.ActorId;
+import io.dapr.actors.ActorUtils;
+import io.dapr.client.DaprApiProtocol;
+import io.dapr.client.DaprHttpBuilder;
+import io.dapr.config.Properties;
+import io.dapr.serializer.DaprObjectSerializer;
+import io.dapr.serializer.DefaultObjectSerializer;
+import io.dapr.v1.DaprGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.io.Closeable;
+import java.lang.reflect.Proxy;
+
+/**
+ * Builder to generate an ActorProxy instance. Builder can be reused for multiple instances.
+ */
+public class DaprChannel implements AutoCloseable {
+
+  /**
+   * Determine if channel is for GRPC clients or HTTP clients.
+   */
+  private final DaprApiProtocol apiProtocol;
+
+  /**
+   * gRPC channel for communication with Dapr sidecar.
+   */
+  private final ManagedChannel channel;
+
+  /**
+   * Instantiates a new channel for Dapr sidecar communication.
+   *
+   * @param apiProtocol    Dapr's API protocol.
+   */
+  private DaprChannel(DaprApiProtocol apiProtocol) {
+    this.apiProtocol = apiProtocol;
+    this.channel = buildManagedChannel(apiProtocol);
+  }
+
+  /**
+   * Instantiates a new builder for a given Actor type, using {@link DefaultObjectSerializer}.
+   *
+   * @param objectSerializer Serializer for objects sent/received.
+   * @return This instance.
+   */
+  public DaprChannel<T> withObjectSerializer(DaprObjectSerializer objectSerializer) {
+    if (objectSerializer == null) {
+      throw new IllegalArgumentException("Serializer is required.");
+    }
+
+    this.objectSerializer = objectSerializer;
+    return this;
+  }
+
+  /**
+   * Instantiates a new ActorProxy.
+   *
+   * @param actorId Actor's identifier.
+   * @return New instance of ActorProxy.
+   */
+  public T build(ActorId actorId) {
+    if (actorId == null) {
+      throw new IllegalArgumentException("Cannot instantiate an Actor without Id.");
+    }
+
+    ActorProxyImpl proxy = new ActorProxyImpl(
+            this.actorType,
+            actorId,
+            this.objectSerializer,
+            buildDaprClient());
+
+    if (this.clazz.equals(ActorProxy.class)) {
+      // If users want to use the not strongly typed API, we respect that here.
+      return (T) proxy;
+    }
+
+    return (T) Proxy.newProxyInstance(
+            ActorProxyImpl.class.getClassLoader(),
+            new Class[]{this.clazz},
+            proxy);
+  }
+
+  /**
+   * Build an instance of the Client based on the provided setup.
+   *
+   * @return an instance of the setup Client
+   * @throws IllegalStateException if any required field is missing
+   */
+  private DaprClient buildDaprClient() {
+    switch (this.apiProtocol) {
+      case GRPC: return new DaprGrpcClient(DaprGrpc.newFutureStub(this.channel));
+      case HTTP: return new DaprHttpClient(daprHttpBuilder.build());
+      default: throw new IllegalStateException("Unsupported protocol: " + this.apiProtocol.name());
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() {
+    if (channel != null && !channel.isShutdown()) {
+      channel.shutdown();
+    }
+  }
+
+  /**
+   * Creates a GRPC managed channel (or null, if not applicable).
+   *
+   * @param apiProtocol Dapr's API protocol.
+   * @return GRPC managed channel or null.
+   */
+  private static ManagedChannel buildManagedChannel(DaprApiProtocol apiProtocol) {
+    if (apiProtocol != DaprApiProtocol.GRPC) {
+      return null;
+    }
+
+    int port = Properties.GRPC_PORT.get();
+    if (port <= 0) {
+      throw new IllegalArgumentException("Invalid port.");
+    }
+
+    return ManagedChannelBuilder.forAddress(Properties.SIDECAR_IP.get(), port).usePlaintext().build();
+  }
+}

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
@@ -50,7 +50,7 @@ public class ActorProxyBuilderTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void buildWithNullChannel() {
+  public void buildWithNullClient() {
     new ActorProxyBuilder("MyActor", Object.class, null);
   }
 

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
@@ -14,37 +14,37 @@ import org.junit.Test;
 
 public class ActorProxyBuilderTest {
 
-  private static DaprChannel daprChannel;
+  private static ActorClient actorClient;
 
   @BeforeClass
   public static void initClass() {
-    daprChannel = new DaprChannel();
+    actorClient = new ActorClient();
   }
 
   @AfterClass
   public static void tearDownClass() {
-    daprChannel.close();
+    actorClient.close();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorId() {
-    new ActorProxyBuilder("test", Object.class, daprChannel)
+    new ActorProxyBuilder("test", Object.class, actorClient)
         .build(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithEmptyActorType() {
-    new ActorProxyBuilder("", Object.class, daprChannel);
+    new ActorProxyBuilder("", Object.class, actorClient);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorType() {
-    new ActorProxyBuilder(null, Object.class, daprChannel);
+    new ActorProxyBuilder(null, Object.class, actorClient);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullSerializer() {
-    new ActorProxyBuilder("MyActor", Object.class, daprChannel)
+    new ActorProxyBuilder("MyActor", Object.class, actorClient)
       .withObjectSerializer(null)
       .build(new ActorId("100"));
   }
@@ -56,7 +56,7 @@ public class ActorProxyBuilderTest {
 
   @Test()
   public void build() {
-    ActorProxyBuilder<ActorProxy> builder = new ActorProxyBuilder("test", ActorProxy.class, daprChannel);
+    ActorProxyBuilder<ActorProxy> builder = new ActorProxyBuilder("test", ActorProxy.class, actorClient);
     ActorProxy actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);
@@ -66,7 +66,7 @@ public class ActorProxyBuilderTest {
 
   @Test()
   public void buildWithType() {
-    ActorProxyBuilder<MyActor> builder = new ActorProxyBuilder(MyActor.class, daprChannel);
+    ActorProxyBuilder<MyActor> builder = new ActorProxyBuilder(MyActor.class, actorClient);
     MyActor actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);
@@ -74,7 +74,7 @@ public class ActorProxyBuilderTest {
 
   @Test()
   public void buildWithTypeDefaultName() {
-    ActorProxyBuilder<ActorWithDefaultName> builder = new ActorProxyBuilder(ActorWithDefaultName.class, daprChannel);
+    ActorProxyBuilder<ActorWithDefaultName> builder = new ActorProxyBuilder(ActorWithDefaultName.class, actorClient);
     ActorWithDefaultName actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyBuilderTest.java
@@ -7,43 +7,56 @@ package io.dapr.actors.client;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ActorProxyBuilderTest {
 
+  private static DaprChannel daprChannel;
+
+  @BeforeClass
+  public static void initClass() {
+    daprChannel = new DaprChannel();
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    daprChannel.close();
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorId() {
-    new ActorProxyBuilder("test", Object.class)
+    new ActorProxyBuilder("test", Object.class, daprChannel)
         .build(null);
-
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithEmptyActorType() {
-    new ActorProxyBuilder("", Object.class)
-        .build(new ActorId("100"));
-
+    new ActorProxyBuilder("", Object.class, daprChannel);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullActorType() {
-    new ActorProxyBuilder(null, Object.class)
-      .build(new ActorId("100"));
-
+    new ActorProxyBuilder(null, Object.class, daprChannel);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void buildWithNullSerializer() {
-    new ActorProxyBuilder("MyActor", Object.class)
+    new ActorProxyBuilder("MyActor", Object.class, daprChannel)
       .withObjectSerializer(null)
       .build(new ActorId("100"));
+  }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void buildWithNullChannel() {
+    new ActorProxyBuilder("MyActor", Object.class, null);
   }
 
   @Test()
   public void build() {
-    ActorProxyBuilder<ActorProxy> builder = new ActorProxyBuilder("test", ActorProxy.class);
+    ActorProxyBuilder<ActorProxy> builder = new ActorProxyBuilder("test", ActorProxy.class, daprChannel);
     ActorProxy actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);
@@ -53,7 +66,7 @@ public class ActorProxyBuilderTest {
 
   @Test()
   public void buildWithType() {
-    ActorProxyBuilder<MyActor> builder = new ActorProxyBuilder(MyActor.class);
+    ActorProxyBuilder<MyActor> builder = new ActorProxyBuilder(MyActor.class, daprChannel);
     MyActor actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);
@@ -61,8 +74,8 @@ public class ActorProxyBuilderTest {
 
   @Test()
   public void buildWithTypeDefaultName() {
-    ActorProxyBuilder<MyActorWithDefaultName> builder = new ActorProxyBuilder(MyActorWithDefaultName.class);
-    MyActorWithDefaultName actorProxy = builder.build(new ActorId("100"));
+    ActorProxyBuilder<ActorWithDefaultName> builder = new ActorProxyBuilder(ActorWithDefaultName.class, daprChannel);
+    ActorWithDefaultName actorProxy = builder.build(new ActorId("100"));
 
     Assert.assertNotNull(actorProxy);
   }
@@ -71,6 +84,7 @@ public class ActorProxyBuilderTest {
   public interface MyActor {
   }
 
-  public interface MyActorWithDefaultName {
+  public interface ActorWithDefaultName {
   }
+
 }

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyForTestsImpl.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyForTestsImpl.java
@@ -10,7 +10,7 @@ import io.dapr.serializer.DaprObjectSerializer;
 
 public class ActorProxyForTestsImpl extends ActorProxyImpl {
 
-  public ActorProxyForTestsImpl(String actorType, ActorId actorId, DaprObjectSerializer serializer, DaprClient daprClient) {
-    super(actorType, actorId, serializer, daprClient);
+  public ActorProxyForTestsImpl(String actorType, ActorId actorId, DaprObjectSerializer serializer, ActorClient actorClient) {
+    super(actorType, actorId, serializer, actorClient);
   }
 }

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplForTests.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplForTests.java
@@ -8,9 +8,9 @@ package io.dapr.actors.client;
 import io.dapr.actors.ActorId;
 import io.dapr.serializer.DaprObjectSerializer;
 
-public class ActorProxyForTestsImpl extends ActorProxyImpl {
+public class ActorProxyImplForTests extends ActorProxyImpl {
 
-  public ActorProxyForTestsImpl(String actorType, ActorId actorId, DaprObjectSerializer serializer, ActorClient actorClient) {
+  public ActorProxyImplForTests(String actorType, ActorId actorId, DaprObjectSerializer serializer, ActorClient actorClient) {
     super(actorType, actorId, serializer, actorClient);
   }
 }

--- a/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/ActorProxyImplTest.java
@@ -23,7 +23,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void constructorActorProxyTest() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     final DaprObjectSerializer serializer = mock(DaprObjectSerializer.class);
     final ActorProxyImpl actorProxy = new ActorProxyImpl(
         "myActorType",
@@ -36,7 +36,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.just(
             "{\n\t\t\"propertyA\": \"valueA\",\n\t\t\"propertyB\": \"valueB\"\n\t}".getBytes());
 
@@ -58,7 +58,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithReturnTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.just(
         "{\n\t\t\"propertyA\": \"valueA\",\n\t\t\"propertyB\": \"valueB\"\n\t}".getBytes());
 
@@ -79,7 +79,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithReturnMonoTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.just(
         "{\n\t\t\"propertyA\": \"valueA\",\n\t\t\"propertyB\": \"valueB\"\n\t}".getBytes());
 
@@ -102,7 +102,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithDataWithReturnTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.just(
         "\"OK\"".getBytes());
 
@@ -125,7 +125,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithDataWithReturnMonoTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.just(
         "\"OK\"".getBytes());
 
@@ -149,7 +149,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithoutReturnTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.empty();
 
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNull()))
@@ -167,7 +167,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithoutReturnTypeMonoViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.empty();
 
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNull()))
@@ -186,7 +186,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithDataWithoutReturnTypeMonoViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.empty();
 
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.eq("\"hello world\"".getBytes())))
@@ -209,7 +209,7 @@ public class ActorProxyImplTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void invokeActorMethodWithTooManyArgsViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
 
     final ActorProxyImpl actorProxy = new ActorProxyImpl(
         "myActorType",
@@ -228,7 +228,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithDataWithoutReturnTypeViaReflection() throws NoSuchMethodException {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     Mono<byte[]> daprResponse = Mono.empty();
 
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.eq("\"hello world\"".getBytes())))
@@ -250,7 +250,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithEmptyReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNull()))
         .thenReturn(Mono.just("".getBytes()));
 
@@ -267,7 +267,7 @@ public class ActorProxyImplTest {
 
   @Test(expected = RuntimeException.class)
   public void invokeActorMethodWithIncorrectReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNull()))
         .thenReturn(Mono.just("{test}".getBytes()));
 
@@ -287,7 +287,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodSavingDataWithReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(
           Mono.just("{\n\t\t\"propertyA\": \"valueA\",\n\t\t\"propertyB\": \"valueB\"\n\t}".getBytes()));
@@ -312,7 +312,7 @@ public class ActorProxyImplTest {
 
   @Test(expected = DaprException.class)
   public void invokeActorMethodSavingDataWithIncorrectReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(Mono.just("{test}".getBytes()));
 
@@ -336,7 +336,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodSavingDataWithEmptyReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(Mono.just("".getBytes()));
 
@@ -358,7 +358,7 @@ public class ActorProxyImplTest {
 
   @Test(expected = DaprException.class)
   public void invokeActorMethodSavingDataWithIncorrectInputType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(Mono.just("{test}".getBytes()));
 
@@ -387,7 +387,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyA("valueA");
     saveData.setPropertyB("valueB");
 
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(Mono.empty());
 
@@ -410,7 +410,7 @@ public class ActorProxyImplTest {
     saveData.setPropertyB("valueB");
     saveData.setMyData(saveData);
 
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNotNull()))
         .thenReturn(Mono.empty());
 
@@ -427,7 +427,7 @@ public class ActorProxyImplTest {
 
   @Test()
   public void invokeActorMethodWithoutDataWithVoidReturnType() {
-    final DaprClient daprClient = mock(DaprClient.class);
+    final ActorClient daprClient = mock(ActorClient.class);
     when(daprClient.invoke(anyString(), anyString(), anyString(), Mockito.isNull()))
         .thenReturn(Mono.empty());
 

--- a/sdk-actors/src/test/java/io/dapr/actors/client/DaprClientStub.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/DaprClientStub.java
@@ -7,7 +7,7 @@ package io.dapr.actors.client;
 
 import reactor.core.publisher.Mono;
 
-public class DaprClientStub implements DaprClient {
+public class DaprClientStub extends ActorClient implements DaprClient {
 
   @Override
   public Mono<byte[]> invoke(String actorType, String actorId, String methodName, byte[] jsonPayload) {

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorCustomSerializerTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorCustomSerializerTest.java
@@ -8,7 +8,7 @@ package io.dapr.actors.runtime;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
 import io.dapr.actors.client.ActorProxy;
-import io.dapr.actors.client.ActorProxyForTestsImpl;
+import io.dapr.actors.client.ActorProxyImplForTests;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DaprObjectSerializer;
 import org.junit.Assert;
@@ -143,7 +143,7 @@ public class ActorCustomSerializerTest {
 
     this.manager.activateActor(actorId).block();
 
-    return new ActorProxyForTestsImpl(
+    return new ActorProxyImplForTests(
       context.getActorTypeInformation().getName(),
       actorId,
       CUSTOM_SERIALIZER,

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorNoStateTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorNoStateTest.java
@@ -9,7 +9,7 @@ import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorMethod;
 import io.dapr.actors.ActorType;
 import io.dapr.actors.client.ActorProxy;
-import io.dapr.actors.client.ActorProxyForTestsImpl;
+import io.dapr.actors.client.ActorProxyImplForTests;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DefaultObjectSerializer;
 import org.junit.Assert;
@@ -245,7 +245,7 @@ public class ActorNoStateTest {
 
     this.manager.activateActor(actorId).block();
 
-    return new ActorProxyForTestsImpl(
+    return new ActorProxyImplForTests(
       context.getActorTypeInformation().getName(),
       actorId,
       new DefaultObjectSerializer(),
@@ -271,13 +271,13 @@ public class ActorNoStateTest {
 
     this.manager.activateActor(actorId).block();
 
-    ActorProxyForTestsImpl proxy = new ActorProxyForTestsImpl(
+    ActorProxyImplForTests proxy = new ActorProxyImplForTests(
             context.getActorTypeInformation().getName(),
             actorId,
             new DefaultObjectSerializer(),
             daprClient);
     return (T) Proxy.newProxyInstance(
-            ActorProxyForTestsImpl.class.getClassLoader(),
+            ActorProxyImplForTests.class.getClassLoader(),
             new Class[]{clazz},
             proxy);
   }

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ActorStatefulTest.java
@@ -8,7 +8,7 @@ package io.dapr.actors.runtime;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
 import io.dapr.actors.client.ActorProxy;
-import io.dapr.actors.client.ActorProxyForTestsImpl;
+import io.dapr.actors.client.ActorProxyImplForTests;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DefaultObjectSerializer;
 import io.dapr.utils.TypeRef;
@@ -620,7 +620,7 @@ public class ActorStatefulTest {
 
     this.manager.activateActor(actorId).block();
 
-    return new ActorProxyForTestsImpl(
+    return new ActorProxyImplForTests(
             context.getActorTypeInformation().getName(),
             actorId,
             new DefaultObjectSerializer(),

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DerivedActorTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DerivedActorTest.java
@@ -8,7 +8,7 @@ package io.dapr.actors.runtime;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
 import io.dapr.actors.client.ActorProxy;
-import io.dapr.actors.client.ActorProxyForTestsImpl;
+import io.dapr.actors.client.ActorProxyImplForTests;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DefaultObjectSerializer;
 import org.junit.Assert;
@@ -340,7 +340,7 @@ public class DerivedActorTest {
 
     this.manager.activateActor(actorId).block();
 
-    return new ActorProxyForTestsImpl(
+    return new ActorProxyImplForTests(
       context.getActorTypeInformation().getName(),
       actorId,
       new DefaultObjectSerializer(),

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/ThrowFromPreAndPostActorMethodsTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/ThrowFromPreAndPostActorMethodsTest.java
@@ -8,7 +8,7 @@ package io.dapr.actors.runtime;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.ActorType;
 import io.dapr.actors.client.ActorProxy;
-import io.dapr.actors.client.ActorProxyForTestsImpl;
+import io.dapr.actors.client.ActorProxyImplForTests;
 import io.dapr.actors.client.DaprClientStub;
 import io.dapr.serializer.DefaultObjectSerializer;
 import org.junit.Assert;
@@ -159,7 +159,7 @@ public class ThrowFromPreAndPostActorMethodsTest {
 
     this.manager.activateActor(actorId).block();
 
-    return new ActorProxyForTestsImpl(
+    return new ActorProxyImplForTests(
       context.getActorTypeInformation().getName(),
       actorId,
       new DefaultObjectSerializer(),

--- a/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
@@ -5,11 +5,11 @@
 
 package io.dapr.it;
 
+import io.dapr.actors.client.DaprChannel;
 import io.dapr.client.DaprApiProtocol;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.AfterClass;
 
-import java.io.Closeable;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -23,7 +23,7 @@ public abstract class BaseIT {
 
   private static final Queue<Stoppable> TO_BE_STOPPED = new LinkedList<>();
 
-  private static final Queue<Closeable> TO_BE_CLOSED = new LinkedList<>();
+  private static final Queue<AutoCloseable> TO_BE_CLOSED = new LinkedList<>();
 
   protected static DaprRun startDaprApp(
       String testName,
@@ -109,18 +109,17 @@ public abstract class BaseIT {
   @AfterClass
   public static void cleanUp() throws Exception {
     while (!TO_BE_CLOSED.isEmpty()) {
-      Closeable toBeClosed = TO_BE_CLOSED.remove();
-      toBeClosed.close();
+      TO_BE_CLOSED.remove().close();
     }
 
     while (!TO_BE_STOPPED.isEmpty()) {
-      Stoppable toBeStopped = TO_BE_STOPPED.remove();
-      toBeStopped.stop();
+      TO_BE_STOPPED.remove().stop();
     }
   }
 
-  protected static <T extends Closeable> T deferClose(T closeable) {
-    TO_BE_CLOSED.add(closeable);
-    return closeable;
+  protected DaprChannel newDaprActorChannel() {
+    DaprChannel channel = new DaprChannel();
+    TO_BE_CLOSED.add(channel);
+    return channel;
   }
 }

--- a/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/BaseIT.java
@@ -5,7 +5,7 @@
 
 package io.dapr.it;
 
-import io.dapr.actors.client.DaprChannel;
+import io.dapr.actors.client.ActorClient;
 import io.dapr.client.DaprApiProtocol;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.AfterClass;
@@ -117,9 +117,9 @@ public abstract class BaseIT {
     }
   }
 
-  protected DaprChannel newDaprActorChannel() {
-    DaprChannel channel = new DaprChannel();
-    TO_BE_CLOSED.add(channel);
-    return channel;
+  protected ActorClient newActorClient() {
+    ActorClient client = new ActorClient();
+    TO_BE_CLOSED.add(client);
+    return client;
   }
 }

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActivationDeactivationIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActivationDeactivationIT.java
@@ -7,6 +7,7 @@ package io.dapr.it.actors;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxyBuilder;
+import io.dapr.actors.client.DaprChannel;
 import io.dapr.it.BaseIT;
 import io.dapr.it.actors.services.springboot.DemoActor;
 import io.dapr.it.actors.services.springboot.DemoActorService;
@@ -38,7 +39,7 @@ public class ActivationDeactivationIT extends BaseIT {
 
     final AtomicInteger atomicInteger = new AtomicInteger(1);
     logger.debug("Creating proxy builder");
-    ActorProxyBuilder<DemoActor> proxyBuilder = deferClose(new ActorProxyBuilder(DemoActor.class));
+    ActorProxyBuilder<DemoActor> proxyBuilder = new ActorProxyBuilder(DemoActor.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId(Integer.toString(atomicInteger.getAndIncrement()));
     logger.debug("Building proxy");

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActivationDeactivationIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActivationDeactivationIT.java
@@ -7,7 +7,6 @@ package io.dapr.it.actors;
 
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxyBuilder;
-import io.dapr.actors.client.DaprChannel;
 import io.dapr.it.BaseIT;
 import io.dapr.it.actors.services.springboot.DemoActor;
 import io.dapr.it.actors.services.springboot.DemoActorService;
@@ -39,7 +38,7 @@ public class ActivationDeactivationIT extends BaseIT {
 
     final AtomicInteger atomicInteger = new AtomicInteger(1);
     logger.debug("Creating proxy builder");
-    ActorProxyBuilder<DemoActor> proxyBuilder = new ActorProxyBuilder(DemoActor.class, newDaprActorChannel());
+    ActorProxyBuilder<DemoActor> proxyBuilder = new ActorProxyBuilder(DemoActor.class, newActorClient());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId(Integer.toString(atomicInteger.getAndIncrement()));
     logger.debug("Building proxy");

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorMethodNameIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorMethodNameIT.java
@@ -33,7 +33,8 @@ public class ActorMethodNameIT extends BaseIT {
         60000);
 
     logger.debug("Creating proxy builder");
-    ActorProxyBuilder<MyActor> proxyBuilder = deferClose(new ActorProxyBuilder("MyActorTest", MyActor.class));
+    ActorProxyBuilder<MyActor> proxyBuilder =
+        new ActorProxyBuilder("MyActorTest", MyActor.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId("1");
     logger.debug("Building proxy");
@@ -47,7 +48,8 @@ public class ActorMethodNameIT extends BaseIT {
     }, 60000);
 
     logger.debug("Creating proxy builder 2");
-    ActorProxyBuilder<ActorProxy> proxyBuilder2 = deferClose(new ActorProxyBuilder("MyActorTest", ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder2 =
+        new ActorProxyBuilder("MyActorTest", ActorProxy.class, newDaprActorChannel());
     logger.debug("Building proxy 2");
     ActorProxy proxy2 = proxyBuilder2.build(actorId1);
 

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorMethodNameIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorMethodNameIT.java
@@ -34,7 +34,7 @@ public class ActorMethodNameIT extends BaseIT {
 
     logger.debug("Creating proxy builder");
     ActorProxyBuilder<MyActor> proxyBuilder =
-        new ActorProxyBuilder("MyActorTest", MyActor.class, newDaprActorChannel());
+        new ActorProxyBuilder("MyActorTest", MyActor.class, newActorClient());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId("1");
     logger.debug("Building proxy");
@@ -49,7 +49,7 @@ public class ActorMethodNameIT extends BaseIT {
 
     logger.debug("Creating proxy builder 2");
     ActorProxyBuilder<ActorProxy> proxyBuilder2 =
-        new ActorProxyBuilder("MyActorTest", ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder("MyActorTest", ActorProxy.class, newActorClient());
     logger.debug("Building proxy 2");
     ActorProxy proxy2 = proxyBuilder2.build(actorId1);
 

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderFailoverIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderFailoverIT.java
@@ -63,7 +63,8 @@ public class ActorReminderFailoverIT extends BaseIT {
     String actorType="MyActorTest";
     logger.debug("Creating proxy builder");
 
-    ActorProxyBuilder<ActorProxy> proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder =
+        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     logger.debug("Building proxy");
     proxy = proxyBuilder.build(actorId);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderFailoverIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderFailoverIT.java
@@ -64,7 +64,7 @@ public class ActorReminderFailoverIT extends BaseIT {
     logger.debug("Creating proxy builder");
 
     ActorProxyBuilder<ActorProxy> proxyBuilder =
-        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     logger.debug("Creating actorId");
     logger.debug("Building proxy");
     proxy = proxyBuilder.build(actorId);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
@@ -8,7 +8,6 @@ package io.dapr.it.actors;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxy;
 import io.dapr.actors.client.ActorProxyBuilder;
-import io.dapr.actors.client.DaprChannel;
 import io.dapr.it.AppRun;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
@@ -53,7 +52,7 @@ public class ActorReminderRecoveryIT extends BaseIT {
     logger.debug("Creating proxy builder");
 
     ActorProxyBuilder<ActorProxy> proxyBuilder =
-        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     logger.debug("Creating actorId");
     logger.debug("Building proxy");
     proxy = proxyBuilder.build(actorId);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
@@ -8,6 +8,7 @@ package io.dapr.it.actors;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxy;
 import io.dapr.actors.client.ActorProxyBuilder;
+import io.dapr.actors.client.DaprChannel;
 import io.dapr.it.AppRun;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
@@ -51,7 +52,8 @@ public class ActorReminderRecoveryIT extends BaseIT {
     String actorType="MyActorTest";
     logger.debug("Creating proxy builder");
 
-    ActorProxyBuilder<ActorProxy> proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder =
+        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     logger.debug("Building proxy");
     proxy = proxyBuilder.build(actorId);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorStateIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorStateIT.java
@@ -8,7 +8,6 @@ package io.dapr.it.actors;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxy;
 import io.dapr.actors.client.ActorProxyBuilder;
-import io.dapr.actors.client.DaprChannel;
 import io.dapr.client.DaprApiProtocol;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
@@ -76,7 +75,7 @@ public class ActorStateIT extends BaseIT {
     String actorType = "StatefulActorTest";
     logger.debug("Building proxy ...");
     ActorProxyBuilder<ActorProxy> proxyBuilder =
-        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     ActorProxy proxy = proxyBuilder.build(actorId);
 
     // Validate conditional read works.
@@ -162,7 +161,7 @@ public class ActorStateIT extends BaseIT {
     runtime.switchToProtocol(this.daprClientProtocol);
 
     // Need new proxy builder because the proxy builder holds the channel.
-    proxyBuilder = new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+    proxyBuilder = new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     ActorProxy newProxy = proxyBuilder.build(actorId);
 
     callWithRetry(() -> {

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorStateIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorStateIT.java
@@ -8,6 +8,7 @@ package io.dapr.it.actors;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxy;
 import io.dapr.actors.client.ActorProxyBuilder;
+import io.dapr.actors.client.DaprChannel;
 import io.dapr.client.DaprApiProtocol;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
@@ -74,7 +75,8 @@ public class ActorStateIT extends BaseIT {
         String.format("%d-%b-%b", System.currentTimeMillis(), this.daprClientProtocol, this.serviceAppProtocol));
     String actorType = "StatefulActorTest";
     logger.debug("Building proxy ...");
-    ActorProxyBuilder<ActorProxy> proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder =
+        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     ActorProxy proxy = proxyBuilder.build(actorId);
 
     // Validate conditional read works.
@@ -160,7 +162,7 @@ public class ActorStateIT extends BaseIT {
     runtime.switchToProtocol(this.daprClientProtocol);
 
     // Need new proxy builder because the proxy builder holds the channel.
-    proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    proxyBuilder = new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     ActorProxy newProxy = proxyBuilder.build(actorId);
 
     callWithRetry(() -> {

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
@@ -48,7 +48,7 @@ public class ActorTimerRecoveryIT extends BaseIT {
     logger.debug("Creating proxy builder");
 
     ActorProxyBuilder<ActorProxy> proxyBuilder =
-        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     logger.debug("Creating actorId");
     ActorId actorId = new ActorId(UUID.randomUUID().toString());
     logger.debug("Building proxy");

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
@@ -47,7 +47,8 @@ public class ActorTimerRecoveryIT extends BaseIT {
     String actorType="MyActorTest";
     logger.debug("Creating proxy builder");
 
-    ActorProxyBuilder<ActorProxy> proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder =
+        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     ActorId actorId = new ActorId(UUID.randomUUID().toString());
     logger.debug("Building proxy");

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
@@ -80,7 +80,8 @@ public class ActorTurnBasedConcurrencyIT extends BaseIT {
     String actorType="MyActorTest";
     logger.debug("Creating proxy builder");
 
-    ActorProxyBuilder<ActorProxy> proxyBuilder = deferClose(new ActorProxyBuilder(actorType, ActorProxy.class));
+    ActorProxyBuilder<ActorProxy> proxyBuilder =
+        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId(ACTOR_ID);
     logger.debug("Building proxy");

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTurnBasedConcurrencyIT.java
@@ -81,7 +81,7 @@ public class ActorTurnBasedConcurrencyIT extends BaseIT {
     logger.debug("Creating proxy builder");
 
     ActorProxyBuilder<ActorProxy> proxyBuilder =
-        new ActorProxyBuilder(actorType, ActorProxy.class, newDaprActorChannel());
+        new ActorProxyBuilder(actorType, ActorProxy.class, newActorClient());
     logger.debug("Creating actorId");
     ActorId actorId1 = new ActorId(ACTOR_ID);
     logger.debug("Building proxy");

--- a/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
@@ -27,26 +27,6 @@ public class DaprHttpBuilder {
   private static final Object LOCK = new Object();
 
   /**
-   * Read timeout used to build object.
-   */
-  private Duration readTimeout = Duration.ofSeconds(Properties.HTTP_CLIENT_READ_TIMEOUT_SECONDS.get());
-
-  /**
-   * Sets the read timeout duration for the instance to be built.
-   *
-   * <p>Instead, set environment variable "DAPR_HTTP_CLIENT_READTIMEOUTSECONDS",
-   *   or system property "dapr.http.client.readtimeoutseconds".
-   *
-   * @param duration Read timeout duration.
-   * @return Same builder instance.
-   */
-  @Deprecated
-  public DaprHttpBuilder withReadTimeout(Duration duration) {
-    this.readTimeout = duration;
-    return this;
-  }
-
-  /**
    * Build an instance of the Http client based on the provided setup.
    *
    * @return an instance of {@link DaprHttp}
@@ -57,7 +37,7 @@ public class DaprHttpBuilder {
   }
 
   /**
-   * Creates and instance of the HTTP Client.
+   * Creates an instance of the HTTP Client.
    *
    * @return Instance of {@link DaprHttp}
    */
@@ -66,7 +46,8 @@ public class DaprHttpBuilder {
       synchronized (LOCK) {
         if (OK_HTTP_CLIENT.get() == null) {
           OkHttpClient.Builder builder = new OkHttpClient.Builder();
-          builder.readTimeout(this.readTimeout);
+          Duration readTimeout = Duration.ofSeconds(Properties.HTTP_CLIENT_READ_TIMEOUT_SECONDS.get());
+          builder.readTimeout(readTimeout);
           OkHttpClient okHttpClient = builder.build();
           OK_HTTP_CLIENT.set(okHttpClient);
         }


### PR DESCRIPTION
# Description

This change creates a class called `DaprChannel` for actor communication in Dapr. It will avoid making `ActorProxyBuilder` a closeable class - it was odd to have a builder class that could not be disposed. Now, `DaprChannel` is the class where users must keep a reference and close in the end. If we decide to use HTTP instead of gRPC, the DaprChannel still holds the Client reference, making it an effective singleton.

Summary:
+ An instance of `ActorProxyBuilder` is now disposable and does not need to exist while DaprClient is being used.
+ `DaprChannel` holds the "channel" to Dapr and must be referenced while app is using Dapr Actor APIs.
+ `DaprChannel` is closeable, so users must close it after done with using Dapr Actor APIs.
+ `DaprChannel` is encourage to be a singleton in the app, creating many instances can trash the application.
+ `DaprChannel` is specific to Actor APIs because `DaprClient` in the regular SDKs is already closeable and must be reused.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: None

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation

RELEASE NOTE: **REFACTOR** Created `DaprChannel` for actor APIs, making `ActorProxyBuilder` not closeable anymore.