### PR TITLE
Updating state management example to include etag mismatch exception handling

### DIFF
--- a/examples/src/main/java/io/dapr/examples/state/README.md
+++ b/examples/src/main/java/io/dapr/examples/state/README.md
@@ -84,8 +84,7 @@ public class StateClient {
         System.out.println("Verify delete key request is aborted if an etag different from stored is passed.");
         // delete state API
         try {
-          Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, "100", null);
-          mono.block();
+          client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, "100", null).block();
         } catch (DaprException ex) {
           if (ex.getErrorCode().equals(Status.Code.ABORTED.toString())) {
             // Expected error due to etag mismatch.
@@ -98,15 +97,13 @@ public class StateClient {
 
         System.out.println("Trying to delete again with correct etag.");
         String storedEtag = client.getState(STATE_STORE_NAME, FIRST_KEY_NAME, MyClass.class).block().getEtag();
-        Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, storedEtag, null);
-        mono.block();
+        client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, storedEtag, null).block();
   
         // Delete operation using transaction API
         operationList.clear();
         operationList.add(new TransactionalStateOperation<>(TransactionalStateOperation.OperationType.DELETE,
             new State<>(SECOND_KEY_NAME)));
-        mono = client.executeStateTransaction(STATE_STORE_NAME, operationList);
-        mono.block();
+        client.executeStateTransaction(STATE_STORE_NAME, operationList).block();
   
         Mono<List<State<MyClass>>> retrievedDeletedMessageMono = client.getStates(STATE_STORE_NAME,
             Arrays.asList(FIRST_KEY_NAME, SECOND_KEY_NAME), MyClass.class);

--- a/examples/src/main/java/io/dapr/examples/state/StateClient.java
+++ b/examples/src/main/java/io/dapr/examples/state/StateClient.java
@@ -89,8 +89,7 @@ public class StateClient {
       System.out.println("Verify delete key request is aborted if an etag different from stored is passed.");
       // delete state API
       try {
-        Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, "100", null);
-        mono.block();
+        client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, "100", null).block();
       } catch (DaprException ex) {
         if (ex.getErrorCode().equals(Status.Code.ABORTED.toString())) {
           // Expected error due to etag mismatch.
@@ -103,14 +102,12 @@ public class StateClient {
 
       System.out.println("Trying to delete again with correct etag.");
       String storedEtag = client.getState(STATE_STORE_NAME, FIRST_KEY_NAME, MyClass.class).block().getEtag();
-      Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, storedEtag, null);
-      mono.block();
+      client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, storedEtag, null).block();
       // Delete operation using transaction API
       operationList.clear();
       operationList.add(new TransactionalStateOperation<>(TransactionalStateOperation.OperationType.DELETE,
           new State<>(SECOND_KEY_NAME)));
-      mono = client.executeStateTransaction(STATE_STORE_NAME, operationList);
-      mono.block();
+      client.executeStateTransaction(STATE_STORE_NAME, operationList).block();
 
       Mono<List<State<MyClass>>> retrievedDeletedMessageMono = client.getBulkState(STATE_STORE_NAME,
           Arrays.asList(FIRST_KEY_NAME, SECOND_KEY_NAME), MyClass.class);

--- a/examples/src/main/java/io/dapr/examples/state/StateClient.java
+++ b/examples/src/main/java/io/dapr/examples/state/StateClient.java
@@ -9,6 +9,8 @@ import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.State;
 import io.dapr.client.domain.TransactionalStateOperation;
+import io.dapr.exceptions.DaprException;
+import io.grpc.Status;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
@@ -84,10 +86,25 @@ public class StateClient {
 
       System.out.println("Deleting states...");
 
+      System.out.println("Verify delete key request is aborted if an etag different from stored is passed.");
       // delete state API
-      Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME);
-      mono.block();
+      try {
+        Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, "100", null);
+        mono.block();
+      } catch (DaprException ex) {
+        if (ex.getErrorCode().equals(Status.Code.ABORTED.toString())) {
+          // Expected error due to etag mismatch.
+          System.out.println(String.format("Expected failure. %s ", ex.getMessage()));
+        } else {
+          System.out.println("Unexpected exception.");
+          throw ex;
+        }
+      }
 
+      System.out.println("Trying to delete again with correct etag.");
+      String storedEtag = client.getState(STATE_STORE_NAME, FIRST_KEY_NAME, MyClass.class).block().getEtag();
+      Mono<Void> mono = client.deleteState(STATE_STORE_NAME, FIRST_KEY_NAME, storedEtag, null);
+      mono.block();
       // Delete operation using transaction API
       operationList.clear();
       operationList.add(new TransactionalStateOperation<>(TransactionalStateOperation.OperationType.DELETE,

--- a/sdk/src/main/java/io/dapr/client/domain/State.java
+++ b/sdk/src/main/java/io/dapr/client/domain/State.java
@@ -26,7 +26,7 @@ public class State<T> {
 
   /**
    * The ETag to be used
-   * Keep in mind that for some state stores (like reids) only numbers are supported.
+   * Keep in mind that for some state stores (like redis) only numbers are supported.
    */
   private final String etag;
 


### PR DESCRIPTION
# Description
Updating state management example to include etag mismatch exception scenario. Dapr runtime grpc exception handling was recently updated to return aborted error code on etage mismatch for mutations, the example is updated to reflect that the runtime updates will be propagated through the java sdk.
`ABORTED: failed deleting state with key myKey: possible etag mismatch. error from state store: ERR Error running script (call to f_9b5da7354cb61e2ca9faff50f6c43b81c73c0b94): @user_script:1: user_script:1: failed to delete Pixiemango-King||myKey`

There were no updates to HTTP in runtime https://github.com/dapr/dapr/blob/3481920cb533b46a9073e206aa215deb2a06e71e/pkg/http/api.go#L549, but I verified that that the error sent by Dapr runtime is passed through for http as well.
`Caused by: io.dapr.exceptions.DaprException: ERR_STATE_DELETE: failed deleting state with key myKey: possible etag mismatch. error from state store: ERR Error running script (call to f_9b5da7354cb61e2ca9faff50f6c43b81c73c0b94): @user_script:1: user_script:1: failed to delete Mousespice-Roarer||myKey`

The updated state.png file is copied below for review.

## Issue reference

Please reference the issue this PR will close: #437

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation

<img width="1789" alt="state" src="https://user-images.githubusercontent.com/74574173/105926119-36263800-5ff6-11eb-9bd5-df9e868e9110.png">
