### PR TITLE
allow supplied ObjectMapper to DefaultObjectSerializer

### DIFF
--- a/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorObjectSerializer.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/runtime/ActorObjectSerializer.java
@@ -174,7 +174,7 @@ public class ActorObjectSerializer extends ObjectSerializer {
       return null;
     }
 
-    JsonNode node = OBJECT_MAPPER.readTree(value);
+    JsonNode node = objectMapper.readTree(value);
     String callback = node.get("callback").asText();
     Duration dueTime = extractDurationOrNull(node, "dueTime");
     Duration period = extractDurationOrNull(node, "period");
@@ -195,7 +195,7 @@ public class ActorObjectSerializer extends ObjectSerializer {
       return null;
     }
 
-    JsonNode node = OBJECT_MAPPER.readTree(value);
+    JsonNode node = objectMapper.readTree(value);
     Duration dueTime = extractDurationOrNull(node, "dueTime");
     Duration period = extractDurationOrNull(node, "period");
     byte[] data = node.get("data") != null ? node.get("data").binaryValue() : null;

--- a/sdk/src/main/java/io/dapr/client/ObjectSerializer.java
+++ b/sdk/src/main/java/io/dapr/client/ObjectSerializer.java
@@ -25,14 +25,23 @@ public class ObjectSerializer {
   /**
    * Shared Json serializer/deserializer as per Jackson's documentation.
    */
-  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  protected final ObjectMapper objectMapper;
 
   /**
    * Default constructor to avoid class from being instantiated outside package but still inherited.
    */
   protected ObjectSerializer() {
+    this.objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  /**
+   * Create an instance with supplied {@link ObjectMapper}.
+   * @param objectMapper supplied {@link ObjectMapper}
+   */
+  protected ObjectSerializer(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
   }
 
   /**
@@ -62,7 +71,7 @@ public class ObjectSerializer {
     }
 
     // Not string, not primitive, so it is a complex type: we use JSON for that.
-    return OBJECT_MAPPER.writeValueAsBytes(state);
+    return objectMapper.writeValueAsBytes(state);
   }
 
   /**
@@ -75,7 +84,7 @@ public class ObjectSerializer {
    * @throws IOException In case content cannot be deserialized.
    */
   public <T> T deserialize(byte[] content, TypeRef<T> type) throws IOException {
-    return deserialize(content, OBJECT_MAPPER.constructType(type.getType()));
+    return deserialize(content, objectMapper.constructType(type.getType()));
   }
 
   /**
@@ -88,7 +97,7 @@ public class ObjectSerializer {
    * @throws IOException In case content cannot be deserialized.
    */
   public <T> T deserialize(byte[] content, Class<T> clazz) throws IOException {
-    return deserialize(content, OBJECT_MAPPER.constructType(clazz));
+    return deserialize(content, objectMapper.constructType(clazz));
   }
 
   private <T> T deserialize(byte[] content, JavaType javaType) throws IOException {
@@ -130,7 +139,7 @@ public class ObjectSerializer {
       }
     }
 
-    return OBJECT_MAPPER.readValue(content, javaType);
+    return objectMapper.readValue(content, javaType);
   }
 
   /**
@@ -141,7 +150,7 @@ public class ObjectSerializer {
    * @throws IOException In case content cannot be parsed.
    */
   public JsonNode parseNode(byte[] content) throws IOException {
-    return  OBJECT_MAPPER.readTree(content);
+    return  objectMapper.readTree(content);
   }
 
   /**
@@ -153,7 +162,7 @@ public class ObjectSerializer {
    * @return Result as corresponding type.
    * @throws IOException if cannot deserialize primitive time.
    */
-  private static <T> T deserializePrimitives(byte[] content, JavaType javaType) throws IOException {
+  private <T> T deserializePrimitives(byte[] content, JavaType javaType) throws IOException {
     if ((content == null) || (content.length == 0)) {
       if (javaType.hasRawClass(boolean.class)) {
         return (T) Boolean.FALSE;
@@ -190,6 +199,6 @@ public class ObjectSerializer {
       return null;
     }
 
-    return OBJECT_MAPPER.readValue(content, javaType);
+    return objectMapper.readValue(content, javaType);
   }
 }

--- a/sdk/src/main/java/io/dapr/serializer/DefaultObjectSerializer.java
+++ b/sdk/src/main/java/io/dapr/serializer/DefaultObjectSerializer.java
@@ -5,6 +5,7 @@
 
 package io.dapr.serializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dapr.client.ObjectSerializer;
 import io.dapr.utils.TypeRef;
 
@@ -14,6 +15,13 @@ import java.io.IOException;
  * Default serializer/deserializer for request/response objects and for state objects too.
  */
 public class DefaultObjectSerializer extends ObjectSerializer implements DaprObjectSerializer {
+  public DefaultObjectSerializer() {
+    super();
+  }
+
+  public DefaultObjectSerializer(ObjectMapper objectMapper) {
+    super(objectMapper);
+  }
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
# Description

allow supplied ObjectMapper to DefaultObjectSerializer so that JSON serialization behaviour can be customised

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #496 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
