### PR TITLE
remove protoc-jar-maven-plugin as dependency for sdk-autogen

### DIFF
--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -48,11 +48,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.os72</groupId>
-      <artifactId>protoc-jar-maven-plugin</artifactId>
-      <version>3.11.4</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>1.33.1</version>


### PR DESCRIPTION
# Description

remove protoc-jar-maven-plugin as dependency for sdk-autogen
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #501 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
