### PR TITLE
Use Mono.empty() instead of a State with null value

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientGrpc.java
@@ -376,10 +376,10 @@ public class DaprClientGrpc extends AbstractDaprClient {
       TypeRef<T> type) throws IOException {
     ByteString payload = response.getData();
     byte[] data = payload == null ? null : payload.toByteArray();
-    T value = stateSerializer.deserialize(data, type);
-    if (value == null) {
+    if (data == null || data.length == 0) {
       return Mono.empty();
     }
+    T value = stateSerializer.deserialize(data, type);
     String etag = response.getEtag();
     if (etag.equals("")) {
       etag = null;

--- a/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientHttp.java
@@ -516,10 +516,10 @@ public class DaprClientHttp extends AbstractDaprClient {
   private <T> Mono<State<T>> buildState(
       DaprHttp.Response response, String requestedKey, StateOptions stateOptions, TypeRef<T> type) throws IOException {
     // The state is in the body directly, so we use the state serializer here.
-    T value = stateSerializer.deserialize(response.getBody(), type);
-    if (value == null) {
+    if (response.getBody() == null || response.getBody().length == 0) {
       return Mono.empty();
     }
+    T value = stateSerializer.deserialize(response.getBody(), type);
     String etag = null;
     if (response.getHeaders() != null && response.getHeaders().containsKey("Etag")) {
       etag = response.getHeaders().get("Etag");


### PR DESCRIPTION
# Description

Use Mono.empty() instead of a State with null value

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #524 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
