### PR TITLE
Add pause between stopping/starting runtime

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
@@ -12,7 +12,6 @@ import io.dapr.it.AppRun;
 import io.dapr.it.BaseIT;
 import io.dapr.it.DaprRun;
 import io.dapr.it.actors.app.MyActorService;
-import io.dapr.it.state.GRPCStateClientIT;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.After;
 import org.junit.Before;
@@ -20,7 +19,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -98,12 +97,18 @@ public class ActorReminderRecoveryIT extends BaseIT {
     // Restarts runtime only.
     logger.info("Stopping Dapr sidecar");
     runs.right.stop();
+
+    // Pause a bit to let placements settle.
+    logger.info("Pausing 10 seconds to let placements settle.");
+    Thread.sleep(Duration.ofSeconds(10).toMillis());
+
     logger.info("Starting Dapr sidecar");
     runs.right.start();
     logger.info("Dapr sidecar started");
 
     logger.info("Pausing 7 seconds to allow sidecar to be healthy");
     Thread.sleep(7000);
+
     callWithRetry(() -> {
       logger.info("Fetching logs for " + METHOD_NAME);
       List<MethodEntryTracker> newLogs = fetchMethodCallLogs(proxy);

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorTimerRecoveryIT.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -24,7 +25,6 @@ import java.util.UUID;
 import static io.dapr.it.Retry.callWithRetry;
 import static io.dapr.it.actors.MyActorTestUtils.fetchMethodCallLogs;
 import static io.dapr.it.actors.MyActorTestUtils.validateMethodCalls;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class ActorTimerRecoveryIT extends BaseIT {
@@ -72,6 +72,11 @@ public class ActorTimerRecoveryIT extends BaseIT {
 
     // Restarts app only.
     runs.left.stop();
+
+    // Pause a bit to let placements settle.
+    logger.info("Pausing 10 seconds to let placements settle.");
+    Thread.sleep(Duration.ofSeconds(10).toMillis());
+
     runs.left.start();
 
     logger.debug("Pausing 10 seconds to allow timer to fire");


### PR DESCRIPTION
# Description
ActorReminderRecoveryIT and ActorTimerRecoveryIT both rely on reminders/timers being persisted when dapr restarts. On some restarts, it appears that the placement service shares its placement table during on ongoing update. This causes the dapr runtime to use the wrong address for the actor.

Placement service logs:
```
INFO[0322] Entering removeMember()                       instance=Hals-MacBook-Pro.local scope=dapr.placement.raft type=log ver=edge
INFO[0322] Loading: 192.168.0.219:50394, 0, 0, ActorReminderRecoveryIT  instance=Hals-MacBook-Pro.local scope=dapr.placement.raft type=log ver=edge
INFO[0322] Loading: 192.168.0.219:50489, 0, 0, ActorReminderRecoveryIT  instance=Hals-MacBook-Pro.local scope=dapr.placement.raft type=log ver=edge
INFO[0322] Start desseminating tables. memberUpdateCount: 1, streams: 2, targets: 2, table generation: 10  instance=Hals-MacBook-Pro.local scope=dapr.placement type=log ver=edge
INFO[0322] Removing 192.168.0.219:50394                  instance=Hals-MacBook-Pro.local scope=dapr.placement.raft type=log ver=edge
INFO[0322] Completed dessemination. memberUpdateCount: 1, streams: 2, targets: 2, table generation: 10  instance=Hals-MacBook-Pro.local scope=dapr.placement type=log ver=edge
```

```
java.lang.RuntimeException: io.dapr.exceptions.DaprException: INTERNAL: error invoke actor method: failed to invoke target 192.168.0.219:50394 after 3 retries
```

When this interleaving happens, the error message received references the actor with the port that was being removed. This implies that the table isn't being updated appropriately and the runtime gets the old port. When the actor is receiving continuous calls, the placement service does not update the location as it believes the actor is busy.

## Issue reference
Closes: #425

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
