### PR TITLE
Revert "Adjusted the configuration of Maven. (#532)"

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,7 @@
 <project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -10,8 +10,10 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
 
+  <groupId>io.dapr</groupId>
   <artifactId>dapr-sdk-examples</artifactId>
   <packaging>jar</packaging>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dapr-sdk-examples</name>
 
   <properties>
@@ -29,39 +31,53 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
+      <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.os72</groupId>
+      <artifactId>protoc-jar-maven-plugin</artifactId>
+      <version>3.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.3.5.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.3.5.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
@@ -81,29 +97,35 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <version>RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>3.6.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-console-standalone</artifactId>
+      <version>1.7.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-springboot</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-actors</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
@@ -145,6 +167,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <release>11</release>
         </configuration>
@@ -159,6 +182,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
+        <version>3.9.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -166,7 +190,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${springboot.version}</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.dapr</groupId>
@@ -14,62 +14,17 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <grpc.version>1.33.1</grpc.version>
+    <protobuf.version>3.13.0</protobuf.version>
+    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.1.0-rc.1/dapr/proto</dapr.proto.baseurl>
+    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.deploy.skip>true</maven.deploy.skip>
-
-    <!--dependencies-->
-    <grpc.version>1.33.1</grpc.version>
-    <protobuf.version>3.13.0</protobuf.version>
-    <json-path.version>2.4.0</json-path.version>
-    <jackson-databind.version>2.11.3</jackson-databind.version>
-
-    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <reactor-core.version>3.3.11.RELEASE</reactor-core.version>
-    <okhttp.version>4.9.0</okhttp.version>
-    <springboot.version>2.3.5.RELEASE</springboot.version>
-
-
-    <grpc-testing.version>1.33.1</grpc-testing.version>
-    <okhttp-mock.version>1.3.2</okhttp-mock.version>
-    <commons-cli.version>1.4</commons-cli.version>
-    <system-rules.version>1.19.0</system-rules.version>
-    <jackson-dataformat-xml.version>2.11.3</jackson-dataformat-xml.version>
-
-    <mockito-core.version>3.6.0</mockito-core.version>
-
-    <junit.version>4.13.1</junit.version>
-    <junit-platform-console-standalone.version>1.7.0</junit-platform-console-standalone.version>
-    <junit-jupiter.version>RELEASE</junit-jupiter.version>
-    <junit-jupiter-engine.version>5.7.0</junit-jupiter-engine.version>
-
-
-    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.1.0-rc.1/dapr/proto</dapr.proto.baseurl>
-
-    <!--plugins-->
-    <download-maven-plugin.version>1.6.0</download-maven-plugin.version>
-    <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
-    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
-    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-    <failsafe-maven-plugin.version>2.4.3-alpha-1</failsafe-maven-plugin.version>
-    <checkstyle.version>8.37</checkstyle.version>
-    <spotbugs-maven-plugin.version>4.1.4</spotbugs-maven-plugin.version>
-    <spotbugs.version>4.0.0-RC1</spotbugs.version>
-
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
-    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
-    <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
-    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
-    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-
-
     <gpg.skip>true</gpg.skip>
+    <spotbugs.version>4.0.0-RC1</spotbugs.version>
     <spotbugs.fail>true</spotbugs.fail>
   </properties>
 
@@ -92,109 +47,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk-examples</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk-autogen</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk-actors</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk-springboot</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-console-standalone</artifactId>
-        <version>${junit-platform-console-standalone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-testing</artifactId>
-        <version>${grpc-testing.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${springboot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java-util</artifactId>
-        <version>${protobuf.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter-engine.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.stefanbirkner</groupId>
-        <artifactId>system-rules</artifactId>
-        <version>${system-rules.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.gmazzo</groupId>
-        <artifactId>okhttp-mock</artifactId>
-        <version>${okhttp-mock.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-cli</groupId>
-        <artifactId>commons-cli</artifactId>
-        <version>${commons-cli.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.jayway.jsonpath</groupId>
-        <artifactId>json-path</artifactId>
-        <version>${json-path.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-xml</artifactId>
-        <version>${jackson-dataformat-xml.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.projectreactor</groupId>
-        <artifactId>reactor-core</artifactId>
-        <version>${reactor-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
         <version>${grpc.version}</version>
@@ -209,211 +61,158 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>4.13.1</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${javax.annotation-api.version}</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>3.6.0</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>${maven-source-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>${maven-deploy-plugin.version}</version>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${jacoco-maven-plugin.version}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>report</id>
-              <phase>test</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>com.googlecode.maven-download-plugin</groupId>
-          <artifactId>download-maven-plugin</artifactId>
-          <version>${download-maven-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>${maven-gpg-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>sign-artifacts</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>sign</goal>
-              </goals>
-              <configuration>
-                <gpgArguments>
-                  <arg>--batch</arg>
-                  <arg>--pinentry-mode</arg>
-                  <arg>loopback</arg>
-                </gpgArguments>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>com.github.os72</groupId>
-          <artifactId>protoc-jar-maven-plugin</artifactId>
-          <version>${protoc-jar-maven-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>failsafe-maven-plugin</artifactId>
-          <version>${failsafe-maven-plugin.version}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-              <configuration>
-                <!--suppress UnresolvedMavenProperty -->
-                <skip>${skipITs}</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${maven-checkstyle-plugin.version}</version>
-          <configuration>
-            <configLocation>checkstyle.xml</configLocation>
-            <encoding>UTF-8</encoding>
-            <consoleOutput>true</consoleOutput>
-            <violationSeverity>warning</violationSeverity>
-            <failOnViolation>true</failOnViolation>
-            <failsOnError>true</failsOnError>
-            <linkXRef>false</linkXRef>
-          </configuration>
-          <executions>
-            <execution>
-              <id>validate</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-          <dependencies>
-            <dependency>
-              <groupId>com.puppycrawl.tools</groupId>
-              <artifactId>checkstyle</artifactId>
-              <version>${checkstyle.version}</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>${spotbugs-maven-plugin.version}</version>
-          <dependencies>
-            <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-            <dependency>
-              <groupId>com.github.spotbugs</groupId>
-              <artifactId>spotbugs</artifactId>
-              <version>${spotbugs.version}</version>
-            </dependency>
-          </dependencies>
-          <configuration>
-            <failOnError>${spotbugs.fail}</failOnError>
-            <xmlOutput>true</xmlOutput>
-          </configuration>
-          <executions>
-            <execution>
-              <id>validate</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>${maven-site-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
-        </plugin>
-
-      </plugins>
-    </pluginManagement>
-
-
+    <plugins>
+      <plugin>
+	<groupId>org.jacoco</groupId>
+	<artifactId>jacoco-maven-plugin</artifactId>
+	<version>0.8.6</version>
+	<executions>
+	  <execution>
+	    <goals>
+	      <goal>prepare-agent</goal>
+	    </goals>
+	  </execution>
+	  <execution>
+	    <id>report</id>
+	    <phase>test</phase>
+	    <goals>
+	      <goal>report</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <gpgArguments>
+                <arg>--batch</arg>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>failsafe-maven-plugin</artifactId>
+        <version>2.4.3-alpha-1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <!--suppress UnresolvedMavenProperty -->
+              <skip>${skipITs}</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <configLocation>checkstyle.xml</configLocation>
+          <encoding>UTF-8</encoding>
+          <consoleOutput>true</consoleOutput>
+          <violationSeverity>warning</violationSeverity>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+          <linkXRef>false</linkXRef>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.37</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.1.4</version>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${spotbugs.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <failOnError>${spotbugs.fail}</failOnError>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.8.2</version>
+      </plugin>
+    </plugins>
   </build>
-
-  <profiles>
-
-  </profiles>
 
   <reporting>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>${maven-project-info-reports-plugin.version}</version>
+        <version>2.9</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -424,6 +223,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <reportSets>
           <reportSet>
             <id>aggregate</id>
@@ -437,9 +237,7 @@
           <failOnWarnings>false</failOnWarnings>
           <failOnError>true</failOnError>
           <goal>site</goal>
-          <excludePackageNames>
-            io.dapr.examples:io.dapr.springboot:io.dapr.examples.*:io.dapr.springboot.*
-          </excludePackageNames>
+          <excludePackageNames>io.dapr.examples:io.dapr.springboot:io.dapr.examples.*:io.dapr.springboot.*</excludePackageNames>
         </configuration>
       </plugin>
     </plugins>
@@ -462,9 +260,9 @@
   </developers>
 
   <scm>
-    <url>https://github.com/dapr/java-sdk</url>
-    <connection>scm:git:https://github.com/dapr/java-sdk.git</connection>
-    <tag>HEAD</tag>
+      <url>https://github.com/dapr/java-sdk</url>
+      <connection>scm:git:https://github.com/dapr/java-sdk.git</connection>
+      <tag>HEAD</tag>
   </scm>
 
   <modules>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -12,6 +12,7 @@
 
   <artifactId>dapr-sdk-actors</artifactId>
   <packaging>jar</packaging>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dapr-sdk-actors</name>
   <description>SDK for Actors on Dapr</description>
 
@@ -34,6 +35,7 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -45,24 +47,28 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.gmazzo</groupId>
-      <artifactId>okhttp-mock</artifactId>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>com.github.gmazzo</groupId>
+          <artifactId>okhttp-mock</artifactId>
+          <version>1.3.2</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.3.5.RELEASE</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -72,6 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -85,6 +92,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -97,6 +105,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>
@@ -124,7 +133,7 @@
                 <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <limit>
+                   <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>80%</minimum>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -12,6 +12,7 @@
 
   <artifactId>dapr-sdk-autogen</artifactId>
   <packaging>jar</packaging>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dapr-sdk-autogen</name>
   <description>Auto-generated SDK for Dapr</description>
 
@@ -25,6 +26,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -45,6 +47,11 @@
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>1.33.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -52,6 +59,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
+        <version>1.6.0</version>
         <executions>
           <execution>
             <id>getCommonProto</id>
@@ -100,6 +108,7 @@
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.11.4</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -133,6 +142,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -145,6 +155,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/sdk-springboot/pom.xml
+++ b/sdk-springboot/pom.xml
@@ -12,6 +12,7 @@
 
   <artifactId>dapr-sdk-springboot</artifactId>
   <packaging>jar</packaging>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dapr-sdk-springboot</name>
   <description>SDK extension for Springboot</description>
 
@@ -28,6 +29,7 @@
 
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>
+    <springboot.version>2.3.5.RELEASE</springboot.version>
   </properties>
 
   <dependencyManagement>
@@ -46,10 +48,12 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-actors</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -61,31 +65,42 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.gmazzo</groupId>
-      <artifactId>okhttp-mock</artifactId>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>com.github.gmazzo</groupId>
+          <artifactId>okhttp-mock</artifactId>
+          <version>1.3.2</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
+      <version>5.2.10.RELEASE</version>
       <scope>compile</scope>
     </dependency>
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-web</artifactId>
+          <version>5.2.10.RELEASE</version>
+          <scope>compile</scope>
+      </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
+      <version>5.2.10.RELEASE</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <scope>compile</scope>
-    </dependency>
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+          <version>5.2.10.RELEASE</version>
+          <scope>compile</scope>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
@@ -104,6 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -117,6 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -129,6 +146,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>
@@ -156,7 +174,7 @@
                 <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <limit>
+                   <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>80%</minimum>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -12,9 +12,10 @@
 
   <artifactId>dapr-sdk</artifactId>
   <packaging>jar</packaging>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dapr-sdk</name>
   <description>SDK for Dapr</description>
-
+  
   <repositories>
     <repository>
       <snapshots>
@@ -34,18 +35,22 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-autogen</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
+      <version>3.3.11.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>4.9.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -60,41 +65,49 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
+      <version>2.11.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.gmazzo</groupId>
       <artifactId>okhttp-mock</artifactId>
+      <version>1.3.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.3.5.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.3.5.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
+      <version>1.33.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -104,6 +117,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -116,6 +130,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -128,6 +143,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>
@@ -155,7 +171,7 @@
                 <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <limit>
+                   <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>80%</minimum>


### PR DESCRIPTION
This reverts commit 5cc79811cb9edb673a394917eee261deef24944c.

# Description

Reverting since this change caused release to skip deploying artifacts:

```txt

1338[INFO] --- maven-deploy-plugin:2.7:deploy (default-deploy) @ dapr-sdk-springboot --- 
1339[INFO] Skipping artifact deployment 
1340[INFO] ------------------------------------------------------------------------ 
1341[INFO] Reactor Summary for dapr-sdk-parent 1.1.0-SNAPSHOT: 
1342[INFO] 
1343[INFO] dapr-sdk-parent .................................... SUCCESS [ 1.011 s] 
1344[INFO] dapr-sdk-autogen ................................... SUCCESS [ 3.947 s] 
1345[INFO] dapr-sdk ........................................... SUCCESS [ 9.805 s] 
1346[INFO] dapr-sdk-actors .................................... SUCCESS [ 7.481 s] 
1347[INFO] dapr-sdk-springboot ................................ SUCCESS [ 0.340 s] 
1348[INFO] ------------------------------------------------------------------------ 
1349[INFO] BUILD SUCCESS 
1350[INFO] ------------------------------------------------------------------------ 
1351[INFO] Total time: 22.864 s 
1352[INFO] Finished at: 2021-04-29T23:54:46Z 
1353[INFO] -----------------------------------------------------------------------

```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

This will reopen: #531

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
