### PR TITLE
Remove no Longer Needed External Maven Repositories From README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,6 @@ For a Maven project, add the following to your `pom.xml` file:
 ```xml
 <project>
   ...
-  <repositories>
-    ...
-    <!-- BEGIN: Dapr's repositories -->
-    <repository>
-      <id>oss-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-    <repository>
-      <id>oss-release</id>
-      <url>https://oss.sonatype.org/content/repositories/releases/</url>
-    </repository>
-    <!-- END: Dapr's repositories -->
-    ...
-  </repositories>
-  ...
   <dependencies>
     ...
      <!-- Dapr's core SDK with all features, except Actors. -->

--- a/README.md
+++ b/README.md
@@ -73,20 +73,6 @@ For a Maven project, add the following to your `pom.xml` file:
 For a Gradle project, add the following to your `build.gradle` file:
 
 ```
-repositories {
-    ...
-    // Dapr repositories
-    maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots"
-	  mavenContent {
-	    snapshotsOnly()
-	  }
-    }
-    maven {
-	  url "https://oss.sonatype.org/content/repositories/releases/"
-    }
-}
-...
 dependencies {
 ...
     // Dapr's core SDK with all features, except Actors.


### PR DESCRIPTION
# Description

The Dapr Java SDK no longer needs external repositories to be downloaded using Maven or Gradle.
They have been removed from the README.

## Issue reference

Fixes #550

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
