### PR TITLE
Declare CloudEvent generic to allow automatic payload deserialization using Jackson

### DIFF
--- a/daprdocs/content/en/java-sdk-docs/_index.md
+++ b/daprdocs/content/en/java-sdk-docs/_index.md
@@ -150,7 +150,7 @@ public class SubscriberController {
 
   @Topic(name = "testingtopic", pubsubName = "${myAppProperty:messagebus}")
   @PostMapping(path = "/testingtopic")
-  public Mono<Void> handleMessage(@RequestBody(required = false) CloudEvent cloudEvent) {
+  public Mono<Void> handleMessage(@RequestBody(required = false) CloudEvent<?> cloudEvent) {
     return Mono.fromRunnable(() -> {
       try {
         System.out.println("Subscriber got: " + cloudEvent.getData());

--- a/examples/src/main/java/io/dapr/examples/pubsub/http/CloudEventPublisher.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/http/CloudEventPublisher.java
@@ -47,7 +47,7 @@ public class CloudEventPublisher {
     //Creating the DaprClient: Using the default builder client produces an HTTP Dapr Client
     try (DaprClient client = new DaprClientBuilder().build()) {
       for (int i = 0; i < NUM_MESSAGES; i++) {
-        CloudEvent cloudEvent = new CloudEvent();
+        CloudEvent<String> cloudEvent = new CloudEvent<>();
         cloudEvent.setId(UUID.randomUUID().toString());
         cloudEvent.setType("example");
         cloudEvent.setSpecversion("1");

--- a/examples/src/main/java/io/dapr/examples/pubsub/http/SubscriberController.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/http/SubscriberController.java
@@ -28,7 +28,7 @@ public class SubscriberController {
    */
   @Topic(name = "testingtopic", pubsubName = "${myAppProperty:messagebus}")
   @PostMapping(path = "/testingtopic")
-  public Mono<Void> handleMessage(@RequestBody(required = false) CloudEvent cloudEvent) {
+  public Mono<Void> handleMessage(@RequestBody(required = false) CloudEvent<String> cloudEvent) {
     return Mono.fromRunnable(() -> {
       try {
         System.out.println("Subscriber got: " + cloudEvent.getData());

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -31,6 +31,7 @@
     <grpc.version>1.39.0</grpc.version>
     <protobuf.version>3.13.0</protobuf.version>
     <opentelemetry.version>0.14.0</opentelemetry.version>
+    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencies>
@@ -112,13 +113,13 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.3.5.RELEASE</version>
+      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>2.3.5.RELEASE</version>
+      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
+++ b/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
@@ -26,10 +26,17 @@ public class SubscriberController {
   private static final List<CloudEvent> messagesReceivedBinaryTopic = new ArrayList();
   private static final List<CloudEvent> messagesReceivedAnotherTopic = new ArrayList();
   private static final List<CloudEvent> messagesReceivedTTLTopic = new ArrayList();
+  private static final List<CloudEvent<PubSubIT.MyObject>> typedMessagesReceivedTopic = new ArrayList<>();
 
   @GetMapping(path = "/messages/testingtopic")
   public List<CloudEvent> getMessagesReceivedTestingTopic() {
     return messagesReceivedTestingTopic;
+  }
+
+  @GetMapping(path = "/messages/typedtestingtopic")
+  public List<CloudEvent<PubSubIT.MyObject>> getMessagesReceivedTypedTestingTopic() {
+    System.out.println("Returning " + typedMessagesReceivedTopic.size() + " messages from typedtestingtopic: " + typedMessagesReceivedTopic);
+    return typedMessagesReceivedTopic;
   }
 
   @GetMapping(path = "/messages/binarytopic")
@@ -56,6 +63,21 @@ public class SubscriberController {
         String contentType = envelope.getDatacontenttype() == null ? "" : envelope.getDatacontenttype();
         System.out.println("Testing topic Subscriber got message: " + message + "; Content-type: " + contentType);
         messagesReceivedTestingTopic.add(envelope);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Topic(name = "typedtestingtopic", pubsubName = "messagebus")
+  @PostMapping(path = "/route1b")
+  public Mono<Void> handleMessageTyped(@RequestBody(required = false) CloudEvent<PubSubIT.MyObject> envelope) {
+    return Mono.fromRunnable(() -> {
+      try {
+        String id = envelope.getData() == null ? "" : envelope.getData().getId();
+        String contentType = envelope.getDatacontenttype() == null ? "" : envelope.getDatacontenttype();
+        System.out.println("Testing typed topic Subscriber got message with ID: " + id + "; Content-type: " + contentType);
+        typedMessagesReceivedTopic.add(envelope);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
+++ b/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
@@ -8,13 +8,17 @@ package io.dapr.it.pubsub.http;
 import io.dapr.Topic;
 import io.dapr.client.domain.CloudEvent;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
  * SpringBoot Controller to handle input binding.
@@ -22,36 +26,11 @@ import java.util.List;
 @RestController
 public class SubscriberController {
 
-  private static final List<CloudEvent> messagesReceivedTestingTopic = new ArrayList();
-  private static final List<CloudEvent> messagesReceivedBinaryTopic = new ArrayList();
-  private static final List<CloudEvent> messagesReceivedAnotherTopic = new ArrayList();
-  private static final List<CloudEvent> messagesReceivedTTLTopic = new ArrayList();
-  private static final List<CloudEvent<PubSubIT.MyObject>> typedMessagesReceivedTopic = new ArrayList<>();
+  private final Map<String, List<CloudEvent<?>>> messagesByTopic = new HashMap<>();
 
-  @GetMapping(path = "/messages/testingtopic")
-  public List<CloudEvent> getMessagesReceivedTestingTopic() {
-    return messagesReceivedTestingTopic;
-  }
-
-  @GetMapping(path = "/messages/typedtestingtopic")
-  public List<CloudEvent<PubSubIT.MyObject>> getMessagesReceivedTypedTestingTopic() {
-    System.out.println("Returning " + typedMessagesReceivedTopic.size() + " messages from typedtestingtopic: " + typedMessagesReceivedTopic);
-    return typedMessagesReceivedTopic;
-  }
-
-  @GetMapping(path = "/messages/binarytopic")
-  public List<CloudEvent> getMessagesReceivedBinaryTopic() {
-    return messagesReceivedBinaryTopic;
-  }
-
-  @GetMapping(path = "/messages/anothertopic")
-  public List<CloudEvent> getMessagesReceivedAnotherTopic() {
-    return messagesReceivedAnotherTopic;
-  }
-
-  @GetMapping(path = "/messages/ttltopic")
-  public List<CloudEvent> getMessagesReceivedTTLTopic() {
-    return messagesReceivedTTLTopic;
+  @GetMapping(path = "/messages/{topic}")
+  public List<CloudEvent<?>> getMessagesByTopic(@PathVariable("topic") String topic) {
+    return messagesByTopic.get(topic);
   }
 
   @Topic(name = "testingtopic", pubsubName = "messagebus")
@@ -62,7 +41,7 @@ public class SubscriberController {
         String message = envelope.getData() == null ? "" : envelope.getData().toString();
         String contentType = envelope.getDatacontenttype() == null ? "" : envelope.getDatacontenttype();
         System.out.println("Testing topic Subscriber got message: " + message + "; Content-type: " + contentType);
-        messagesReceivedTestingTopic.add(envelope);
+        messagesByTopic.compute("testingtopic", merge(envelope));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -77,7 +56,7 @@ public class SubscriberController {
         String id = envelope.getData() == null ? "" : envelope.getData().getId();
         String contentType = envelope.getDatacontenttype() == null ? "" : envelope.getDatacontenttype();
         System.out.println("Testing typed topic Subscriber got message with ID: " + id + "; Content-type: " + contentType);
-        typedMessagesReceivedTopic.add(envelope);
+        messagesByTopic.compute("typedtestingtopic", merge(envelope));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -92,7 +71,7 @@ public class SubscriberController {
         String message = envelope.getData() == null ? "" : envelope.getData().toString();
         String contentType = envelope.getDatacontenttype() == null ? "" : envelope.getDatacontenttype();
         System.out.println("Binary topic Subscriber got message: " + message + "; Content-type: " + contentType);
-        messagesReceivedBinaryTopic.add(envelope);
+        messagesByTopic.compute("binarytopic", merge(envelope));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -106,7 +85,7 @@ public class SubscriberController {
       try {
         String message = envelope.getData() == null ? "" : envelope.getData().toString();
         System.out.println("Another topic Subscriber got message: " + message);
-        messagesReceivedAnotherTopic.add(envelope);
+        messagesByTopic.compute("anothertopic", merge(envelope));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -120,11 +99,18 @@ public class SubscriberController {
       try {
         String message = envelope.getData() == null ? "" : envelope.getData().toString();
         System.out.println("TTL topic Subscriber got message: " + message);
-        messagesReceivedTTLTopic.add(envelope);
+        messagesByTopic.compute("ttltopic", merge(envelope));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
     });
   }
 
+  private BiFunction<String, List<CloudEvent<?>>, List<CloudEvent<?>>> merge(final CloudEvent<?> item) {
+    return (key, value) -> {
+      final List<CloudEvent<?>> list = value == null ? new ArrayList<>() : value;
+      list.add(item);
+      return list;
+    };
+  }
 }

--- a/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
+++ b/sdk-tests/src/test/java/io/dapr/it/pubsub/http/SubscriberController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,7 @@ public class SubscriberController {
 
   @GetMapping(path = "/messages/{topic}")
   public List<CloudEvent<?>> getMessagesByTopic(@PathVariable("topic") String topic) {
-    return messagesByTopic.get(topic);
+    return messagesByTopic.getOrDefault(topic, Collections.emptyList());
   }
 
   @Topic(name = "testingtopic", pubsubName = "messagebus")

--- a/sdk-tests/src/test/resources/logback.xml
+++ b/sdk-tests/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d {HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/sdk/src/main/java/io/dapr/client/domain/CloudEvent.java
+++ b/sdk/src/main/java/io/dapr/client/domain/CloudEvent.java
@@ -16,8 +16,9 @@ import java.util.Objects;
 
 /**
  * A cloud event in Dapr.
+ * @param <T> The type of the payload.
  */
-public final class CloudEvent {
+public final class CloudEvent<T> {
 
   /**
    * Mime type used for CloudEvent.
@@ -59,7 +60,7 @@ public final class CloudEvent {
   /**
    * Cloud event specs says data can be a JSON object or string.
    */
-  private Object data;
+  private T data;
 
   /**
    * Cloud event specs says binary data should be in data_base64.
@@ -88,7 +89,7 @@ public final class CloudEvent {
       String type,
       String specversion,
       String datacontenttype,
-      Object data) {
+      T data) {
     this.id = id;
     this.source = source;
     this.type = type;
@@ -126,7 +127,7 @@ public final class CloudEvent {
    * @return Message (can be null if input is null)
    * @throws IOException If cannot parse.
    */
-  public static CloudEvent deserialize(byte[] payload) throws IOException {
+  public static CloudEvent<?> deserialize(byte[] payload) throws IOException {
     if (payload == null) {
       return null;
     }
@@ -218,7 +219,7 @@ public final class CloudEvent {
    * Gets the cloud event data.
    * @return Cloud event's data. As per specs, data can be a JSON object or string.
    */
-  public Object getData() {
+  public T getData() {
     return data;
   }
 
@@ -226,7 +227,7 @@ public final class CloudEvent {
    * Sets the cloud event data. As per specs, data can be a JSON object or string.
    * @param data Cloud event's data. As per specs, data can be a JSON object or string.
    */
-  public void setData(Object data) {
+  public void setData(T data) {
     this.data = data;
   }
 
@@ -257,7 +258,7 @@ public final class CloudEvent {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    CloudEvent that = (CloudEvent) o;
+    CloudEvent<?> that = (CloudEvent<?>) o;
     return Objects.equals(id, that.id)
         && Objects.equals(source, that.source)
         && Objects.equals(type, that.type)


### PR DESCRIPTION
# Description
I've made the `CloudEvent` class a generic class, meaning its instance variable `data` is now of a generic type `<T>`. This allows Spring Boot controller methods to accept an argument `CloudEvent<MyPayload>`, which will make the code inside that controller method a lot easier as the `MyPayload` object will automatically be populated from a JSON payload.

At runtime, this generic type `<T>` resorts to `Object`, which I believe makes this backward compatible. The existing tests are all green which supports this claim.

Also, I did a small refactoring in the Spring Boot _Rest Controller_ that the `PubSubIT` uses to make it easier to maintain. 

## Issue reference

This closes #576.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
