### PR TITLE
Update dapr and proto version to 1.4 RCs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       JDK_VER: ${{ matrix.java }}
-      DAPR_CLI_VER: 1.3.0-rc.1
-      DAPR_RUNTIME_VER: 1.3.0-rc.1
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.3.0-rc.1/install/install.sh
+      DAPR_CLI_VER: 1.4.0-rc.1
+      DAPR_RUNTIME_VER: 1.4.0-rc.6
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.4.0-rc.1/install/install.sh
       DAPR_CLI_REF:
       DAPR_REF:
       OSSRH_USER_TOKEN: ${{ secrets.OSSRH_USER_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         echo "DEPLOY_OSSRH=true" >> $GITHUB_ENV
     - name: Publish to ossrh
-      if: env.DEPLOY_OSSRH == 'true'
+      if: env.DEPLOY_OSSRH == 'true' && env.JDK_VER == '11'
       run: |
         echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d > private-key.gpg
         export GPG_TTY=$(tty)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,9 +30,9 @@ jobs:
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       JDK_VER: ${{ matrix.java }}
-      DAPR_CLI_VER: 1.3.0-rc.1
-      DAPR_RUNTIME_VER: 1.3.0-rc.1
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/3dacfb672d55f1436c249057aaebbe597e1066f3/install/install.sh
+      DAPR_CLI_VER: 1.4.0-rc.1
+      DAPR_RUNTIME_VER: 1.4.0-rc.6
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.4.0-rc.1/install/install.sh
       DAPR_CLI_REF:
       DAPR_REF:
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.39.0</grpc.version>
     <protobuf.version>3.13.0</protobuf.version>
-    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.3.0-rc.1/dapr/proto</dapr.proto.baseurl>
+    <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.4.0-rc.6/dapr/proto</dapr.proto.baseurl>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>


### PR DESCRIPTION
# Description

Update dapr and proto version to 1.4 RCs.
Fixes publish step to only run on JDK 11.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: endgame

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
