### PR TITLE
Migrated out of JCenter as a Maven repository manager

### DIFF
--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -16,17 +16,6 @@
   <name>dapr-sdk-actors</name>
   <description>SDK for Actors on Dapr</description>
 
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
-
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>
     <grpc.version>1.39.0</grpc.version>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
           <groupId>com.github.gmazzo</groupId>
           <artifactId>okhttp-mock</artifactId>
-          <version>1.3.2</version>
+          <version>1.4.1</version>
           <scope>test</scope>
       </dependency>
     <dependency>

--- a/sdk-springboot/pom.xml
+++ b/sdk-springboot/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.github.gmazzo</groupId>
       <artifactId>okhttp-mock</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk-springboot/pom.xml
+++ b/sdk-springboot/pom.xml
@@ -16,17 +16,6 @@
   <name>dapr-sdk-springboot</name>
   <description>SDK extension for Springboot</description>
 
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
-
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>
     <springboot.version>2.3.5.RELEASE</springboot.version>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -9,17 +9,6 @@
   <version>0.0.0-SNAPSHOT</version>
   <name>dapr-sdk-tests</name>
   <description>Tests for Dapr's Java SDK - not to be published as a jar.</description>
-  
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.github.gmazzo</groupId>
       <artifactId>okhttp-mock</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -15,17 +15,6 @@
   <version>1.4.0-SNAPSHOT</version>
   <name>dapr-sdk</name>
   <description>SDK for Dapr</description>
-  
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
 
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>


### PR DESCRIPTION
# Description

There was one artifact (`com.github.gmazzo:okhttp-mock:1.3.2`) used for tests. That artifact wasn't deployed to Maven Central, only to JCenter. I've upgraded that one to the latest version (1.4.1) which is available in Maven Central.

## Issue reference

Closes #608.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] ~~Created/updated tests~~
* [ ] ~~Extended the documentation~~
