### PR TITLE
fix github action for dapr comment analyzer bot

### DIFF
--- a/.github/workflows/dapr_bot.yml
+++ b/.github/workflows/dapr_bot.yml
@@ -20,7 +20,8 @@ jobs:
 
             if (!isFromPulls && commentBody && commentBody.indexOf("/assign") == 0) {
               if (!issue.assignees || issue.assignees.length === 0) {
-                await github.issues.addAssignees({
+                // See https://github.com/actions/github-script#breaking-changes-in-v5
+                await github.rest.issues.addAssignees({
                   owner: issue.owner,
                   repo: issue.repo,
                   issue_number: issue.number,


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <msundar.ms@outlook.com>

# Description

Fixing the Github comment analyser Dapr bot workflow. Currently it is failing because with v5 for the GitHub script action, there has been a breaking change - https://github.com/actions/github-script#breaking-changes-in-v5

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
