### PR TITLE
set maxRequestsPerHost of okhttp to support slow response requests and high TPS

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
@@ -14,9 +14,12 @@ limitations under the License.
 package io.dapr.client;
 
 import io.dapr.config.Properties;
+import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A builder for the DaprHttp.
@@ -32,6 +35,13 @@ public class DaprHttpBuilder {
    * Static lock object.
    */
   private static final Object LOCK = new Object();
+
+  /**
+   * HTTP keep alive duration in seconds.
+   *
+   * <p>Just hard code to a reasonable value.
+   */
+  private static final int KEEP_ALIVE_DURATION = 30;
 
   /**
    * Build an instance of the Http client based on the provided setup.
@@ -55,6 +65,19 @@ public class DaprHttpBuilder {
           OkHttpClient.Builder builder = new OkHttpClient.Builder();
           Duration readTimeout = Duration.ofSeconds(Properties.HTTP_CLIENT_READ_TIMEOUT_SECONDS.get());
           builder.readTimeout(readTimeout);
+
+          Dispatcher dispatcher = new Dispatcher();
+          dispatcher.setMaxRequests(Properties.HTTP_CLIENT_MAX_REQUESTS.get());
+          // The maximum number of requests for each host to execute concurrently.
+          // Default value is 5 in okjava which is totally UNACCEPTABLE!
+          // For sidecar case, set it the same as maxRequests.
+          dispatcher.setMaxRequestsPerHost(Properties.HTTP_CLIENT_MAX_REQUESTS.get());
+          builder.dispatcher(dispatcher);
+
+          ConnectionPool pool = new ConnectionPool(Properties.HTTP_CLIENT_MAX_IDLE_CONNECTIONS.get(),
+                  KEEP_ALIVE_DURATION, TimeUnit.SECONDS);
+          builder.connectionPool(pool);
+
           OK_HTTP_CLIENT = builder.build();
         }
       }

--- a/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttpBuilder.java
@@ -69,7 +69,7 @@ public class DaprHttpBuilder {
           Dispatcher dispatcher = new Dispatcher();
           dispatcher.setMaxRequests(Properties.HTTP_CLIENT_MAX_REQUESTS.get());
           // The maximum number of requests for each host to execute concurrently.
-          // Default value is 5 in okjava which is totally UNACCEPTABLE!
+          // Default value is 5 in okhttp which is totally UNACCEPTABLE!
           // For sidecar case, set it the same as maxRequests.
           dispatcher.setMaxRequestsPerHost(Properties.HTTP_CLIENT_MAX_REQUESTS.get());
           builder.dispatcher(dispatcher);

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -56,7 +56,24 @@ public class Properties {
   /**
    * Dapr's default timeout in seconds for HTTP client reads.
    */
-  private static final Integer DEFAULT_HTTP_CLIENT_READTIMEOUTSECONDS = 60;
+  private static final Integer DEFAULT_HTTP_CLIENT_READ_TIMEOUT_SECONDS = 60;
+
+  /**
+   *   The default maximum number of requests to execute concurrently.
+   *
+   *   <p>Above this requests queue in memory, waiting for the running calls to complete.
+   *   Default is 64 in okjava which is OK for most case, but for some special case
+   *   which is slow response and high concurrency, the value should set to a little big.
+   */
+  private static final Integer DEFAULT_HTTP_CLIENT_MAX_REQUESTS = 1024;
+
+  /**
+   *   The default maximum number of idle connections of HTTP connection pool.
+   *
+   *   <p>Attention! This is max IDLE connection, NOT max connection!
+   *   It is also very important for high concurrency cases.
+   */
+  private static final Integer DEFAULT_HTTP_CLIENT_MAX_IDLE_CONNECTIONS = 128;
 
   /**
    * IP for Dapr's sidecar.
@@ -123,5 +140,21 @@ public class Properties {
   public static final Property<Integer> HTTP_CLIENT_READ_TIMEOUT_SECONDS = new IntegerProperty(
       "dapr.http.client.readTimeoutSeconds",
       "DAPR_HTTP_CLIENT_READ_TIMEOUT_SECONDS",
-      DEFAULT_HTTP_CLIENT_READTIMEOUTSECONDS);
+          DEFAULT_HTTP_CLIENT_READ_TIMEOUT_SECONDS);
+
+  /**
+   * Dapr's timeout in seconds for HTTP client reads.
+   */
+  public static final Property<Integer> HTTP_CLIENT_MAX_REQUESTS = new IntegerProperty(
+          "dapr.http.client.maxRequests",
+          "DAPR_HTTP_CLIENT_MAX_REQUESTS",
+          DEFAULT_HTTP_CLIENT_MAX_REQUESTS);
+
+  /**
+   * The default maximum number of idle connections of HTTP connection pool.
+   */
+  public static final Property<Integer> HTTP_CLIENT_MAX_IDLE_CONNECTIONS = new IntegerProperty(
+          "dapr.http.client.maxIdleConnections",
+          "DAPR_HTTP_CLIENT_MAX_IDLE_CONNECTIONS",
+          DEFAULT_HTTP_CLIENT_MAX_IDLE_CONNECTIONS);
 }

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -62,13 +62,13 @@ public class Properties {
    *   Dapr's default maximum number of requests for HTTP client to execute concurrently.
    *
    *   <p>Above this requests queue in memory, waiting for the running calls to complete.
-   *   Default is 64 in okjava which is OK for most case, but for some special case
+   *   Default is 64 in okhttp which is OK for most case, but for some special case
    *   which is slow response and high concurrency, the value should set to a little big.
    */
   private static final Integer DEFAULT_HTTP_CLIENT_MAX_REQUESTS = 1024;
 
   /**
-   *   The default maximum number of idle connections of HTTP connection pool.
+   *   Dapr's default maximum number of idle connections of HTTP connection pool.
    *
    *   <p>Attention! This is max IDLE connection, NOT max connection!
    *   It is also very important for high concurrency cases.
@@ -143,7 +143,7 @@ public class Properties {
           DEFAULT_HTTP_CLIENT_READ_TIMEOUT_SECONDS);
 
   /**
-   * Dapr's timeout in seconds for HTTP client reads.
+   * Dapr's default maximum number of requests for HTTP client to execute concurrently.
    */
   public static final Property<Integer> HTTP_CLIENT_MAX_REQUESTS = new IntegerProperty(
           "dapr.http.client.maxRequests",
@@ -151,7 +151,7 @@ public class Properties {
           DEFAULT_HTTP_CLIENT_MAX_REQUESTS);
 
   /**
-   * The default maximum number of idle connections of HTTP connection pool.
+   * Dapr's default maximum number of idle connections for HTTP connection pool.
    */
   public static final Property<Integer> HTTP_CLIENT_MAX_IDLE_CONNECTIONS = new IntegerProperty(
           "dapr.http.client.maxIdleConnections",

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -59,7 +59,7 @@ public class Properties {
   private static final Integer DEFAULT_HTTP_CLIENT_READ_TIMEOUT_SECONDS = 60;
 
   /**
-   *   The default maximum number of requests to execute concurrently.
+   *   Dapr's default maximum number of requests for HTTP client to execute concurrently.
    *
    *   <p>Above this requests queue in memory, waiting for the running calls to complete.
    *   Default is 64 in okjava which is OK for most case, but for some special case


### PR DESCRIPTION
# Description

In dapr java sdk, there are some default settings in okhttp which we don't set and use the default value:

- maxRequests: default to 64
- maxRequestsPerHost: default to 5! 
- maxIdleConnections

The default value  5 of maxRequestsPerHost is totally unacceptable, it will lead to very serious problems of very low throughput as discribed in issue dapr/java-sdk#709.

And the default value 64 of maxRequests is not enough for the user case of high TPS. For example, if the response time is 100 ms, 64 connections leads to at most 640 TPS. 

## Issue reference

This PR is to fix this issue.

dapr/java-sdk#709

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
