### PR TITLE
fix duration parsing

### DIFF
--- a/sdk/src/test/java/io/dapr/utils/DurationUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/DurationUtilsTest.java
@@ -30,6 +30,76 @@ public class DurationUtilsTest {
   }
 
   @Test
+  public void testParsePartialDurationMillis(){
+    String s = "0h0m0s101ms";
+    String partial = "101ms";
+    Duration d1 = DurationUtils.convertDurationFromDaprFormat(partial);
+
+    String t = DurationUtils.convertDurationToDaprFormat(d1);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testParsePartialDurationSeconds(){
+    String s = "0h0m42s0ms";
+    String partial = "42s";
+    Duration d1 = DurationUtils.convertDurationFromDaprFormat(partial);
+
+    String t = DurationUtils.convertDurationToDaprFormat(d1);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testParsePartialDurationMinutes(){
+    String s = "0h29m0s0ms";
+    String partial = "29m";
+    Duration d1 = DurationUtils.convertDurationFromDaprFormat(partial);
+
+    String t = DurationUtils.convertDurationToDaprFormat(d1);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testParsePartialDurationHours(){
+    String s = "17h0m0s0ms";
+    String partial = "17h";
+    Duration d1 = DurationUtils.convertDurationFromDaprFormat(partial);
+
+    String t = DurationUtils.convertDurationToDaprFormat(d1);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testZeroDurationString(){
+    String s = "0h0m0s0ms";
+    String partial = "0";
+    Duration d1 = DurationUtils.convertDurationFromDaprFormat(partial);
+
+    String t = DurationUtils.convertDurationToDaprFormat(d1);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testZeroDuration(){
+    String s = "0h0m0s0ms";
+    String t = DurationUtils.convertDurationToDaprFormat(Duration.ZERO);
+    Assert.assertEquals(s, t);
+  }
+
+  @Test
+  public void testNullString() {
+    Assert.assertThrows(IllegalArgumentException.class, () ->{
+      DurationUtils.convertDurationFromDaprFormat(null);
+    });
+  }
+
+  @Test
+  public void testEmptyString() {
+    Duration d = DurationUtils.convertDurationFromDaprFormat("");
+    Assert.assertEquals(Duration.ZERO, d);
+  }
+
+  @Test
   public void largeHours() {
     // hours part is larger than 24
     String s = "31h15m50s60ms";


### PR DESCRIPTION
# Description

Fix the Duration parsing. When reminder dueTime is stored in DB as "30m" or "10s" etc ... Java SDK fails to load the reminder with IndexOutOfBoundException. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #712 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
