### PR TITLE
typo fix

### DIFF
--- a/daprdocs/content/en/java-sdk-docs/_index.md
+++ b/daprdocs/content/en/java-sdk-docs/_index.md
@@ -175,7 +175,7 @@ public class SubscriberController {
 }
 ```
 
-- For a full list of state operations visit [How-To: Publish & subscribe]({{< ref howto-publish-subscribe.md >}}).
+- For a full guide on publishing messages and subscribing to a topic [How-To: Publish & subscribe]({{< ref howto-publish-subscribe.md >}}).
 - Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/pubsub/http) for code samples and instructions to try out pub/sub
 
 ### Interact with output bindings


### PR DESCRIPTION
Signed-off-by: Hannah Hunter <hannahhunter@microsoft.com>

# Description

Fix copy/past typo under [pub/sub section](https://docs.dapr.io/developing-applications/sdks/java/#publish--subscribe-to-messages). 

## Issue reference

PR will close: https://github.com/dapr/docs/issues/2444
