### PR TITLE
Allow subscription builder to be called with the same route

### DIFF
--- a/sdk-springboot/src/main/java/io/dapr/springboot/DaprSubscriptionBuilder.java
+++ b/sdk-springboot/src/main/java/io/dapr/springboot/DaprSubscriptionBuilder.java
@@ -47,10 +47,12 @@ class DaprSubscriptionBuilder {
    */
   DaprSubscriptionBuilder setDefaultPath(String path) {
     if (defaultPath != null) {
-      throw new RuntimeException(
-              String.format(
-                      "a default route is already set for topic %s on pubsub %s",
-                      this.topic, this.pubsubName));
+      if (!defaultPath.equals(path)) {
+        throw new RuntimeException(
+                String.format(
+                        "a default route is already set for topic %s on pubsub %s (current: '%s', supplied: '%s')",
+                        this.topic, this.pubsubName, this.defaultPath, path));
+      }
     }
     defaultPath = path;
     return this;

--- a/sdk-springboot/src/test/java/io/dapr/springboot/DaprRuntimeTest.java
+++ b/sdk-springboot/src/test/java/io/dapr/springboot/DaprRuntimeTest.java
@@ -1,0 +1,81 @@
+package io.dapr.springboot;
+
+import io.dapr.Rule;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+
+public class DaprRuntimeTest {
+
+  @Test
+  public void testPubsubDefaultPathDuplicateRegistration() {
+    String pubSubName = "pubsub";
+    String topicName = "topic";
+    String match = "";
+    String route = String.format("%s/%s", pubSubName, topicName);
+    HashMap<String, String> metadata = new HashMap<String, String>();
+
+    Rule rule = new Rule(){
+      @Override
+      public Class<? extends Annotation> annotationType() {
+        return Rule.class;
+      }
+
+      public String match() {
+        return match;
+      }
+      public int priority() {
+        return 0;
+      }
+    };
+
+    DaprRuntime runtime = DaprRuntime.getInstance();
+    Assert.assertNotNull(runtime);
+
+    // We should be able to register the same route multiple times
+    runtime.addSubscribedTopic(
+            pubSubName, topicName, match, rule.priority(), route, metadata);
+    runtime.addSubscribedTopic(
+            pubSubName, topicName, match, rule.priority(), route, metadata);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testPubsubDefaultPathDifferentRegistration() {
+    String pubSubName = "pubsub";
+    String topicName = "topic";
+    String match = "";
+    String firstRoute = String.format("%s/%s", pubSubName, topicName);
+    String secondRoute = String.format("%s/%s/subscribe", pubSubName, topicName);
+
+
+    HashMap<String, String> metadata = new HashMap<String, String>();
+
+    Rule rule = new Rule(){
+      @Override
+      public Class<? extends Annotation> annotationType() {
+        return Rule.class;
+      }
+
+      public String match() {
+        return match;
+      }
+      public int priority() {
+        return 0;
+      }
+    };
+
+    DaprRuntime runtime = DaprRuntime.getInstance();
+
+    Assert.assertNotNull(runtime);
+    runtime.addSubscribedTopic(
+            pubSubName, topicName, match, rule.priority(), firstRoute, metadata);
+
+    // Supplying the same pubsub bits but a different route should fail
+    runtime.addSubscribedTopic(
+            pubSubName, topicName, match, rule.priority(), secondRoute, metadata);
+
+  }
+
+}


### PR DESCRIPTION

# Description

If the route being provided for a topic is the same as it was previously, do not raise an exception.

Fixes parallel test execution without `forkMode=always` (#766)

Note: this will allow for a subsequent registration to overwrite metadata as it is un-guarded and, since there's no exception when setting a duplicate path, that code will get executed in these cases. If that needs to not happen then we can fix that here before merging it.

## Issue reference

Please reference the issue this PR will close: #766

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation (N/A)
