### PR TITLE
auto validate actors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -154,6 +154,10 @@ jobs:
         working-directory: ./examples
         run: |
             mm.py ./src/main/java/io/dapr/examples/configuration/http/README.md
+      - name: Validate actors example
+        working-directory: ./examples
+        run: |
+            mm.py ./src/main/java/io/dapr/examples/actors/README.md
       - name: Validate query state HTTP example
         working-directory: ./examples
         run: |

--- a/examples/src/main/java/io/dapr/examples/actors/DemoActor.java
+++ b/examples/src/main/java/io/dapr/examples/actors/DemoActor.java
@@ -23,7 +23,9 @@ import reactor.core.publisher.Mono;
 @ActorType(name = "DemoActor")
 public interface DemoActor {
 
-  void registerReminder();
+  void registerTimer(String state);
+
+  void registerReminder(int index);
 
   @ActorMethod(name = "echo_message")
   String say(String something);

--- a/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
+++ b/examples/src/main/java/io/dapr/examples/actors/DemoActorClient.java
@@ -49,7 +49,8 @@ public class DemoActorClient {
         DemoActor actor = builder.build(actorId);
 
         // Start a thread per actor.
-        Thread thread = new Thread(() -> callActorForever(actorId.toString(), actor));
+        int finalI = i;
+        Thread thread = new Thread(() -> callActorForever(finalI, actorId.toString(), actor));
         thread.start();
         threads.add(thread);
       }
@@ -68,19 +69,23 @@ public class DemoActorClient {
    * @param actorId Actor's identifier.
    * @param actor Actor to be invoked.
    */
-  private static final void callActorForever(String actorId, DemoActor actor) {
+  private static final void callActorForever(int index, String actorId, DemoActor actor) {
     // First, register reminder.
-    actor.registerReminder();
+    actor.registerReminder(index);
+    // Second register timer.
+    actor.registerTimer("ping! {" + index + "} ");
 
     // Now, we run until thread is interrupted.
     while (!Thread.currentThread().isInterrupted()) {
       // Invoke actor method to increment counter by 1, then build message.
       int messageNumber = actor.incrementAndGet(1).block();
-      String message = String.format("Actor %s said message #%d", actorId, messageNumber);
+      String message = String.format("Message #%d received from actor at index %d with ID %s", messageNumber,
+          index, actorId);
 
       // Invoke the 'say' method in actor.
       String result = actor.say(message);
-      System.out.println(String.format("Actor %s got a reply: %s", actorId, result));
+      System.out.println(String.format("Reply %s received from actor at index %d with ID %s ", result,
+          index, actorId));
 
       try {
         // Waits for up to 1 second.

--- a/examples/src/main/java/io/dapr/examples/actors/DemoActorImpl.java
+++ b/examples/src/main/java/io/dapr/examples/actors/DemoActorImpl.java
@@ -43,11 +43,18 @@ public class DemoActorImpl extends AbstractActor implements DemoActor, Remindabl
    */
   public DemoActorImpl(ActorRuntimeContext runtimeContext, ActorId id) {
     super(runtimeContext, id);
+  }
 
+  /**
+   * Register a timer.
+   */
+  @Override
+  public void registerTimer(String state) {
+    // For example, the state will be formatted as `ping! {INDEX}` where INDEX is the index of the actor related to ID.
     super.registerActorTimer(
         null,
         "clock",
-        "ping!",
+        state,
         Duration.ofSeconds(2),
         Duration.ofSeconds(1)).block();
   }
@@ -56,10 +63,11 @@ public class DemoActorImpl extends AbstractActor implements DemoActor, Remindabl
    * Registers a reminder.
    */
   @Override
-  public void registerReminder() {
+  public void registerReminder(int index) {
+    // For this example, the state reminded by the reminder is deterministic to be the index(not ID) of the actor.
     super.registerReminder(
         "myremind",
-        (int) (Integer.MAX_VALUE * Math.random()),
+        index,
         Duration.ofSeconds(5),
         Duration.ofSeconds(2)).block();
   }
@@ -120,9 +128,9 @@ public class DemoActorImpl extends AbstractActor implements DemoActor, Remindabl
     String utcNowAsString = DATE_FORMAT.format(utcNow.getTime());
 
     // Handles the request by printing message.
-    System.out.println("Server timer for actor "
-        + super.getId() + ": "
-        + (message == null ? "" : message + " @ " + utcNowAsString));
+    System.out.println("Server timer triggered with state "
+        + (message == null ? "" : message) + " for actor "
+        + super.getId() + "@ " + utcNowAsString);
   }
 
   /**
@@ -148,8 +156,8 @@ public class DemoActorImpl extends AbstractActor implements DemoActor, Remindabl
       Calendar utcNow = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
       String utcNowAsString = DATE_FORMAT.format(utcNow.getTime());
 
-      String message = String.format("Server reminded actor %s of: %s for %d @ %s",
-          this.getId(), reminderName, state, utcNowAsString);
+      String message = String.format("Reminder %s with state {%d} triggered for actor %s @ %s",
+          reminderName, state, this.getId(), utcNowAsString);
 
       // Handles the request by printing message.
       System.out.println(message);


### PR DESCRIPTION
# Description

Autovalidation of substring of actor output.

Added a deterministic index that is passed in as state or during method call. 

Specifically only the index is matched. The ID of the actor is not matched. Only partial output match is possible.

The `mm.py` matches 
Method call and timer

![image](https://github.com/dapr/java-sdk/assets/65565396/55e5eec3-b7ca-4751-8d62-d15ab59afc4a)

Reminder
![image](https://github.com/dapr/java-sdk/assets/65565396/7cd55ff0-e162-4e72-86c0-bebb902c3c0e)

Client 
![image](https://github.com/dapr/java-sdk/assets/65565396/b3e3171b-1504-4035-b4d0-064c183be2c4)


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #468 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation

