### PR TITLE
Add `NewWorkflowOption` to config version, time, input, etc when start a new workflow

### DIFF
--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
@@ -13,10 +13,7 @@ limitations under the License.
 
 package io.dapr.workflows.client;
 
-import com.microsoft.durabletask.DurableTaskClient;
-import com.microsoft.durabletask.DurableTaskGrpcClientBuilder;
-import com.microsoft.durabletask.OrchestrationMetadata;
-import com.microsoft.durabletask.PurgeResult;
+import com.microsoft.durabletask.*;
 import io.dapr.client.Headers;
 import io.dapr.config.Properties;
 import io.dapr.utils.NetworkUtils;
@@ -117,6 +114,18 @@ public class DaprWorkflowClient implements AutoCloseable {
    */
   public <T extends Workflow> String scheduleNewWorkflow(Class<T> clazz, Object input, String instanceId) {
     return this.innerClient.scheduleNewOrchestrationInstance(clazz.getCanonicalName(), input, instanceId);
+  }
+
+  /**
+   * Schedules a new workflow with a specified set of options for execution.
+   *
+   * @param <T>        any Workflow type
+   * @param clazz      Class extending Workflow to start an instance of.
+   * @param options the options for the new workflow, including input, instance ID, etc.
+   * @return the <code>instanceId</code> parameter value.
+   */
+  public <T extends Workflow> String scheduleNewWorkflow(Class<T> clazz, NewWorkflowOption options) {
+    return this.innerClient.scheduleNewOrchestrationInstance(clazz.getCanonicalName(), options.getNewOrchestrationInstanceOptions());
   }
 
   /**

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
@@ -13,7 +13,10 @@ limitations under the License.
 
 package io.dapr.workflows.client;
 
-import com.microsoft.durabletask.*;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.DurableTaskGrpcClientBuilder;
+import com.microsoft.durabletask.OrchestrationMetadata;
+import com.microsoft.durabletask.PurgeResult;
 import io.dapr.client.Headers;
 import io.dapr.config.Properties;
 import io.dapr.utils.NetworkUtils;
@@ -125,7 +128,8 @@ public class DaprWorkflowClient implements AutoCloseable {
    * @return the <code>instanceId</code> parameter value.
    */
   public <T extends Workflow> String scheduleNewWorkflow(Class<T> clazz, NewWorkflowOption options) {
-    return this.innerClient.scheduleNewOrchestrationInstance(clazz.getCanonicalName(), options.getNewOrchestrationInstanceOptions());
+    return this.innerClient.scheduleNewOrchestrationInstance(clazz.getCanonicalName(),
+        options.getNewOrchestrationInstanceOptions());
   }
 
   /**

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOption.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOption.java
@@ -1,100 +1,114 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package io.dapr.workflows.client;
 
 import com.microsoft.durabletask.NewOrchestrationInstanceOptions;
+
 import java.time.Instant;
 
 /**
  * Options for starting a new instance of a workflow.
  */
 public class NewWorkflowOption {
-    private final NewOrchestrationInstanceOptions newOrchestrationInstanceOptions = new NewOrchestrationInstanceOptions();
+  private final NewOrchestrationInstanceOptions newOrchestrationInstanceOptions = new NewOrchestrationInstanceOptions();
 
-    /**
-     * Sets the version of the workflow to start.
-     *
-     * @param version the user-defined version of workflow
-     * @return this {@link NewWorkflowOption} object
-     */
-    public NewWorkflowOption setVersion(String version) {
-        this.newOrchestrationInstanceOptions.setVersion(version);
-        return this;
-    }
+  /**
+   * Sets the version of the workflow to start.
+   *
+   * @param version the user-defined version of workflow
+   * @return this {@link NewWorkflowOption} object
+   */
+  public NewWorkflowOption setVersion(String version) {
+    this.newOrchestrationInstanceOptions.setVersion(version);
+    return this;
+  }
 
-    /**
-     * Sets the instance ID of the workflow to start.
-     * <p>
-     * If no instance ID is configured, the workflow will be created with a randomly generated instance ID.
-     *
-     * @param instanceId the ID of the new workflow
-     * @return this {@link NewWorkflowOption} object
-     */
-    public NewWorkflowOption setInstanceId(String instanceId) {
-        this.newOrchestrationInstanceOptions.setInstanceId(instanceId);
-        return this;
-    }
+  /**
+   * Sets the instance ID of the workflow to start.
+   *
+   * <p>If no instance ID is configured, the workflow will be created with a randomly generated instance ID.
+   *
+   * @param instanceId the ID of the new workflow
+   * @return this {@link NewWorkflowOption} object
+   */
+  public NewWorkflowOption setInstanceId(String instanceId) {
+    this.newOrchestrationInstanceOptions.setInstanceId(instanceId);
+    return this;
+  }
 
-    /**
-     * Sets the input of the workflow to start.
-     *
-     * @param input the input of the new workflow
-     * @return this {@link NewWorkflowOption} object
-     */
-    public NewWorkflowOption setInput(Object input) {
-        this.newOrchestrationInstanceOptions.setInput(input);
-        return this;
-    }
+  /**
+   * Sets the input of the workflow to start.
+   *
+   * @param input the input of the new workflow
+   * @return this {@link NewWorkflowOption} object
+   */
+  public NewWorkflowOption setInput(Object input) {
+    this.newOrchestrationInstanceOptions.setInput(input);
+    return this;
+  }
 
-    /**
-     * Sets the start time of the new workflow.
-     * <p>
-     * By default, new workflow instances start executing immediately. This method can be used
-     * to start them at a specific time in the future.
-     *
-     * @param startTime the start time of the new workflow
-     * @return this {@link NewWorkflowOption} object
-     */
-    public NewWorkflowOption setStartTime(Instant startTime) {
-        this.newOrchestrationInstanceOptions.setStartTime(startTime);
-        return this;
-    }
+  /**
+   * Sets the start time of the new workflow.
+   *
+   * <p>By default, new workflow instances start executing immediately. This method can be used
+   * to start them at a specific time in the future.
+   *
+   * @param startTime the start time of the new workflow
+   * @return this {@link NewWorkflowOption} object
+   */
+  public NewWorkflowOption setStartTime(Instant startTime) {
+    this.newOrchestrationInstanceOptions.setStartTime(startTime);
+    return this;
+  }
 
-    /**
-     * Gets the user-specified version of the new workflow.
-     *
-     * @return the user-specified version of the new workflow.
-     */
-    public String getVersion() {
-        return this.newOrchestrationInstanceOptions.getVersion();
-    }
+  /**
+   * Gets the user-specified version of the new workflow.
+   *
+   * @return the user-specified version of the new workflow.
+   */
+  public String getVersion() {
+    return this.newOrchestrationInstanceOptions.getVersion();
+  }
 
-    /**
-     * Gets the instance ID of the new workflow.
-     *
-     * @return the instance ID of the new workflow.
-     */
-    public String getInstanceId() {
-        return this.newOrchestrationInstanceOptions.getInstanceId();
-    }
+  /**
+   * Gets the instance ID of the new workflow.
+   *
+   * @return the instance ID of the new workflow.
+   */
+  public String getInstanceId() {
+    return this.newOrchestrationInstanceOptions.getInstanceId();
+  }
 
-    /**
-     * Gets the input of the new workflow.
-     *
-     * @return the input of the new workflow.
-     */
-    public Object getInput() {
-        return this.newOrchestrationInstanceOptions.getInput();
-    }
+  /**
+   * Gets the input of the new workflow.
+   *
+   * @return the input of the new workflow.
+   */
+  public Object getInput() {
+    return this.newOrchestrationInstanceOptions.getInput();
+  }
 
-    /**
-     * Gets the configured start time of the new workflow instance.
-     *
-     * @return the configured start time of the new workflow instance.
-     */
-    public Instant getStartTime() {
-        return this.newOrchestrationInstanceOptions.getStartTime();
-    }
+  /**
+   * Gets the configured start time of the new workflow instance.
+   *
+   * @return the configured start time of the new workflow instance.
+   */
+  public Instant getStartTime() {
+    return this.newOrchestrationInstanceOptions.getStartTime();
+  }
 
-    public NewOrchestrationInstanceOptions getNewOrchestrationInstanceOptions() {
-        return newOrchestrationInstanceOptions;
-    }
+  public NewOrchestrationInstanceOptions getNewOrchestrationInstanceOptions() {
+    return newOrchestrationInstanceOptions;
+  }
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOption.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOption.java
@@ -1,0 +1,100 @@
+package io.dapr.workflows.client;
+
+import com.microsoft.durabletask.NewOrchestrationInstanceOptions;
+import java.time.Instant;
+
+/**
+ * Options for starting a new instance of a workflow.
+ */
+public class NewWorkflowOption {
+    private final NewOrchestrationInstanceOptions newOrchestrationInstanceOptions = new NewOrchestrationInstanceOptions();
+
+    /**
+     * Sets the version of the workflow to start.
+     *
+     * @param version the user-defined version of workflow
+     * @return this {@link NewWorkflowOption} object
+     */
+    public NewWorkflowOption setVersion(String version) {
+        this.newOrchestrationInstanceOptions.setVersion(version);
+        return this;
+    }
+
+    /**
+     * Sets the instance ID of the workflow to start.
+     * <p>
+     * If no instance ID is configured, the workflow will be created with a randomly generated instance ID.
+     *
+     * @param instanceId the ID of the new workflow
+     * @return this {@link NewWorkflowOption} object
+     */
+    public NewWorkflowOption setInstanceId(String instanceId) {
+        this.newOrchestrationInstanceOptions.setInstanceId(instanceId);
+        return this;
+    }
+
+    /**
+     * Sets the input of the workflow to start.
+     *
+     * @param input the input of the new workflow
+     * @return this {@link NewWorkflowOption} object
+     */
+    public NewWorkflowOption setInput(Object input) {
+        this.newOrchestrationInstanceOptions.setInput(input);
+        return this;
+    }
+
+    /**
+     * Sets the start time of the new workflow.
+     * <p>
+     * By default, new workflow instances start executing immediately. This method can be used
+     * to start them at a specific time in the future.
+     *
+     * @param startTime the start time of the new workflow
+     * @return this {@link NewWorkflowOption} object
+     */
+    public NewWorkflowOption setStartTime(Instant startTime) {
+        this.newOrchestrationInstanceOptions.setStartTime(startTime);
+        return this;
+    }
+
+    /**
+     * Gets the user-specified version of the new workflow.
+     *
+     * @return the user-specified version of the new workflow.
+     */
+    public String getVersion() {
+        return this.newOrchestrationInstanceOptions.getVersion();
+    }
+
+    /**
+     * Gets the instance ID of the new workflow.
+     *
+     * @return the instance ID of the new workflow.
+     */
+    public String getInstanceId() {
+        return this.newOrchestrationInstanceOptions.getInstanceId();
+    }
+
+    /**
+     * Gets the input of the new workflow.
+     *
+     * @return the input of the new workflow.
+     */
+    public Object getInput() {
+        return this.newOrchestrationInstanceOptions.getInput();
+    }
+
+    /**
+     * Gets the configured start time of the new workflow instance.
+     *
+     * @return the configured start time of the new workflow instance.
+     */
+    public Instant getStartTime() {
+        return this.newOrchestrationInstanceOptions.getStartTime();
+    }
+
+    public NewOrchestrationInstanceOptions getNewOrchestrationInstanceOptions() {
+        return newOrchestrationInstanceOptions;
+    }
+}

--- a/sdk-workflows/src/test/java/io/dapr/workflows/client/DaprWorkflowClientTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/client/DaprWorkflowClientTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 
@@ -104,6 +105,19 @@ public class DaprWorkflowClientTest {
 
     verify(mockInnerClient, times(1))
         .scheduleNewOrchestrationInstance(expectedName, expectedInput, expectedInstanceId);
+  }
+
+  @Test
+  public void scheduleNewWorkflowWithNewWorkflowOption() {
+    String expectedName = TestWorkflow.class.getCanonicalName();
+    Object expectedInput = new Object();
+    NewWorkflowOption newWorkflowOption = new NewWorkflowOption();
+    newWorkflowOption.setInput(expectedInput).setStartTime(Instant.now());
+
+    client.scheduleNewWorkflow(TestWorkflow.class, newWorkflowOption);
+
+    verify(mockInnerClient, times(1))
+        .scheduleNewOrchestrationInstance(expectedName, newWorkflowOption.getNewOrchestrationInstanceOptions());
   }
 
   @Test

--- a/sdk-workflows/src/test/java/io/dapr/workflows/client/NewWorkflowOptionTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/client/NewWorkflowOptionTest.java
@@ -1,0 +1,28 @@
+package io.dapr.workflows.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+public class NewWorkflowOptionTest {
+
+  @Test
+  void testNewWorkflowOption() {
+    NewWorkflowOption workflowOption = new NewWorkflowOption();
+    String version = "v1";
+    String instanceId = "123";
+    Object input = new Object();
+    Instant startTime = Instant.now();
+
+    workflowOption.setVersion(version)
+        .setInstanceId(instanceId)
+        .setInput(input)
+        .setStartTime(startTime);
+
+    Assertions.assertEquals(version, workflowOption.getVersion());
+    Assertions.assertEquals(instanceId, workflowOption.getInstanceId());
+    Assertions.assertEquals(input, workflowOption.getInput());
+    Assertions.assertEquals(startTime, workflowOption.getStartTime());
+  }
+}


### PR DESCRIPTION
# Description

This PR fix https://github.com/dapr/java-sdk/issues/943 by providing the customer a `NewWorkflowOption` to config version, time, input, etc when start a new workflow. 

(This is my first PR in this repo, hope not miss anything)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[[943](https://github.com/dapr/java-sdk/issues/943)]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
