### PR TITLE
Update CLI link in example readme's

### DIFF
--- a/examples/src/main/java/io/dapr/examples/actors/README.md
+++ b/examples/src/main/java/io/dapr/examples/actors/README.md
@@ -13,7 +13,7 @@ This example contains the follow classes:
  
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/bindings/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/bindings/http/README.md
@@ -17,7 +17,7 @@ Visit [this](https://github.com/dapr/components-contrib/tree/master/bindings) li
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/configuration/grpc/README.md
+++ b/examples/src/main/java/io/dapr/examples/configuration/grpc/README.md
@@ -11,7 +11,7 @@ The Java SDK exposes several methods for this -
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/configuration/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/configuration/http/README.md
@@ -12,7 +12,7 @@ The java SDK exposes several methods for this -
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/exception/README.md
+++ b/examples/src/main/java/io/dapr/examples/exception/README.md
@@ -4,7 +4,7 @@ This sample illustrates how to handle exceptions in Dapr.
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/invoke/grpc/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/grpc/README.md
@@ -4,7 +4,7 @@ In this example, you will run a Grpc service and client using Dapr's invoke feat
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/invoke/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/README.md
@@ -14,7 +14,7 @@ This sample uses the Client provided in Dapr Java SDK invoking a remote method.
 
 ## Pre-requisites
 
-* [Dapr and Dapr CLI](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/lock/grpc/README.md
+++ b/examples/src/main/java/io/dapr/examples/lock/grpc/README.md
@@ -11,7 +11,7 @@ The java SDK exposes several methods for this -
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/lock/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/lock/http/README.md
@@ -11,7 +11,7 @@ The java SDK exposes several methods for this -
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/pubsub/README.md
+++ b/examples/src/main/java/io/dapr/examples/pubsub/README.md
@@ -9,7 +9,7 @@ Visit [this](https://docs.dapr.io/developing-applications/building-blocks/pubsub
 This sample uses the HTTP Springboot integration provided in Dapr Java SDK for subscribing, and gRPC client for publishing. This example uses Redis Streams (enabled in Redis versions => 5).
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/querystate/README.md
+++ b/examples/src/main/java/io/dapr/examples/querystate/README.md
@@ -5,7 +5,10 @@ This sample illustrates the capabilities provided by Dapr Java SDK for querying 
 ## Pre-requisites
 
 * [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater): [Oracle JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11) or [OpenJDK](https://jdk.java.net/13/).
+* Java JDK 11 (or greater):
+    * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
+    * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
+    * [OpenJDK 11](https://jdk.java.net/11/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 ### Checking out the code

--- a/examples/src/main/java/io/dapr/examples/querystate/README.md
+++ b/examples/src/main/java/io/dapr/examples/querystate/README.md
@@ -4,7 +4,7 @@ This sample illustrates the capabilities provided by Dapr Java SDK for querying 
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater): [Oracle JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11) or [OpenJDK](https://jdk.java.net/13/).
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 

--- a/examples/src/main/java/io/dapr/examples/secrets/README.md
+++ b/examples/src/main/java/io/dapr/examples/secrets/README.md
@@ -17,7 +17,7 @@ Visit [this](https://github.com/dapr/components-contrib/tree/master/secretstores
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
   * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
   * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/state/README.md
+++ b/examples/src/main/java/io/dapr/examples/state/README.md
@@ -4,7 +4,7 @@ This sample illustrates the capabilities provided by Dapr Java SDK for state man
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/tracing/README.md
+++ b/examples/src/main/java/io/dapr/examples/tracing/README.md
@@ -16,7 +16,7 @@ This sample uses the Client provided in Dapr Java SDK invoking a remote method a
 
 ## Pre-requisites
 
-* [Dapr and Dapr CLI](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/unittesting/README.md
+++ b/examples/src/main/java/io/dapr/examples/unittesting/README.md
@@ -4,7 +4,7 @@ This sample illustrates how applications can write unit tests with Dapr's Java S
 
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)

--- a/examples/src/main/java/io/dapr/examples/workflows/README.md
+++ b/examples/src/main/java/io/dapr/examples/workflows/README.md
@@ -12,7 +12,7 @@ This example contains the follow classes:
  
 ## Pre-requisites
 
-* [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr/).
+* [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 * Java JDK 11 (or greater):
     * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
     * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)


### PR DESCRIPTION
# Description

Based on issue #950 checked repo and found all the example point to the same 404.
Corrected the link.

Also found the querystate example list of SDKs was deviating from the other examples and updated this.

## Issue reference

Closes: #950
