### PR TITLE
fix flaky integration test ActorReminderRecoveryIT

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorReminderRecoveryIT.java
@@ -128,6 +128,9 @@ public class ActorReminderRecoveryIT extends BaseIT {
   ) throws Exception {
     setup(actorType);
 
+    logger.debug("Pausing 3 seconds to let gRPC connection get ready");
+    Thread.sleep(3000);
+    
     logger.debug("Invoking actor method 'startReminder' which will register a reminder");
     proxy.invokeMethod("setReminderData", reminderDataParam).block();
 


### PR DESCRIPTION
# Description
it always fali due to rpc invoke connection refused. Pausing 3 seconds after set up is helpful for gRPC connection getting ready.

## Issue reference


Please refer to the the point 4 of issue [#7128](https://github.com/dapr/dapr/issues/7128) in dapr/dapr.


