### PR TITLE
fix flaky integration test MethodInvokeIT

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -40,14 +40,18 @@ public class MethodInvokeIT extends BaseIT {
           MethodInvokeService.class,
           DaprApiProtocol.GRPC,  // appProtocol
           60000);
+        System.out.println("#### startDaprApp ");
         daprRun.switchToGRPC();
+        System.out.println("#### switchToGRPC ");
         daprRun.waitForAppHealth(30000);
+        System.out.println("#### waitForAppHealth ");
     }
 
     @Test
     public void testInvoke() throws Exception {
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
+            System.out.println("#### waitForSidecar ");
             for (int i = 0; i < NUM_MESSAGES; i++) {
                 String message = String.format("This is message #%d", i);
 

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -43,7 +43,7 @@ public class MethodInvokeIT extends BaseIT {
         System.out.println("#### startDaprApp ");
         daprRun.switchToGRPC();
         System.out.println("#### switchToGRPC ");
-        daprRun.waitForAppHealth(30000);
+        daprRun.waitForAppHealth(50000);
         System.out.println("#### waitForAppHealth ");
     }
 

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -41,7 +41,7 @@ public class MethodInvokeIT extends BaseIT {
           DaprApiProtocol.GRPC,  // appProtocol
           60000);
         daprRun.switchToGRPC();
-        daprRun.waitForAppHealth(20000);
+        daprRun.waitForAppHealth(30000);
     }
 
     @Test

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -122,6 +122,8 @@ public class MethodInvokeIT extends BaseIT {
             // This message is not ideal but last time it was improved, there was side effects reported by users.
             // If this test fails, there might be a regression in runtime (like we had in 1.10.0).
             // The expectations below are as per 1.9 release and (later on) hotfixed in 1.10.
+            System.out.println("#### "+exception.getErrorCode());
+            System.out.println("#### "+exception.getMessage());
             assertEquals("UNKNOWN", exception.getErrorCode());
             assertEquals("UNKNOWN: ", exception.getMessage());
         }

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -43,7 +43,7 @@ public class MethodInvokeIT extends BaseIT {
         System.out.println("#### startDaprApp ");
         daprRun.switchToGRPC();
         System.out.println("#### switchToGRPC ");
-        daprRun.waitForAppHealth(50000);
+        daprRun.waitForAppHealth(40000);
         System.out.println("#### waitForAppHealth ");
     }
 
@@ -114,6 +114,8 @@ public class MethodInvokeIT extends BaseIT {
     public void testInvokeException() throws Exception {
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
+            daprRun.waitForAppHealth(10000);
+            
             SleepRequest req = SleepRequest.newBuilder().setSeconds(-9).build();
             DaprException exception = assertThrows(DaprException.class, () ->
                 client.invokeMethod(daprRun.getAppName(), "sleep", req.toByteArray(), HttpExtension.POST).block());

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -40,18 +40,16 @@ public class MethodInvokeIT extends BaseIT {
           MethodInvokeService.class,
           DaprApiProtocol.GRPC,  // appProtocol
           60000);
-        System.out.println("#### startDaprApp ");
         daprRun.switchToGRPC();
-        System.out.println("#### switchToGRPC ");
         daprRun.waitForAppHealth(40000);
-        System.out.println("#### waitForAppHealth ");
     }
 
     @Test
     public void testInvoke() throws Exception {
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
-            System.out.println("#### waitForSidecar ");
+            daprRun.waitForAppHealth(10000);
+            
             for (int i = 0; i < NUM_MESSAGES; i++) {
                 String message = String.format("This is message #%d", i);
 
@@ -99,6 +97,8 @@ public class MethodInvokeIT extends BaseIT {
     public void testInvokeTimeout() throws Exception {
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
+            daprRun.waitForAppHealth(10000);
+
             long started = System.currentTimeMillis();
             SleepRequest req = SleepRequest.newBuilder().setSeconds(1).build();
             String message = assertThrows(IllegalStateException.class, () ->
@@ -124,8 +124,6 @@ public class MethodInvokeIT extends BaseIT {
             // This message is not ideal but last time it was improved, there was side effects reported by users.
             // If this test fails, there might be a regression in runtime (like we had in 1.10.0).
             // The expectations below are as per 1.9 release and (later on) hotfixed in 1.10.
-            System.out.println("#### "+exception.getErrorCode());
-            System.out.println("#### "+exception.getMessage());
             assertEquals("UNKNOWN", exception.getErrorCode());
             assertEquals("UNKNOWN: ", exception.getMessage());
         }


### PR DESCRIPTION
# Description

Its test case `testInvoke` always fail due to app is not in a healthy state. Increasing time of waiting for app health can be helpful.

## Issue reference

Please refer to the the point 4 of issue [#7128](https://github.com/dapr/dapr/issues/7128) in dapr/dapr.

