### PR TITLE
migrate upload-artifact v4 breaking change to fix github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,24 +126,24 @@ jobs:
       id: integration_tests
       run: PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} ./mvnw -B -f sdk-tests/pom.xml verify
     - name: Upload test report for sdk
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: report-dapr-java-sdk
         path: sdk/target/jacoco-report/
     - name: Upload test report for sdk-actors
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: report-dapr-java-sdk-actors
         path: sdk-actors/target/jacoco-report/
     - name: Upload failsafe test report for sdk-tests on failure
       if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: failsafe-report-sdk-tests
         path: sdk-tests/target/failsafe-reports
     - name: Upload surefire test report for sdk-tests on failure
       if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: surefire-report-sdk-tests
         path: sdk-tests/target/surefire-reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,26 +126,26 @@ jobs:
       id: integration_tests
       run: PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} ./mvnw -B -f sdk-tests/pom.xml verify
     - name: Upload test report for sdk
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: report-dapr-java-sdk
+        name: report-dapr-java-sdk-jdk${{ matrix.java }}-sb${{ matrix.spring-boot-version }}
         path: sdk/target/jacoco-report/
     - name: Upload test report for sdk-actors
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: report-dapr-java-sdk-actors
+        name: report-dapr-java-sdk-actors-jdk${{ matrix.java }}-sb${{ matrix.spring-boot-version }}
         path: sdk-actors/target/jacoco-report/
     - name: Upload failsafe test report for sdk-tests on failure
       if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: failsafe-report-sdk-tests
+        name: failsafe-report-sdk-tests-jdk${{ matrix.java }}-sb${{ matrix.spring-boot-version }}
         path: sdk-tests/target/failsafe-reports
     - name: Upload surefire test report for sdk-tests on failure
       if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: surefire-report-sdk-tests
+        name: surefire-report-sdk-tests-jdk${{ matrix.java }}-sb${{ matrix.spring-boot-version }}
         path: sdk-tests/target/surefire-reports
 
   publish:


### PR DESCRIPTION
# Description

Version 4 of the upload-artifact plugin contains a breaking change on artifact naming. Either need to revert to v3 or make artifact naming distinct for each run.

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
