### PR TITLE
fix the orphaned channel due to the telemetry test

### DIFF
--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTelemetryTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTelemetryTest.java
@@ -30,6 +30,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -183,6 +184,14 @@ null,
     DaprHttp daprHTTP = Mockito.mock(DaprHttp.class);
     client = new DaprClientGrpc(
       new GrpcChannelFacade(channel, daprHTTP), asyncStub, new DefaultObjectSerializer(), new DefaultObjectSerializer());
+  }
+
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.close();
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
# Description

I've noticed several orphaned channels showing up locally and in CI. These orphaned channels muddy the error output when trying to debug other issues. I think this resolves one due to the `DaprClientGrpcTelemetryTest`.

[See 'passing' CI log here where there is an orphaned channel](https://github.com/dapr/java-sdk/actions/runs/7623906031/job/20764920109#step:16:611)

I see we have the `grpcCleanup`, but with the `daprHTTP` being added when creating new `DaprClientGrpc`, I'm not convinced its properly cleaning everything up. 

I no longer see the orphaned channel due to this test file locally with this fix.

## Issue reference


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
