### PR TITLE
Improve build name in GH actions to avoid change on patch upgrades.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: "Build jdk:${{ matrix.java }} sb:${{ matrix.spring-boot-version }} exp:${{ matrix.experimental }}"
+    name: "Build jdk:${{ matrix.java }} sb:${{ matrix.spring-boot-display-version }} exp:${{ matrix.experimental }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental }}
@@ -28,12 +28,15 @@ jobs:
         include:
           - java: 17
             spring-boot-version: 2.7.18
+            spring-boot-display-version: 2.7.x
             experimental: false
           - java: 17
             spring-boot-version: 2.6.14
+            spring-boot-display-version: 2.6.x
             experimental: false
           - java: 17
             spring-boot-version: 2.5.7
+            spring-boot-display-version: 2.5.x
             experimental: false
     env:
       GOVER: "1.20"


### PR DESCRIPTION
# Description

Improve build name in GH actions to avoid change on patch upgrades.
Otherwise, we have to keep changing Gh settings of the repo on every patch version of springboot we upgrade to.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
