### PR TITLE
Increase Kafka container wait time for HTTP bindings examples

### DIFF
--- a/examples/src/main/java/io/dapr/examples/bindings/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/bindings/http/README.md
@@ -60,7 +60,7 @@ Before getting into the application code, follow these steps in order to set up 
 name: Setup kafka container
 expected_stderr_lines:
   - 'Creating network "http_default" with the default driver'
-sleep: 5
+sleep: 20
 -->
 
 ```bash


### PR DESCRIPTION
# Description

Currently when running Java SDK examples for HTTP bindings it fails. It seems that using `sleep: 5` to wait for Kafka container to be up and running is not enough. The change is to increase the sleep value from `5` to `20`. This is not ideal, but it proved to work when running:
```
mm.py ./src/main/java/io/dapr/examples/bindings/http/README.md
```
on local box.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
