### PR TITLE
Add missing data to Dapr Metadata and its components

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
@@ -16,6 +16,7 @@ package io.dapr.client;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import io.dapr.client.domain.ActorMetadata;
 import io.dapr.client.domain.AppConnectionPropertiesHealthMetadata;
 import io.dapr.client.domain.AppConnectionPropertiesMetadata;
 import io.dapr.client.domain.BulkPublishEntry;
@@ -65,6 +66,8 @@ import io.dapr.utils.TypeRef;
 import io.dapr.v1.CommonProtos;
 import io.dapr.v1.DaprGrpc;
 import io.dapr.v1.DaprProtos;
+import io.dapr.v1.DaprProtos.ActiveActorsCount;
+import io.dapr.v1.DaprProtos.ActorRuntime;
 import io.dapr.v1.DaprProtos.AppConnectionHealthProperties;
 import io.dapr.v1.DaprProtos.AppConnectionProperties;
 import io.dapr.v1.DaprProtos.MetadataHTTPEndpoint;
@@ -1266,14 +1269,27 @@ public class DaprClientImpl extends AbstractDaprClient {
     String id = response.getId();
     String runtimeVersion = response.getRuntimeVersion();
     List<String> enabledFeatures = response.getEnabledFeaturesList();
+    List<ActorMetadata> actors = getActors(response);
     Map<String, String> attributes = response.getExtendedMetadataMap();
     List<ComponentMetadata> components = getComponents(response);
     List<HttpEndpointMetadata> httpEndpoints = getHttpEndpoints(response);
     List<SubscriptionMetadata> subscriptions = getSubscriptions(response);
     AppConnectionPropertiesMetadata appConnectionProperties = getAppConnectionProperties(response);
 
-    return new DaprMetadata(id, runtimeVersion, enabledFeatures, attributes, components, httpEndpoints, subscriptions,
-      appConnectionProperties);
+    return new DaprMetadata(id, runtimeVersion, enabledFeatures, actors, attributes, components, httpEndpoints,
+      subscriptions, appConnectionProperties);
+  }
+
+  private List<ActorMetadata> getActors(DaprProtos.GetMetadataResponse response) {
+    ActorRuntime actorRuntime = response.getActorRuntime();
+    List<ActiveActorsCount> activeActorsList = actorRuntime.getActiveActorsList();
+
+    List<ActorMetadata> actors = new ArrayList<>();
+    for (ActiveActorsCount aac : activeActorsList) {
+      actors.add(new ActorMetadata(aac.getType(), aac.getCount()));
+    }
+
+    return actors;
   }
 
   private List<ComponentMetadata> getComponents(DaprProtos.GetMetadataResponse response) {
@@ -1281,7 +1297,7 @@ public class DaprClientImpl extends AbstractDaprClient {
 
     List<ComponentMetadata> components = new ArrayList<>();
     for (RegisteredComponents rc : registeredComponentsList) {
-      components.add(new ComponentMetadata(rc.getName(), rc.getType(), rc.getVersion()));
+      components.add(new ComponentMetadata(rc.getName(), rc.getType(), rc.getVersion(), rc.getCapabilitiesList()));
     }
 
     return components;
@@ -1295,9 +1311,9 @@ public class DaprClientImpl extends AbstractDaprClient {
       List<PubsubSubscriptionRule> rulesList = s.getRules().getRulesList();
       List<RuleMetadata> rules = new ArrayList<>();
       for (PubsubSubscriptionRule r : rulesList) {
-        rules.add(new RuleMetadata(r.getPath()));
+        rules.add(new RuleMetadata(r.getMatch(), r.getPath()));
       }
-      subscriptions.add(new SubscriptionMetadata(s.getTopic(), s.getPubsubName(), s.getDeadLetterTopic(), rules));
+      subscriptions.add(new SubscriptionMetadata(s.getPubsubName(), s.getTopic(), rules, s.getDeadLetterTopic()));
     }
 
     return subscriptions;

--- a/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
@@ -1313,7 +1313,8 @@ public class DaprClientImpl extends AbstractDaprClient {
       for (PubsubSubscriptionRule r : rulesList) {
         rules.add(new RuleMetadata(r.getMatch(), r.getPath()));
       }
-      subscriptions.add(new SubscriptionMetadata(s.getPubsubName(), s.getTopic(), rules, s.getDeadLetterTopic()));
+      subscriptions.add(new SubscriptionMetadata(s.getPubsubName(), s.getTopic(), s.getMetadataMap(), rules,
+          s.getDeadLetterTopic()));
     }
 
     return subscriptions;

--- a/sdk/src/main/java/io/dapr/client/domain/ActorMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/ActorMetadata.java
@@ -14,23 +14,28 @@ limitations under the License.
 package io.dapr.client.domain;
 
 /**
- * HttpEndpointMetadata describes a registered Dapr HTTP endpoint.
+ * ActorMetadata describes a registered Dapr Actor.
  */
-public final class HttpEndpointMetadata {
-
-  private final String name;
+public final class ActorMetadata {
+  private final String type;
+  private final int count;
 
   /**
-   * Constructor for a HttpEndpointMetadata.
+   * Constructor for a ActorMetadata.
    *
-   * @param name of the HTTP endpoint
+   * @param type of the actor
+   * @param count number of actors of a particular type
    */
-  public HttpEndpointMetadata(String name) {
-    this.name = name;
+  public ActorMetadata(String type, int count) {
+    this.type = type;
+    this.count = count;
   }
 
-  public String getName() {
-    return name;
+  public String getType() {
+    return type;
   }
 
+  public int getCount() {
+    return count;
+  }
 }

--- a/sdk/src/main/java/io/dapr/client/domain/AppConnectionPropertiesHealthMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/AppConnectionPropertiesHealthMetadata.java
@@ -13,6 +13,9 @@ limitations under the License.
 
 package io.dapr.client.domain;
 
+/**
+ * AppConnectionPropertiesHealthMetadata describes the application health properties.
+ */
 public final class AppConnectionPropertiesHealthMetadata {
 
   private final String healthCheckPath;

--- a/sdk/src/main/java/io/dapr/client/domain/AppConnectionPropertiesMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/AppConnectionPropertiesMetadata.java
@@ -13,6 +13,9 @@ limitations under the License.
 
 package io.dapr.client.domain;
 
+/**
+ * AppConnectionPropertiesMetadata describes the application connection properties.
+ */
 public final class AppConnectionPropertiesMetadata {
 
   private final int port;

--- a/sdk/src/main/java/io/dapr/client/domain/ComponentMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/ComponentMetadata.java
@@ -13,16 +13,18 @@ limitations under the License.
 
 package io.dapr.client.domain;
 
-import java.util.Objects;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * ComponentMetadata describes a Dapr Component.
  */
 public final class ComponentMetadata {
 
-  private String name;
-  private String type;
-  private String version;
+  private final String name;
+  private final String type;
+  private final String version;
+  private final List<String> capabilities;
 
   /**
    * Constructor for a ComponentMetadata.
@@ -30,11 +32,13 @@ public final class ComponentMetadata {
    * @param name of the component
    * @param type component type
    * @param version version of the component
+   * @param capabilities capabilities of the component
    */
-  public ComponentMetadata(String name, String type, String version) {
+  public ComponentMetadata(String name, String type, String version, List<String> capabilities) {
     this.name = name;
     this.type = type;
     this.version = version;
+    this.capabilities = capabilities == null ? Collections.emptyList() : Collections.unmodifiableList(capabilities);
   }
 
   public String getName() {
@@ -48,5 +52,9 @@ public final class ComponentMetadata {
   public String getVersion() {
     return version;
   }
- 
+
+  public List<String> getCapabilities() {
+    return capabilities;
+  }
+
 }

--- a/sdk/src/main/java/io/dapr/client/domain/DaprMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/DaprMetadata.java
@@ -25,6 +25,7 @@ public final class DaprMetadata {
   private final String id;
   private final String runtimeVersion;
   private final List<String> enabledFeatures;
+  private final List<ActorMetadata> actors;
   private final Map<String, String> attributes;
   private final List<ComponentMetadata> components;
   private final List<HttpEndpointMetadata> httpEndpoints;
@@ -37,19 +38,21 @@ public final class DaprMetadata {
    * @param id of the application
    * @param runtimeVersion Dapr version
    * @param enabledFeatures list of enabled features
+   * @param actors list of registered features
    * @param attributes map of extended attributes
    * @param components list of registered components
    * @param httpEndpoints list of registered http endpoints
    * @param subscriptions list of registered subscription
    * @param appConnectionProperties connection properties of the application
    */
-  public DaprMetadata(String id, String runtimeVersion, List<String> enabledFeatures, Map<String, String> attributes,
-      List<ComponentMetadata> components, List<HttpEndpointMetadata> httpEndpoints,
+  public DaprMetadata(String id, String runtimeVersion, List<String> enabledFeatures, List<ActorMetadata> actors,
+      Map<String, String> attributes, List<ComponentMetadata> components, List<HttpEndpointMetadata> httpEndpoints,
       List<SubscriptionMetadata> subscriptions, AppConnectionPropertiesMetadata appConnectionProperties) {
     this.id = id;
     this.runtimeVersion = runtimeVersion;
     this.enabledFeatures = enabledFeatures == null ? Collections.emptyList() :
       Collections.unmodifiableList(enabledFeatures);
+    this.actors = actors == null ? Collections.emptyList() : Collections.unmodifiableList(actors);
     this.attributes = attributes == null ? Collections.emptyMap() : Collections.unmodifiableMap(attributes);
     this.components = components == null ? Collections.emptyList() : Collections.unmodifiableList(components);
     this.httpEndpoints = httpEndpoints == null ? Collections.emptyList() : Collections.unmodifiableList(httpEndpoints);
@@ -67,6 +70,10 @@ public final class DaprMetadata {
 
   public List<String> getEnabledFeatures() {
     return enabledFeatures;
+  }
+
+  public List<ActorMetadata> getActors() {
+    return actors;
   }
 
   public Map<String, String> getAttributes() {

--- a/sdk/src/main/java/io/dapr/client/domain/RuleMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/RuleMetadata.java
@@ -17,10 +17,23 @@ package io.dapr.client.domain;
  * RuleMetadata describes the Subscription Rule's Metadata.
  */
 public final class RuleMetadata {
-  private String path;
 
-  public RuleMetadata(String path) {
+  private final String match;
+  private final String path;
+
+  /**
+   * Constructor for a RuleMetadata.
+   *
+   * @param match CEL expression to match the message
+   * @param path path to route the message
+   */
+  public RuleMetadata(String match, String path) {
+    this.match = match;
     this.path = path;
+  }
+
+  public String getMatch() {
+    return match;
   }
 
   public String getPath() {

--- a/sdk/src/main/java/io/dapr/client/domain/SubscriptionMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/SubscriptionMetadata.java
@@ -15,48 +15,46 @@ package io.dapr.client.domain;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * SubscriptionMetadata describes the Subscription Metadata.
  */
 public final class SubscriptionMetadata {
-  private String topic;
-  private String pubsubname;
-  private String deadLetterTopic;
-  private List<RuleMetadata> rules;
+
+  private final String pubsubname;
+  private final String topic;
+  private final List<RuleMetadata> rules;
+  private final String deadLetterTopic;
 
   /**
    * Constructor for a SubscriptionMetadata.
    *
-   * @param topic of the pubsub component
    * @param pubsubname component name
-   * @param deadLetterTopic dead letter topic  
+   * @param topic of the pubsub component
    * @param rules subscription path rules
+   * @param deadLetterTopic dead letter topic
    */
-  public SubscriptionMetadata(String topic, String pubsubname, String deadLetterTopic, List<RuleMetadata> rules) {
-    this.topic = topic;
+  public SubscriptionMetadata(String pubsubname, String topic, List<RuleMetadata> rules, String deadLetterTopic) {
     this.pubsubname = pubsubname;
-    this.deadLetterTopic = deadLetterTopic;
+    this.topic = topic;
     this.rules = rules == null ? Collections.emptyList() : Collections.unmodifiableList(rules);
-  }
-
-  public String getTopic() {
-    return topic;
+    this.deadLetterTopic = deadLetterTopic;
   }
 
   public String getPubsubname() {
     return pubsubname;
   }
 
-
-  public String getDeadLetterTopic() {
-    return deadLetterTopic;
+  public String getTopic() {
+    return topic;
   }
-
 
   public List<RuleMetadata> getRules() {
     return rules;
+  }
+
+  public String getDeadLetterTopic() {
+    return deadLetterTopic;
   }
 
 }

--- a/sdk/src/main/java/io/dapr/client/domain/SubscriptionMetadata.java
+++ b/sdk/src/main/java/io/dapr/client/domain/SubscriptionMetadata.java
@@ -15,6 +15,7 @@ package io.dapr.client.domain;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * SubscriptionMetadata describes the Subscription Metadata.
@@ -23,6 +24,7 @@ public final class SubscriptionMetadata {
 
   private final String pubsubname;
   private final String topic;
+  private final Map<String, String> metadata;
   private final List<RuleMetadata> rules;
   private final String deadLetterTopic;
 
@@ -31,12 +33,15 @@ public final class SubscriptionMetadata {
    *
    * @param pubsubname component name
    * @param topic of the pubsub component
+   * @param metadata of the pubsub component
    * @param rules subscription path rules
    * @param deadLetterTopic dead letter topic
    */
-  public SubscriptionMetadata(String pubsubname, String topic, List<RuleMetadata> rules, String deadLetterTopic) {
+  public SubscriptionMetadata(String pubsubname, String topic, Map<String, String> metadata, List<RuleMetadata> rules,
+      String deadLetterTopic) {
     this.pubsubname = pubsubname;
     this.topic = topic;
+    this.metadata = metadata == null ? Collections.emptyMap() : Collections.unmodifiableMap(metadata);
     this.rules = rules == null ? Collections.emptyList() : Collections.unmodifiableList(rules);
     this.deadLetterTopic = deadLetterTopic;
   }
@@ -47,6 +52,10 @@ public final class SubscriptionMetadata {
 
   public String getTopic() {
     return topic;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
   }
 
   public List<RuleMetadata> getRules() {


### PR DESCRIPTION
# Description

There were a couple of PRs related to `getMetadata()` method that has been added to `DaprClient`, but the `DaprMetadata` didn't contain all the details found here: https://docs.dapr.io/reference/api/metadata_api. This PR adds all the missing pieces

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/1058

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
