### PR TITLE
Upgrade OTEL to v1.39.0 in integration tests

### DIFF
--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -20,7 +20,7 @@
     <protobuf.input.directory>${project.basedir}/proto</protobuf.input.directory>
     <grpc.version>1.59.0</grpc.version>
     <protobuf.version>3.17.3</protobuf.version>
-    <opentelemetry.version>0.14.0</opentelemetry.version>
+    <opentelemetry.version>1.39.0</opentelemetry.version>
     <spring-boot.version>3.0.13</spring-boot.version>
   </properties>
 
@@ -103,7 +103,12 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-metrics</artifactId>
-      <version>${opentelemetry.version}-alpha</version>
+      <version>${opentelemetry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-common</artifactId>
+      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
@@ -114,6 +119,17 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-zipkin</artifactId>
       <version>${opentelemetry.version}</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.zipkin.reporter2/zipkin-reporter -->
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>3.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
@@ -9,9 +9,9 @@ import io.dapr.it.DaprRun;
 import io.dapr.it.tracing.Validation;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,28 +37,27 @@ public class TracingIT extends BaseIT {
           AppRun.AppProtocol.GRPC,  // appProtocol
           60000);
 
-        daprRun.waitForAppHealth(10000);
+        daprRun.waitForAppHealth(60000);
     }
 
     @Test
     public void testInvoke() throws Exception {
-        final OpenTelemetry openTelemetry = createOpenTelemetry("service over grpc");
-        final Tracer tracer = openTelemetry.getTracer("grpc integration test tracer");
-
-        final String spanName = UUID.randomUUID().toString();
-        Span span = tracer.spanBuilder(spanName).setSpanKind(Span.Kind.CLIENT).startSpan();
+        OpenTelemetry openTelemetry = createOpenTelemetry("service over grpc");
+        Tracer tracer = openTelemetry.getTracer("grpc integration test tracer");
+        String spanName = UUID.randomUUID().toString();
+        Span span = tracer.spanBuilder(spanName).setSpanKind(SpanKind.CLIENT).startSpan();
 
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
             try (Scope scope = span.makeCurrent()) {
                 SleepRequest req = SleepRequest.newBuilder().setSeconds(1).build();
                 client.invokeMethod(daprRun.getAppName(), "sleepOverGRPC", req.toByteArray(), HttpExtension.POST)
-                    .contextWrite(getReactorContext())
+                    .contextWrite(getReactorContext(openTelemetry))
                     .block();
             }
         }
+
         span.end();
-        OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
 
         Validation.validate(spanName, "calllocal/tracingitgrpc-service/sleepovergrpc");
     }

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
@@ -37,7 +37,7 @@ public class TracingIT extends BaseIT {
           AppRun.AppProtocol.GRPC,  // appProtocol
           60000);
 
-        daprRun.waitForAppHealth(60000);
+        daprRun.waitForAppHealth(10000);
     }
 
     @Test

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/http/OpenTelemetryInterceptor.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/http/OpenTelemetryInterceptor.java
@@ -15,6 +15,7 @@ package io.dapr.it.tracing.http;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,9 +33,9 @@ public class OpenTelemetryInterceptor implements HandlerInterceptor {
   @Autowired
   private OpenTelemetry openTelemetry;
 
-  // implmentation for springboot 3.0, which uses jakarta.servlet instead of javax.servlet
-  private static final TextMapPropagator.Getter<HttpServletRequest> JAKARTA_HTTP_SERVLET_REQUEST_GETTER =
-      new TextMapPropagator.Getter<>() {
+  // Implementation for springboot 3.0, which uses jakarta.servlet instead of javax.servlet
+  private static final TextMapGetter<HttpServletRequest> JAKARTA_HTTP_SERVLET_REQUEST_GETTER =
+      new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(HttpServletRequest carrier) {
           return Collections.list(carrier.getHeaderNames());
@@ -67,9 +68,9 @@ public class OpenTelemetryInterceptor implements HandlerInterceptor {
   }
 
   
-  // implmentation for springboot 3.0, which uses jakarta.servlet instead of javax.servlet
-  private static final TextMapPropagator.Getter<javax.servlet.http.HttpServletRequest> JAVA_HTTP_SERVLET_REQUEST_GETTER =
-      new TextMapPropagator.Getter<>() {
+  // Implementation for springboot 3.0, which uses jakarta.servlet instead of javax.servlet
+  private static final TextMapGetter<javax.servlet.http.HttpServletRequest> JAVA_HTTP_SERVLET_REQUEST_GETTER =
+      new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(javax.servlet.http.HttpServletRequest carrier) {
           return Collections.list(carrier.getHeaderNames());

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/http/OpenTelemetryInterceptorConfig.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/http/OpenTelemetryInterceptorConfig.java
@@ -28,4 +28,5 @@ public class OpenTelemetryInterceptorConfig extends WebMvcConfigurationSupport {
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(interceptor);
   }
+
 }

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/http/TracingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/http/TracingIT.java
@@ -8,9 +8,9 @@ import io.dapr.it.DaprRun;
 import io.dapr.it.tracing.Validation;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,22 +41,21 @@ public class TracingIT extends BaseIT {
 
     @Test
     public void testInvoke() throws Exception {
-        final OpenTelemetry openTelemetry = createOpenTelemetry(OpenTelemetryConfig.SERVICE_NAME);
-        final Tracer tracer = openTelemetry.getTracer(OpenTelemetryConfig.TRACER_NAME);
-
-        final String spanName = UUID.randomUUID().toString();
-        Span span = tracer.spanBuilder(spanName).setSpanKind(Span.Kind.CLIENT).startSpan();
+        OpenTelemetry openTelemetry = createOpenTelemetry(OpenTelemetryConfig.SERVICE_NAME);
+        Tracer tracer = openTelemetry.getTracer(OpenTelemetryConfig.TRACER_NAME);
+        String spanName = UUID.randomUUID().toString();
+        Span span = tracer.spanBuilder(spanName).setSpanKind(SpanKind.CLIENT).startSpan();
 
         try (DaprClient client = new DaprClientBuilder().build()) {
             client.waitForSidecar(10000).block();
             try (Scope scope = span.makeCurrent()) {
                 client.invokeMethod(daprRun.getAppName(), "sleep", 1, HttpExtension.POST)
-                    .contextWrite(getReactorContext())
+                    .contextWrite(getReactorContext(openTelemetry))
                     .block();
             }
         }
+
         span.end();
-        OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
 
         Validation.validate(spanName, "calllocal/tracingithttp-service/sleep");
     }


### PR DESCRIPTION
# Description

While we were trying to upgrade to Spring Boot 3.2.x and 3.3.x as part of #1050 we saw that `TracingIT` tests are failing. Upon further investigation it was clear that there are mismatches between OTEL that is brought in by Spring Boot 3.2.x and the OTEL version used in integration tests. This PR tries to upgrade OTEL to version 1.39.0 which is the latest. available version.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/1063

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
