### PR TITLE
Adding Dapr Container default wait strategy based on healthz/outbound

### DIFF
--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -25,7 +25,7 @@
     <springboot.version>3.3.1</springboot.version>
     <logback-classic.version>1.4.12</logback-classic.version>
     <wiremock.version>3.9.1</wiremock.version>
-    <testcontainers-dapr.version>0.13.0-SNAPSHOT</testcontainers-dapr.version>
+    <testcontainers-dapr.version>${dapr.sdk.alpha.version}</testcontainers-dapr.version>
     <testcontainers-test.version>1.20.0</testcontainers-test.version>
   </properties>
 

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -25,6 +25,8 @@
     <springboot.version>3.3.1</springboot.version>
     <logback-classic.version>1.4.12</logback-classic.version>
     <wiremock.version>3.9.1</wiremock.version>
+    <testcontainers-dapr.version>0.13.0-SNAPSHOT</testcontainers-dapr.version>
+    <testcontainers-test.version>1.20.0</testcontainers-test.version>
   </properties>
 
   <dependencyManagement>
@@ -213,6 +215,17 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.1</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dapr</groupId>
+      <artifactId>testcontainers-dapr</artifactId>
+      <version>${testcontainers-dapr.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers-test.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/DaprContainerTest.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/DaprContainerTest.java
@@ -13,7 +13,7 @@ limitations under the License.
 
 package io.dapr.it.testcontainers;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.Metadata;
@@ -23,10 +23,10 @@ import io.dapr.testcontainers.DaprContainer;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.testcontainers.Testcontainers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.util.Map;
@@ -43,11 +43,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
+@Testcontainers
+@WireMockTest(httpPort = 8081)
 public class DaprContainerTest {
 
   // Time-to-live for messages published.
@@ -57,10 +58,7 @@ public class DaprContainerTest {
   private static final String PUBSUB_NAME = "pubsub";
   private static final String PUBSUB_TOPIC_NAME = "topic";
 
-  @ClassRule
-  public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8081));
-
-  @ClassRule
+  @Container
   public static DaprContainer daprContainer = new DaprContainer("daprio/daprd")
       .withAppName("dapr-app")
       .withAppPort(8081)
@@ -69,16 +67,15 @@ public class DaprContainerTest {
   /**
    * Sets the Dapr properties for the test.
    */
-  @BeforeClass
+  @BeforeAll
   public static void setDaprProperties() {
     configStub();
-    Testcontainers.exposeHostPorts(8081);
+    org.testcontainers.Testcontainers.exposeHostPorts(8081);
     System.setProperty("dapr.grpc.port", Integer.toString(daprContainer.getGrpcPort()));
     System.setProperty("dapr.http.port", Integer.toString(daprContainer.getHttpPort()));
   }
 
   private static void configStub() {
-
     stubFor(any(urlMatching("/dapr/subscribe"))
         .willReturn(aResponse().withBody("[]").withStatus(200)));
 
@@ -98,19 +95,20 @@ public class DaprContainerTest {
   @Test
   public void testDaprContainerDefaults() {
     assertEquals(
-        "The pubsub and kvstore component should be configured by default",
         2,
-        daprContainer.getComponents().size());
+        daprContainer.getComponents().size(),
+        "The pubsub and kvstore component should be configured by default"
+    );
     assertEquals(
-        "A subscription should be configured by default if none is provided",
         1,
-        daprContainer.getSubscriptions().size());
+        daprContainer.getSubscriptions().size(),
+        "A subscription should be configured by default if none is provided");
   }
 
   @Test
   public void testStateStore() throws Exception {
     try (DaprClient client = (new DaprClientBuilder()).build()) {
-      client.waitForSidecar(5000).block();
+      client.waitForSidecar(1000).block();
 
       String value = "value";
       // Save state
@@ -127,7 +125,7 @@ public class DaprContainerTest {
   public void testPlacement() throws Exception {
     // Here we are just waiting for Dapr to be ready
     try (DaprClient client = (new DaprClientBuilder()).build()) {
-      client.waitForSidecar(5000).block();
+      client.waitForSidecar(1000).block();
     }
 
     OkHttpClient client = new OkHttpClient.Builder().build();
@@ -143,13 +141,12 @@ public class DaprContainerTest {
         throw new IOException("Unexpected response: " + response.code());
       }
     }
-
   }
 
   @Test
   public void testPubSub() throws Exception {
     try (DaprClient client = (new DaprClientBuilder()).build()) {
-      client.waitForSidecar(5000).block();
+      client.waitForSidecar(1000).block();
 
       String message = "message content";
       Map<String, String> metadata = singletonMap(Metadata.TTL_IN_SECONDS, MESSAGE_TTL_IN_SECONDS);

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/DaprPlacementContainerTest.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/DaprPlacementContainerTest.java
@@ -11,19 +11,23 @@
 limitations under the License.
 */
 
-package io.dapr.testcontainers;
+package io.dapr.it.testcontainers;
 
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import io.dapr.testcontainers.DaprPlacementContainer;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
 public class DaprPlacementContainerTest {
 
-  @ClassRule
-  public static DaprPlacementContainer placement = new DaprPlacementContainer("daprio/placement");
+  @Container
+  private static final DaprPlacementContainer PLACEMENT_CONTAINER = new DaprPlacementContainer("daprio/placement");
 
   @Test
   public void testDaprPlacementContainerDefaults() {
-    Assert.assertEquals("The default port is set", 50005, placement.getPort());
+    assertEquals(50005, PLACEMENT_CONTAINER.getPort(), "The default port is set");
   }
 }

--- a/testcontainers-dapr/pom.xml
+++ b/testcontainers-dapr/pom.xml
@@ -15,6 +15,11 @@
 	<packaging>jar</packaging>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprProtocol.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprProtocol.java
@@ -17,7 +17,7 @@ public enum DaprProtocol {
   HTTP("http"),
   GRPC("grpc");
 
-  private String name;
+  private final String name;
 
   DaprProtocol(String name) {
     this.name = name;

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/Subscription.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/Subscription.java
@@ -14,10 +14,10 @@ limitations under the License.
 package io.dapr.testcontainers;
 
 public class Subscription {
-  private String name;
-  private String pubsubName;
-  private String topic;
-  private String route;
+  private final String name;
+  private final String pubsubName;
+  private final String topic;
+  private final String route;
 
   /**
    * Creates a new subscription.

--- a/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
+++ b/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
@@ -13,8 +13,7 @@ limitations under the License.
 
 package io.dapr.testcontainers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -22,7 +21,9 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Set;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DaprComponentTest {
 
@@ -39,10 +40,10 @@ public class DaprComponentTest {
         .withAppChannelAddress("host.testcontainers.internal");
 
     Set<Component> components = dapr.getComponents();
-    Assert.assertEquals(1, components.size());
+    assertEquals(1, components.size());
 
     Component kvstore = components.iterator().next();
-    Assert.assertEquals(false, kvstore.getMetadata().isEmpty());
+    assertFalse(kvstore.getMetadata().isEmpty());
 
     String componentYaml = dapr.componentToYaml(kvstore);
     String expectedComponentYaml = "metadata:\n" + "  name: statestore\n"
@@ -55,25 +56,21 @@ public class DaprComponentTest {
         + "  type: state.in-memory\n"
         + "  version: v1\n";
 
-    Assert.assertEquals(expectedComponentYaml, componentYaml);
+    assertEquals(expectedComponentYaml, componentYaml);
   }
 
   @Test
   public void containerConfigurationTest() {
     DaprContainer dapr = new DaprContainer("daprio/daprd")
-            .withAppName("dapr-app")
-            .withAppPort(8081)
-            .withDaprLogLevel(DaprLogLevel.DEBUG)
-            .withAppChannelAddress("host.testcontainers.internal");
+        .withAppName("dapr-app")
+        .withAppPort(8081)
+        .withDaprLogLevel(DaprLogLevel.DEBUG)
+        .withAppChannelAddress("host.testcontainers.internal");
 
     dapr.configure();
 
-    assertThrows(IllegalStateException.class, () -> { dapr.getHttpEndpoint(); });
-    assertThrows(IllegalStateException.class, () -> { dapr.getGrpcPort(); });
-
-
-
-
+    assertThrows(IllegalStateException.class, dapr::getHttpEndpoint);
+    assertThrows(IllegalStateException.class, dapr::getGrpcPort);
   }
 
   @Test
@@ -85,7 +82,7 @@ public class DaprComponentTest {
         .withAppChannelAddress("host.testcontainers.internal");
 
     Set<Subscription> subscriptions = dapr.getSubscriptions();
-    Assert.assertEquals(1, subscriptions.size());
+    assertEquals(1, subscriptions.size());
 
     String subscriptionYaml = dapr.subscriptionToYaml(subscriptions.iterator().next());
     String expectedSubscriptionYaml = "metadata:\n" + "  name: my-subscription\n"
@@ -95,7 +92,7 @@ public class DaprComponentTest {
         + "  route: /events\n"
         + "  pubsubname: pubsub\n"
         + "  topic: topic\n";
-    Assert.assertEquals(expectedSubscriptionYaml, subscriptionYaml);
+    assertEquals(expectedSubscriptionYaml, subscriptionYaml);
   }
 
   @Test
@@ -110,9 +107,9 @@ public class DaprComponentTest {
         .withAppChannelAddress("host.testcontainers.internal");
 
     Set<Component> components = dapr.getComponents();
-    Assert.assertEquals(1, components.size());
+    assertEquals(1, components.size());
     Component kvstore = components.iterator().next();
-    Assert.assertEquals(false, kvstore.getMetadata().isEmpty());
+    assertFalse(kvstore.getMetadata().isEmpty());
 
     String componentYaml = dapr.componentToYaml(kvstore);
     String expectedComponentYaml = "metadata:\n"
@@ -136,6 +133,6 @@ public class DaprComponentTest {
         + "  type: null\n"
         + "  version: v1\n";
 
-    Assert.assertEquals(expectedComponentYaml, componentYaml);
+    assertEquals(expectedComponentYaml, componentYaml);
   }
 }


### PR DESCRIPTION
# Description

Adding Dapr Container default wait strategy based on healthz/outbound

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1104

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
