### PR TITLE
Adding Maven Profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       run: ./mvnw install -q -B -DskipTests
     - name: Integration tests using spring boot version ${{ matrix.spring-boot-version }}
       id: integration_tests
-      run: PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} ./mvnw -B -f sdk-tests/pom.xml verify
+      run: PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} ./mvnw -B -Pintegration-tests verify
     - name: Upload test report for sdk
       uses: actions/upload-artifact@v4
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -318,24 +318,19 @@
     <tag>HEAD</tag>
   </scm>
 
+  <modules>
+    <module>sdk-autogen</module>
+    <module>sdk</module>
+    <module>sdk-actors</module>
+    <module>sdk-workflows</module>
+    <module>sdk-springboot</module>
+    <module>dapr-spring</module>
+    <module>examples</module>
+    <!-- We are following test containers artifact convention on purpose, don't rename -->
+    <module>testcontainers-dapr</module>
+  </modules>
+
   <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <modules>
-        <module>sdk-autogen</module>
-        <module>sdk</module>
-        <module>sdk-actors</module>
-        <module>sdk-workflows</module>
-        <module>sdk-springboot</module>
-        <module>dapr-spring</module>
-        <module>examples</module>
-        <!-- We are following test containers artifact convention on purpose, don't rename -->
-        <module>testcontainers-dapr</module>
-      </modules>
-    </profile>
     <profile>
       <id>integration-tests</id>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -318,20 +318,30 @@
     <tag>HEAD</tag>
   </scm>
 
-  <modules>
-    <module>sdk-autogen</module>
-    <module>sdk</module>
-    <module>sdk-actors</module>
-    <module>sdk-workflows</module>
-    <module>sdk-springboot</module>
-    <module>dapr-spring</module>
-    <module>examples</module>
-    <!-- We are following test containers artifact convention on purpose, don't rename -->
-    <module>testcontainers-dapr</module>
-    <!-- don't add sdk-tests to the build, 
-      it's only used for CI testing by github action
-    <module>sdk-tests</module>
-    -->
-  </modules>
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>sdk-autogen</module>
+        <module>sdk</module>
+        <module>sdk-actors</module>
+        <module>sdk-workflows</module>
+        <module>sdk-springboot</module>
+        <module>dapr-spring</module>
+        <module>examples</module>
+        <!-- We are following test containers artifact convention on purpose, don't rename -->
+        <module>testcontainers-dapr</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>integration-tests</id>
+      <modules>
+        <module>sdk-tests</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -4,9 +4,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.dapr</groupId>
+  <parent>
+    <groupId>io.dapr</groupId>
+    <artifactId>dapr-sdk-parent</artifactId>
+    <version>1.13.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>dapr-sdk-tests</artifactId>
-  <version>0.0.0-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <name>dapr-sdk-tests</name>
   <description>Tests for Dapr's Java SDK - not to be published as a jar.</description>
 
@@ -320,15 +325,6 @@
       <properties>
         <springboot.version>${env.PRODUCT_SPRING_BOOT_VERSION}</springboot.version>
       </properties>
-      <dependencies>
-        <dependency>
-          <!-- Needed for dapr compatibility for spring boot versions before 2.7 -->
-          <groupId>com.squareup.okhttp3</groupId>
-          <artifactId>okhttp</artifactId>
-          <version>4.9.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
# Description

This PR adds support for Maven Profiles so we can improve developer experience when developing the Dapr Java SDK. This should allow us to load all the code in a single IDE instance while allowing us the flexibility to run integration test modules separately from the main code.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1119.

It is also somewhat related to #1075.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
