### PR TITLE
Add Micrometer Observation support to Spring Dapr Messaging

### DIFF
--- a/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
@@ -28,8 +28,8 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -40,6 +40,10 @@
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-keyvalue</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-tracing-bridge-otel</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
@@ -42,10 +42,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-tracing-bridge-otel</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <scope>test</scope>

--- a/dapr-spring/dapr-spring-boot-autoconfigure/src/main/java/io/dapr/spring/boot/autoconfigure/pubsub/DaprPubSubProperties.java
+++ b/dapr-spring/dapr-spring-boot-autoconfigure/src/main/java/io/dapr/spring/boot/autoconfigure/pubsub/DaprPubSubProperties.java
@@ -25,6 +25,7 @@ public class DaprPubSubProperties {
    * Name of the PubSub Dapr component.
    */
   private String name;
+  private boolean observationEnabled;
 
   public String getName() {
     return name;
@@ -34,4 +35,11 @@ public class DaprPubSubProperties {
     this.name = name;
   }
 
+  public boolean isObservationEnabled() {
+    return observationEnabled;
+  }
+
+  public void setObservationEnabled(boolean observationEnabled) {
+    this.observationEnabled = observationEnabled;
+  }
 }

--- a/dapr-spring/dapr-spring-messaging/pom.xml
+++ b/dapr-spring/dapr-spring-messaging/pom.xml
@@ -12,6 +12,13 @@
   <artifactId>dapr-spring-messaging</artifactId>
   <name>dapr-spring-messaging</name>
   <description>Dapr Spring Messaging</description>
-    <packaging>jar</packaging>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-tracing</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/dapr-spring/dapr-spring-messaging/pom.xml
+++ b/dapr-spring/dapr-spring-messaging/pom.xml
@@ -14,11 +14,4 @@
   <description>Dapr Spring Messaging</description>
   <packaging>jar</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-tracing</artifactId>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/DaprMessagingTemplate.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/DaprMessagingTemplate.java
@@ -113,7 +113,7 @@ public class DaprMessagingTemplate<T> implements DaprMessagingOperations<T>, App
 
   @Override
   public SendMessageBuilder<T> newMessage(T message) {
-    return new DeefaultSendMessageBuilder<>(this, message);
+    return new DefaultSendMessageBuilder<>(this, message);
   }
 
   private void doSend(String topic, T message) {
@@ -170,7 +170,7 @@ public class DaprMessagingTemplate<T> implements DaprMessagingOperations<T>, App
     );
   }
 
-  private static class DeefaultSendMessageBuilder<T> implements SendMessageBuilder<T> {
+  private static class DefaultSendMessageBuilder<T> implements SendMessageBuilder<T> {
 
     private final DaprMessagingTemplate<T> template;
 
@@ -178,7 +178,7 @@ public class DaprMessagingTemplate<T> implements DaprMessagingOperations<T>, App
 
     private String topic;
 
-    DeefaultSendMessageBuilder(DaprMessagingTemplate<T> template, T message) {
+    DefaultSendMessageBuilder(DaprMessagingTemplate<T> template, T message) {
       this.template = template;
       this.message = message;
     }

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/DaprMessagingTemplate.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/DaprMessagingTemplate.java
@@ -18,7 +18,6 @@ import io.dapr.client.domain.Metadata;
 import io.dapr.spring.messaging.observation.DaprMessagingObservationConvention;
 import io.dapr.spring.messaging.observation.DaprMessagingObservationDocumentation;
 import io.dapr.spring.messaging.observation.DaprMessagingSenderContext;
-import io.dapr.spring.messaging.observation.DefaultDaprMessagingObservationConvention;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
@@ -43,7 +42,7 @@ public class DaprMessagingTemplate<T> implements DaprMessagingOperations<T>, App
   private static final Logger LOGGER = LoggerFactory.getLogger(DaprMessagingTemplate.class);
   private static final String MESSAGE_TTL_IN_SECONDS = "10";
   private static final DaprMessagingObservationConvention DEFAULT_OBSERVATION_CONVENTION =
-      DefaultDaprMessagingObservationConvention.INSTANCE;
+      DaprMessagingObservationConvention.getDefault();
 
   private final DaprClient daprClient;
   private final String pubsubName;

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationConvention.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationConvention.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.spring.messaging.observation;
+
+import io.micrometer.observation.Observation.Context;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * {@link ObservationConvention} for Dapr Messaging.
+ *
+ */
+public interface DaprMessagingObservationConvention extends ObservationConvention<DaprMessagingSenderContext> {
+
+  @Override
+  default boolean supportsContext(Context context) {
+    return context instanceof DaprMessagingSenderContext;
+  }
+
+  @Override
+  default String getName() {
+    return "spring.dapr.messaging.template";
+  }
+
+}

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationConvention.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationConvention.java
@@ -32,4 +32,8 @@ public interface DaprMessagingObservationConvention extends ObservationConventio
     return "spring.dapr.messaging.template";
   }
 
+  static DaprMessagingObservationConvention getDefault() {
+    return DefaultDaprMessagingObservationConvention.INSTANCE;
+  }
+
 }

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationDocumentation.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingObservationDocumentation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.spring.messaging.observation;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Context;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+/**
+ * An {@link Observation} for {@link io.dapr.spring.messaging.DaprMessagingTemplate}.
+ *
+ */
+public enum DaprMessagingObservationDocumentation implements ObservationDocumentation {
+
+  /**
+   * Observation created when a Dapr template sends a message.
+   */
+  TEMPLATE_OBSERVATION {
+
+    @Override
+    public Class<? extends ObservationConvention<? extends Context>> getDefaultConvention() {
+      return DefaultDaprMessagingObservationConvention.class;
+    }
+
+    @Override
+    public String getPrefix() {
+      return "spring.dapr.messaging.template";
+    }
+
+    @Override
+    public KeyName[] getLowCardinalityKeyNames() {
+      return TemplateLowCardinalityTags.values();
+    }
+  };
+
+  /**
+   * Low cardinality tags.
+   */
+  public enum TemplateLowCardinalityTags implements KeyName {
+    /**
+     * Bean name of the template that sent the message.
+     */
+    BEAN_NAME {
+
+      @Override
+      public String asString() {
+        return "spring.dapr.messaging.template.name";
+      }
+    }
+  }
+}

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingSenderContext.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DaprMessagingSenderContext.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.spring.messaging.observation;
+
+import io.micrometer.observation.transport.SenderContext;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link SenderContext} for Dapr Messaging.
+ *
+ */
+public final class DaprMessagingSenderContext extends SenderContext<DaprMessagingSenderContext.Carrier> {
+  private final String beanName;
+
+  private final String destination;
+
+  private DaprMessagingSenderContext(Carrier dataHolder, String topic, String beanName) {
+    super((carrier, key, value) -> dataHolder.property(key, value));
+    setCarrier(dataHolder);
+    this.beanName = beanName;
+    this.destination = topic;
+  }
+
+  /**
+   * Create a new context.
+   * @param topic topic to be used
+   * @param beanName name of the bean used usually (typically a {@code DaprMessagingTemplate})
+   * @return DaprMessageSenderContext
+   */
+  public static DaprMessagingSenderContext newContext(String topic, String beanName) {
+    Carrier carrier = new Carrier();
+    return new DaprMessagingSenderContext(carrier, topic, beanName);
+  }
+
+  /**
+   * The properties of the message.
+   * @return the properties of the message
+   */
+  public Map<String, String> properties() {
+    Carrier carrier = getCarrier();
+
+    if (carrier == null) {
+      return Map.of();
+    }
+
+    return carrier.properties();
+  }
+
+
+  /**
+   * The name of the bean sending the message (typically a {@code DaprMessagingTemplate}).
+   * @return the name of the bean sending the message
+   */
+  public String getBeanName() {
+    return this.beanName;
+  }
+
+  /**
+   * The destination topic for the message.
+   * @return the topic the message is being sent to
+   */
+  public String getDestination() {
+    return this.destination;
+  }
+
+
+  /**
+   * Acts as a carrier for a Dapr message and records the propagated properties for
+   * later access by the Dapr.
+   */
+  public static final class Carrier {
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    private Carrier() {
+    }
+
+    public void property(String key, String value) {
+      this.properties.put(key, value);
+    }
+
+    public Map<String, String> properties() {
+      return Map.copyOf(this.properties);
+    }
+  }
+}

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DefaultDaprMessagingObservationConvention.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DefaultDaprMessagingObservationConvention.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.spring.messaging.observation;
+
+import io.micrometer.common.KeyValues;
+
+/**
+ * Default {@link DefaultDaprMessagingObservationConvention} for Dapr template key values.
+ *
+ */
+public class DefaultDaprMessagingObservationConvention implements DaprMessagingObservationConvention {
+  /**
+   * A singleton instance of the convention.
+   */
+  public static final DefaultDaprMessagingObservationConvention INSTANCE =
+      new DefaultDaprMessagingObservationConvention();
+
+  @Override
+  public KeyValues getLowCardinalityKeyValues(DaprMessagingSenderContext context) {
+    return KeyValues.of(DaprMessagingObservationDocumentation.TemplateLowCardinalityTags.BEAN_NAME.asString(),
+        context.getBeanName());
+  }
+
+  // Remove once addressed:
+  // https://github.com/micrometer-metrics/micrometer-docs-generator/issues/30
+  @Override
+  public String getName() {
+    return "spring.dapr.messaging.template";
+  }
+
+  @Override
+  public String getContextualName(DaprMessagingSenderContext context) {
+    return context.getDestination() + " send";
+  }
+
+}

--- a/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DefaultDaprMessagingObservationConvention.java
+++ b/dapr-spring/dapr-spring-messaging/src/main/java/io/dapr/spring/messaging/observation/DefaultDaprMessagingObservationConvention.java
@@ -19,7 +19,7 @@ import io.micrometer.common.KeyValues;
  * Default {@link DefaultDaprMessagingObservationConvention} for Dapr template key values.
  *
  */
-public class DefaultDaprMessagingObservationConvention implements DaprMessagingObservationConvention {
+class DefaultDaprMessagingObservationConvention implements DaprMessagingObservationConvention {
   /**
    * A singleton instance of the convention.
    */

--- a/dapr-spring/pom.xml
+++ b/dapr-spring/pom.xml
@@ -75,6 +75,16 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- OTEL dependencies -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-context</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestApplication.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestApplication.java
@@ -35,7 +35,9 @@ public class TestApplication {
     @Bean
     public DaprMessagingTemplate<String> messagingTemplate(DaprClient daprClient,
                                                            DaprPubSubProperties daprPubSubProperties) {
-      return new DaprMessagingTemplate<>(daprClient, daprPubSubProperties.getName());
+      String pubsubName = daprPubSubProperties.getName();
+      boolean observationEnabled = daprPubSubProperties.isObservationEnabled();
+      return new DaprMessagingTemplate<>(daprClient, pubsubName, observationEnabled);
     }
 
   }


### PR DESCRIPTION
# Description

This PR adds support for Micrometer Observation into Spring Dapr Messaging. If everything goes well we will add similar support to Spring Dapr Data. This PR is heavily inspired and is a continuation of this PR: https://github.com/dapr/java-sdk/pull/1126.

In this PR I didn't enable any Project Reactor Hooks for context propagation. If we want to have context data being sent to OTEL or any other Micrometer exporter, this should be controlled by `spring.reactor.context-propagation=auto` Spring Boot application configuration. More details can be found here: https://docs.spring.io/spring-boot/reference/actuator/observability.html.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1149

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
