### PR TITLE
Simplify OTEL integration to reduce deps

### DIFF
--- a/dapr-spring/pom.xml
+++ b/dapr-spring/pom.xml
@@ -75,16 +75,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- OTEL dependencies -->
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-context</artifactId>
-    </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Description

This PR has been created after looking at Micrometer Observation integration in `PulsarTemplate` here: https://github.com/spring-projects/spring-pulsar/blob/main/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java#L298. Many thanks to @salaboy for pointing this out.

The main idea was to remove explicit OTEL dependency from Dapr Messaging since Micrometer Observation should be able to handle `traceparent` generation behind the scenes and OOTB. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
