### PR TITLE
[release-1.13] Actor client metadata in release-1.13

### DIFF
--- a/sdk-actors/src/test/java/io/dapr/actors/client/DaprGrpcClientTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/client/DaprGrpcClientTest.java
@@ -106,7 +106,7 @@ public class DaprGrpcClientTest {
         InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
     // Create a HelloWorldClient using the in-process channel;
-    client = new DaprClientImpl(DaprGrpc.newStub(channel), null, null);
+    client = new DaprClientImpl(DaprGrpc.newStub(channel), null, null, null);
   }
 
   @Test

--- a/sdk-tests/src/test/java/io/dapr/it/DaprRun.java
+++ b/sdk-tests/src/test/java/io/dapr/it/DaprRun.java
@@ -187,11 +187,19 @@ public class DaprRun implements Stoppable {
   }
 
   public ActorClient newActorClient() {
-    return this.newActorClient(null);
+    return this.newActorClient(null, null);
+  }
+
+  public ActorClient newActorClient(Map<String, String> metadata) {
+    return this.newActorClient(metadata, null);
   }
 
   public ActorClient newActorClient(ResiliencyOptions resiliencyOptions) {
-    return new ActorClient(new Properties(this.getPropertyOverrides()), resiliencyOptions);
+    return this.newActorClient(null, resiliencyOptions);
+  }
+
+  public ActorClient newActorClient(Map<String, String> metadata, ResiliencyOptions resiliencyOptions) {
+    return new ActorClient(new Properties(this.getPropertyOverrides()), metadata, resiliencyOptions);
   }
 
   public void waitForAppHealth(int maxWaitMilliseconds) throws InterruptedException {

--- a/sdk-tests/src/test/java/io/dapr/it/actors/ActorExceptionIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/actors/ActorExceptionIT.java
@@ -16,11 +16,16 @@ package io.dapr.it.actors;
 import io.dapr.actors.ActorId;
 import io.dapr.actors.client.ActorProxyBuilder;
 import io.dapr.it.BaseIT;
+import io.dapr.it.DaprRun;
 import io.dapr.it.actors.app.MyActor;
 import io.dapr.it.actors.app.MyActorService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 import static io.dapr.it.Retry.callWithRetry;
 import static io.dapr.it.TestUtils.assertThrowsDaprExceptionSubstring;
@@ -30,29 +35,46 @@ public class ActorExceptionIT extends BaseIT {
 
   private static Logger logger = LoggerFactory.getLogger(ActorExceptionIT.class);
 
-  @Test
-  public void exceptionTest() throws Exception {
+  private static DaprRun run;
+
+  @BeforeAll
+  public static void start() throws Exception {
     // The call below will fail if service cannot start successfully.
-    var run = startDaprApp(
+    run = startDaprApp(
         ActorExceptionIT.class.getSimpleName(),
         MyActorService.SUCCESS_MESSAGE,
         MyActorService.class,
         true,
         60000);
+  }
 
-    logger.debug("Creating proxy builder");
+  @Test
+  public void exceptionTest() throws Exception {
     ActorProxyBuilder<MyActor> proxyBuilder =
         new ActorProxyBuilder("MyActorTest", MyActor.class, deferClose(run.newActorClient()));
-    logger.debug("Creating actorId");
-    ActorId actorId1 = new ActorId("1");
-    logger.debug("Building proxy");
-    MyActor proxy = proxyBuilder.build(actorId1);
+    MyActor proxy = proxyBuilder.build(new ActorId("1"));
 
     callWithRetry(() -> {
       assertThrowsDaprExceptionSubstring(
           "INTERNAL",
           "INTERNAL: error invoke actor method: error from actor service",
           () ->  proxy.throwException());
+    }, 10000);
+  }
+
+  @Test
+  public void exceptionDueToMetadataTest() throws Exception {
+    // Setting this HTTP header via actor metadata will cause the Actor HTTP server to error.
+    Map<String, String> metadata = Map.of("Content-Length", "9999");
+    ActorProxyBuilder<MyActor> proxyBuilderMetadataOverride =
+        new ActorProxyBuilder("MyActorTest", MyActor.class, deferClose(run.newActorClient(metadata)));
+
+    MyActor proxyWithMetadata = proxyBuilderMetadataOverride.build(new ActorId("2"));
+    callWithRetry(() -> {
+      assertThrowsDaprExceptionSubstring(
+          "INTERNAL",
+          "ContentLength=9999 with Body length 13",
+          () -> proxyWithMetadata.say("hello world"));
     }, 10000);
   }
 }

--- a/sdk/src/main/java/io/dapr/internal/grpc/DaprClientGrpcInterceptors.java
+++ b/sdk/src/main/java/io/dapr/internal/grpc/DaprClientGrpcInterceptors.java
@@ -15,7 +15,7 @@ package io.dapr.internal.grpc;
 
 import io.dapr.internal.grpc.interceptors.DaprApiTokenInterceptor;
 import io.dapr.internal.grpc.interceptors.DaprAppIdInterceptor;
-import io.dapr.internal.grpc.interceptors.DaprMetadataInterceptor;
+import io.dapr.internal.grpc.interceptors.DaprMetadataReceiverInterceptor;
 import io.dapr.internal.grpc.interceptors.DaprTimeoutInterceptor;
 import io.dapr.internal.grpc.interceptors.DaprTracingInterceptor;
 import io.dapr.internal.resiliency.TimeoutPolicy;
@@ -35,10 +35,18 @@ public class DaprClientGrpcInterceptors {
 
   private final TimeoutPolicy timeoutPolicy;
 
+  /**
+   * Instantiates a holder of all gRPC interceptors.
+   */
   public DaprClientGrpcInterceptors() {
     this(null, null);
   }
 
+  /**
+   * Instantiates a holder of all gRPC interceptors.
+   * @param daprApiToken Dapr API token.
+   * @param timeoutPolicy Timeout Policy.
+   */
   public DaprClientGrpcInterceptors(String daprApiToken, TimeoutPolicy timeoutPolicy) {
     this.daprApiToken = daprApiToken;
     this.timeoutPolicy = timeoutPolicy;
@@ -118,7 +126,7 @@ public class DaprClientGrpcInterceptors {
         new DaprApiTokenInterceptor(this.daprApiToken),
         new DaprTimeoutInterceptor(this.timeoutPolicy),
         new DaprTracingInterceptor(context),
-        new DaprMetadataInterceptor(metadataConsumer));
+        new DaprMetadataReceiverInterceptor(metadataConsumer));
   }
 
 }

--- a/sdk/src/main/java/io/dapr/internal/grpc/interceptors/DaprApiTokenInterceptor.java
+++ b/sdk/src/main/java/io/dapr/internal/grpc/interceptors/DaprApiTokenInterceptor.java
@@ -14,7 +14,6 @@ limitations under the License.
 package io.dapr.internal.grpc.interceptors;
 
 import io.dapr.client.Headers;
-import io.dapr.config.Properties;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;

--- a/sdk/src/main/java/io/dapr/internal/grpc/interceptors/DaprMetadataReceiverInterceptor.java
+++ b/sdk/src/main/java/io/dapr/internal/grpc/interceptors/DaprMetadataReceiverInterceptor.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 /**
  * Consumes gRPC metadata.
  */
-public class DaprMetadataInterceptor implements ClientInterceptor {
+public class DaprMetadataReceiverInterceptor implements ClientInterceptor {
 
   private final Consumer<Metadata> metadataConsumer;
 
@@ -35,7 +35,7 @@ public class DaprMetadataInterceptor implements ClientInterceptor {
    * Creates an instance of the consumer for gRPC metadata.
    * @param metadataConsumer gRPC metadata consumer
    */
-  public DaprMetadataInterceptor(Consumer<Metadata> metadataConsumer) {
+  public DaprMetadataReceiverInterceptor(Consumer<Metadata> metadataConsumer) {
     this.metadataConsumer = metadataConsumer;
   }
 


### PR DESCRIPTION
# Description

Allows actor clients to include metadata in their calls, mapping to HTTP headers or gRPC metadata.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/1071

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
