### PR TITLE
Fixing vulnerability in transitive protobuf-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.64.0</grpc.version>
+    <grpc.version>1.68.2</grpc.version>
     <protobuf.version>3.25.5</protobuf.version>
     <protocCommand>protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.14.4/dapr/proto</dapr.proto.baseurl>


### PR DESCRIPTION
# Description

This upgrades the GRPC java version that we are using to 1.68.2 that brings protobuf-java 3.25.5 which fix a HIGH vulnerability. 

https://central.sonatype.com/artifact/io.grpc/grpc-protobuf/1.68.2


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1178 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
