### PR TITLE
Fixing all protobuf java to be 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.64.0</grpc.version>
+    <grpc.version>1.69.0</grpc.version>
     <protobuf.version>3.25.5</protobuf.version>
     <protocCommand>protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.14.4/dapr/proto</dapr.proto.baseurl>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -21,9 +21,9 @@
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.build.directory}/proto</protobuf.input.directory>
     <maven.deploy.skip>false</maven.deploy.skip>
-    <grpc.version>1.64.0</grpc.version>
+    <grpc.version>1.69.0</grpc.version>
     <protocCommand>protoc</protocCommand>
-    <protobuf.version>3.25.0</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# Description

Updating grpc to 1.69.0 to match protobuf-java to 3.25.5

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1178 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
