### PR TITLE
up maven plugins and okhttp versions

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-resources-plugin</artifactId>
-      <version>3.3.0</version>
+      <version>3.3.1</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.2</version>
+      <version>4.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
- Upgrades the `com.squareup.okhttp3:okhttp` from `4.9.2` -> `4.9.3` to resolve a security issue by using the secure version of `org.jetbrains.kotlin:kotlin-stdlib@1.4.10`
- Upgrades the `org.apache.maven.plugins:maven-resources-plugin` from `3.3.0` -> `3.3.1` to resolve a security issue by using the secure version of `commons-io:commons-io@2.11.0`

 