### PR TITLE
[1.13] up versions to be secure and fix issues due to deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
         /home/runner/.local/bin/toxiproxy-server --version
     - name: Clean up files
       run: ./mvnw clean -B
+    - name: Check protoc version
+      run: protoc --version || echo "protoc not found"
     - name: Build sdk
       run: ./mvnw compile -B -q
     - name: Unit tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,6 @@ jobs:
         /home/runner/.local/bin/toxiproxy-server --version
     - name: Clean up files
       run: ./mvnw clean -B
-    - name: Check protoc version
-      run: protoc --version || echo "protoc not found"
     - name: Build sdk
       run: ./mvnw compile -B -q
     - name: Unit tests

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.69.0</grpc.version>
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>4.29.2</protobuf.version>
     <protocCommand>protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.14.4/dapr/proto</dapr.proto.baseurl>
     <dapr.sdk.version>1.13.1</dapr.sdk.version>
@@ -113,6 +113,11 @@
         <version>${grpc.version}</version>
         <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>2.1.0</version>
+    </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.69.0</grpc.version>
-    <protobuf.version>4.29.2</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <protocCommand>protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.14.4/dapr/proto</dapr.proto.baseurl>
     <dapr.sdk.version>1.13.1</dapr.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.68.2</grpc.version>
+    <grpc.version>1.69.0</grpc.version>
     <protobuf.version>3.25.5</protobuf.version>
     <protocCommand>protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.14.4/dapr/proto</dapr.proto.baseurl>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -61,6 +61,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.29.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>3.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>1.7</version>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -32,9 +32,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.gmazzo</groupId>
-      <artifactId>okhttp-mock</artifactId>
-      <version>1.4.1</version>
+      <groupId>com.github.gmazzo.okhttp.mock</groupId>
+      <artifactId>mock-client</artifactId>
+      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -59,21 +59,6 @@
       <artifactId>grpc-testing</artifactId>
       <version>${grpc.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>3.9.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>4.29.2</version>
+      <version>3.25.5</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>

--- a/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprGrpcClientTest.java
+++ b/sdk-actors/src/test/java/io/dapr/actors/runtime/DaprGrpcClientTest.java
@@ -301,8 +301,8 @@ public class DaprGrpcClientTest {
             responseObserver.onError(se);
         }
 
-        private <T extends GeneratedMessageV3> void populateObserver(StreamObserver<T> responseObserver, GeneratedMessageV3 generatedMessageV3) {
-            responseObserver.onNext((T) generatedMessageV3);
+        private <T extends com.google.protobuf.Message> void populateObserver(StreamObserver<T> responseObserver, T message) {
+            responseObserver.onNext(message);
             responseObserver.onCompleted();
         }
     }

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -28,6 +28,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.29.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>3.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -145,7 +145,7 @@
             <configuration>
               <protocCommand>protoc</protocCommand>
               <protocVersion>${protobuf.version}</protocVersion>
-              <protocArtifact>com.google.protobuf:protoc:3.21.1</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:4.29.2</protocArtifact>
               <addProtoSources>inputs</addProtoSources>
               <includeMavenTypes>direct</includeMavenTypes>
               <includeStdTypes>true</includeStdTypes>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -23,7 +23,7 @@
     <maven.deploy.skip>false</maven.deploy.skip>
     <grpc.version>1.69.0</grpc.version>
     <protocCommand>protoc</protocCommand>
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>4.29.2</protobuf.version>
   </properties>
 
   <dependencies>
@@ -54,6 +54,16 @@
       <artifactId>grpc-testing</artifactId>
       <version>${grpc.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>3.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -21,9 +21,9 @@
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.build.directory}/proto</protobuf.input.directory>
     <maven.deploy.skip>false</maven.deploy.skip>
-    <grpc.version>1.64.0</grpc.version>
+    <grpc.version>1.69.0</grpc.version>
     <protocCommand>protoc</protocCommand>
-    <protobuf.version>3.25.0</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
   </properties>
 
   <dependencies>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -23,7 +23,7 @@
     <maven.deploy.skip>false</maven.deploy.skip>
     <grpc.version>1.69.0</grpc.version>
     <protocCommand>protoc</protocCommand>
-    <protobuf.version>4.29.2</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
   </properties>
 
   <dependencies>
@@ -59,11 +59,6 @@
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
       <version>3.9.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 
@@ -140,7 +135,7 @@
             <configuration>
               <protocCommand>protoc</protocCommand>
               <protocVersion>${protobuf.version}</protocVersion>
-              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:3.25.5</protocArtifact>
               <addProtoSources>inputs</addProtoSources>
               <includeMavenTypes>direct</includeMavenTypes>
               <includeStdTypes>true</includeStdTypes>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -130,7 +130,7 @@
             <configuration>
               <protocCommand>protoc</protocCommand>
               <protocVersion>${protobuf.version}</protocVersion>
-              <protocArtifact>com.google.protobuf:protoc:4.29.2</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
               <addProtoSources>inputs</addProtoSources>
               <includeMavenTypes>direct</includeMavenTypes>
               <includeStdTypes>true</includeStdTypes>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>4.29.2</version>
+      <version>3.25.5</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -28,21 +28,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>3.9.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>2.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -27,7 +27,7 @@
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.basedir}/proto</protobuf.input.directory>
     <grpc.version>1.69.0</grpc.version>
-    <protobuf.version>4.29.2</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <opentelemetry.version>1.39.0</opentelemetry.version>
     <springboot.version>3.3.1</springboot.version>
     <logback-classic.version>1.4.12</logback-classic.version>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -26,8 +26,8 @@
     <dapr.sdk.alpha.version>0.13.1</dapr.sdk.alpha.version>
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.basedir}/proto</protobuf.input.directory>
-    <grpc.version>1.64.0</grpc.version>
-    <protobuf.version>3.25.0</protobuf.version>
+    <grpc.version>1.69.0</grpc.version>
+    <protobuf.version>4.29.2</protobuf.version>
     <opentelemetry.version>1.39.0</opentelemetry.version>
     <springboot.version>3.3.1</springboot.version>
     <logback-classic.version>1.4.12</logback-classic.version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.3</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -72,9 +72,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.gmazzo</groupId>
-      <artifactId>okhttp-mock</artifactId>
-      <version>1.4.1</version>
+      <groupId>com.github.gmazzo.okhttp.mock</groupId>
+      <artifactId>mock-client</artifactId>
+      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -53,6 +53,12 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>4.12.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Updates the `dapr-sdk-autogen` & `dapr-sdk-actors` pkgs to explicitly include secure versions of the following dependencies:
- `protobuf-java`
- `okio`
- `kotlin-stdlib`

These dependencies were transitive, but were not properly included with secure versions, so I explicitly set them. 

I also had to address the deprecation of `GeneratedMessageV3` in the newer version of `protobuf-java`