### PR TITLE
remove duplicated dependency

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -137,12 +137,6 @@
       <artifactId>grpc-inprocess</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.dapr</groupId>
-      <artifactId>dapr-sdk-autogen</artifactId>
-      <version>1.14.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
# Description

the 'dapr-sdk-autogen' has already imported at above code use ${project.version}.

