### PR TITLE
Register workflows and acitivities using instances along classes

### DIFF
--- a/dapr-spring/dapr-spring-workflows/src/main/java/io/dapr/spring/workflows/config/DaprWorkflowsConfiguration.java
+++ b/dapr-spring/dapr-spring-workflows/src/main/java/io/dapr/spring/workflows/config/DaprWorkflowsConfiguration.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class DaprWorkflowsConfiguration implements ApplicationContextAware {
   private static final Logger LOGGER = LoggerFactory.getLogger(DaprWorkflowsConfiguration.class);
 
-  private WorkflowRuntimeBuilder workflowRuntimeBuilder;
+  private final WorkflowRuntimeBuilder workflowRuntimeBuilder;
 
   public DaprWorkflowsConfiguration(WorkflowRuntimeBuilder workflowRuntimeBuilder) {
     this.workflowRuntimeBuilder = workflowRuntimeBuilder;
@@ -29,16 +29,21 @@ public class DaprWorkflowsConfiguration implements ApplicationContextAware {
    */
   private void registerWorkflowsAndActivities(ApplicationContext applicationContext) {
     LOGGER.info("Registering Dapr Workflows and Activities");
+
     Map<String, Workflow> workflowBeans = applicationContext.getBeansOfType(Workflow.class);
-    for (Workflow w :  workflowBeans.values()) {
-      LOGGER.info("Dapr Workflow: '{}' registered", w.getClass().getName());
-      workflowRuntimeBuilder.registerWorkflow(w.getClass());
+
+    for (Workflow workflow :  workflowBeans.values()) {
+      LOGGER.info("Dapr Workflow: '{}' registered", workflow.getClass().getName());
+
+      workflowRuntimeBuilder.registerWorkflow(workflow);
     }
 
     Map<String, WorkflowActivity> workflowActivitiesBeans = applicationContext.getBeansOfType(WorkflowActivity.class);
-    for (WorkflowActivity a :  workflowActivitiesBeans.values()) {
-      LOGGER.info("Dapr Workflow Activity: '{}' registered", a.getClass().getName());
-      workflowRuntimeBuilder.registerActivity(a.getClass());
+
+    for (WorkflowActivity activity :  workflowActivitiesBeans.values()) {
+      LOGGER.info("Dapr Workflow Activity: '{}' registered", activity.getClass().getName());
+
+      workflowRuntimeBuilder.registerActivity(activity);
     }
 
     try (WorkflowRuntime runtime = workflowRuntimeBuilder.build()) {

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapper.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapper.java
@@ -23,7 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Wrapper for Durable Task Framework task activity factory.
  */
-public class WorkflowActivityWrapper<T extends WorkflowActivity> implements TaskActivityFactory {
+public class WorkflowActivityClassWrapper<T extends WorkflowActivity> implements TaskActivityFactory {
   private final Constructor<T> activityConstructor;
   private final String name;
 
@@ -32,7 +32,7 @@ public class WorkflowActivityWrapper<T extends WorkflowActivity> implements Task
    *
    * @param clazz Class of the activity to wrap.
    */
-  public WorkflowActivityWrapper(Class<T> clazz) {
+  public WorkflowActivityClassWrapper(Class<T> clazz) {
     this.name = clazz.getCanonicalName();
     try {
       this.activityConstructor = clazz.getDeclaredConstructor();

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapper.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.workflows.runtime;
+
+import com.microsoft.durabletask.TaskActivity;
+import com.microsoft.durabletask.TaskActivityFactory;
+import io.dapr.workflows.WorkflowActivity;
+
+/**
+ * Wrapper for Durable Task Framework task activity factory.
+ */
+public class WorkflowActivityInstanceWrapper<T extends WorkflowActivity> implements TaskActivityFactory {
+  private final T activity;
+  private final String name;
+
+  /**
+   * Constructor for WorkflowActivityWrapper.
+   *
+   * @param instance Instance of the activity to wrap.
+   */
+  public WorkflowActivityInstanceWrapper(T instance) {
+    this.name = instance.getClass().getCanonicalName();
+    this.activity = instance;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public TaskActivity create() {
+    return ctx -> activity.run(new DefaultWorkflowActivityContext(ctx));
+  }
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowClassWrapper.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowClassWrapper.java
@@ -24,11 +24,11 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Wrapper for Durable Task Framework orchestration factory.
  */
-class WorkflowWrapper<T extends Workflow> implements TaskOrchestrationFactory {
+class WorkflowClassWrapper<T extends Workflow> implements TaskOrchestrationFactory {
   private final Constructor<T> workflowConstructor;
   private final String name;
 
-  public WorkflowWrapper(Class<T> clazz) {
+  public WorkflowClassWrapper(Class<T> clazz) {
     this.name = clazz.getCanonicalName();
     try {
       this.workflowConstructor = clazz.getDeclaredConstructor();

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowInstanceWrapper.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowInstanceWrapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.workflows.runtime;
+
+import com.microsoft.durabletask.TaskOrchestration;
+import com.microsoft.durabletask.TaskOrchestrationFactory;
+import io.dapr.workflows.Workflow;
+import io.dapr.workflows.saga.Saga;
+
+/**
+ * Wrapper for Durable Task Framework orchestration factory.
+ */
+class WorkflowInstanceWrapper<T extends Workflow> implements TaskOrchestrationFactory {
+  private final T workflow;
+  private final String name;
+
+  public WorkflowInstanceWrapper(T instance) {
+    this.name = instance.getClass().getCanonicalName();
+    this.workflow = instance;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public TaskOrchestration create() {
+    return ctx -> {
+      if (workflow.getSagaOption() != null) {
+        Saga saga = new Saga(workflow.getSagaOption());
+        workflow.run(new DefaultWorkflowContext(ctx, saga));
+      } else {
+        workflow.run(new DefaultWorkflowContext(ctx));
+      }
+    };
+  }
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilder.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilder.java
@@ -92,11 +92,30 @@ public class WorkflowRuntimeBuilder {
    * @return the WorkflowRuntimeBuilder
    */
   public <T extends Workflow> WorkflowRuntimeBuilder registerWorkflow(Class<T> clazz) {
-    this.builder.addOrchestration(new WorkflowWrapper<>(clazz));
+    this.builder.addOrchestration(new WorkflowClassWrapper<>(clazz));
     this.workflowSet.add(clazz.getCanonicalName());
     this.workflows.add(clazz.getSimpleName());
 
-    this.logger.info("Registered Workflow: " +  clazz.getSimpleName());
+    this.logger.info("Registered Workflow: {}", clazz.getSimpleName());
+
+    return this;
+  }
+
+  /**
+   * Registers a Workflow object.
+   *
+   * @param <T>   any Workflow type
+   * @param instance the workflow instance being registered
+   * @return the WorkflowRuntimeBuilder
+   */
+  public <T extends Workflow> WorkflowRuntimeBuilder registerWorkflow(T instance) {
+    Class<T> clazz = (Class<T>) instance.getClass();
+
+    this.builder.addOrchestration(new WorkflowInstanceWrapper<>(instance));
+    this.workflowSet.add(clazz.getCanonicalName());
+    this.workflows.add(clazz.getSimpleName());
+
+    this.logger.info("Registered Workflow: {}", clazz.getSimpleName());
 
     return this;
   }
@@ -109,11 +128,30 @@ public class WorkflowRuntimeBuilder {
    * @return the WorkflowRuntimeBuilder
    */
   public <T extends WorkflowActivity> WorkflowRuntimeBuilder registerActivity(Class<T> clazz) {
-    this.builder.addActivity(new WorkflowActivityWrapper<>(clazz));
+    this.builder.addActivity(new WorkflowActivityClassWrapper<>(clazz));
     this.activitySet.add(clazz.getCanonicalName());
     this.activities.add(clazz.getSimpleName());
 
-    this.logger.info("Registered Activity: " +  clazz.getSimpleName());
+    this.logger.info("Registered Activity: {}", clazz.getSimpleName());
+
+    return this;
+  }
+
+  /**
+   * Registers an Activity object.
+   *
+   * @param <T>   any WorkflowActivity type
+   * @param instance the class instance being registered
+   * @return the WorkflowRuntimeBuilder
+   */
+  public <T extends WorkflowActivity> WorkflowRuntimeBuilder registerActivity(T instance) {
+    Class<T> clazz = (Class<T>) instance.getClass();
+
+    this.builder.addActivity(new WorkflowActivityInstanceWrapper<>(instance));
+    this.activitySet.add(clazz.getCanonicalName());
+    this.activities.add(clazz.getSimpleName());
+
+    this.logger.info("Registered Activity: {}", clazz.getSimpleName());
 
     return this;
   }

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapperTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-public class WorkflowActivityWrapperTest {
+public class WorkflowActivityClassWrapperTest {
   public static class TestActivity implements WorkflowActivity {
     @Override
     public Object run(WorkflowActivityContext ctx) {
@@ -23,10 +23,10 @@ public class WorkflowActivityWrapperTest {
 
   @Test
   public void getName() throws NoSuchMethodException {
-    WorkflowActivityWrapper<TestActivity> wrapper = new WorkflowActivityWrapper<>(
-        WorkflowActivityWrapperTest.TestActivity.class);
+    WorkflowActivityClassWrapper<TestActivity> wrapper = new WorkflowActivityClassWrapper<>(
+        WorkflowActivityClassWrapperTest.TestActivity.class);
     Assert.assertEquals(
-        "io.dapr.workflows.runtime.WorkflowActivityWrapperTest.TestActivity",
+        "io.dapr.workflows.runtime.WorkflowActivityClassWrapperTest.TestActivity",
         wrapper.getName()
     );
   }
@@ -34,8 +34,8 @@ public class WorkflowActivityWrapperTest {
   @Test
   public void createWithClass() throws NoSuchMethodException {
     TaskActivityContext mockContext = mock(TaskActivityContext.class);
-    WorkflowActivityWrapper<TestActivity> wrapper = new WorkflowActivityWrapper<>(
-        WorkflowActivityWrapperTest.TestActivity.class);
+    WorkflowActivityClassWrapper<TestActivity> wrapper = new WorkflowActivityClassWrapper<>(
+        WorkflowActivityClassWrapperTest.TestActivity.class);
     when(mockContext.getInput(String.class)).thenReturn("Hello");
     when(mockContext.getName()).thenReturn("TestActivityContext");
     Object result = wrapper.create().run(mockContext);

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapperTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class WorkflowActivityClassWrapperTest {
+public class WorkflowActivityInstanceWrapperTest {
   public static class TestActivity implements WorkflowActivity {
     @Override
     public Object run(WorkflowActivityContext ctx) {
@@ -22,18 +22,18 @@ public class WorkflowActivityClassWrapperTest {
 
   @Test
   public void getName() {
-    WorkflowActivityClassWrapper<TestActivity> wrapper = new WorkflowActivityClassWrapper<>(TestActivity.class);
+    WorkflowActivityInstanceWrapper<TestActivity> wrapper = new WorkflowActivityInstanceWrapper<>(new TestActivity());
 
     assertEquals(
-        "io.dapr.workflows.runtime.WorkflowActivityClassWrapperTest.TestActivity",
+        "io.dapr.workflows.runtime.WorkflowActivityInstanceWrapperTest.TestActivity",
         wrapper.getName()
     );
   }
 
   @Test
-  public void createWithClass() {
+  public void createWithInstance() {
     TaskActivityContext mockContext = mock(TaskActivityContext.class);
-    WorkflowActivityClassWrapper<TestActivity> wrapper = new WorkflowActivityClassWrapper<>(TestActivity.class);
+    WorkflowActivityInstanceWrapper<TestActivity> wrapper = new WorkflowActivityInstanceWrapper<>(new TestActivity());
 
     when(mockContext.getInput(String.class)).thenReturn("Hello");
     when(mockContext.getName()).thenReturn("TestActivityContext");

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowClassWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowClassWrapperTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class WorkflowWrapperTest {
+public class WorkflowClassWrapperTest {
   public static class TestWorkflow implements Workflow {
     @Override
     public WorkflowStub create() {
@@ -36,9 +36,9 @@ public class WorkflowWrapperTest {
 
   @Test
   public void getName() {
-    WorkflowWrapper<TestWorkflow> wrapper = new WorkflowWrapper<>(TestWorkflow.class);
+    WorkflowClassWrapper<TestWorkflow> wrapper = new WorkflowClassWrapper<>(TestWorkflow.class);
     Assertions.assertEquals(
-        "io.dapr.workflows.runtime.WorkflowWrapperTest.TestWorkflow",
+        "io.dapr.workflows.runtime.WorkflowClassWrapperTest.TestWorkflow",
         wrapper.getName()
     );
   }
@@ -46,7 +46,7 @@ public class WorkflowWrapperTest {
   @Test
   public void createWithClass() {
     TaskOrchestrationContext mockContext = mock(TaskOrchestrationContext.class);
-    WorkflowWrapper<TestWorkflow> wrapper = new WorkflowWrapper<>(TestWorkflow.class);
+    WorkflowClassWrapper<TestWorkflow> wrapper = new WorkflowClassWrapper<>(TestWorkflow.class);
     when(mockContext.getInstanceId()).thenReturn("uuid");
     wrapper.create().run(mockContext);
     verify(mockContext, times(1)).getInstanceId();

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowInstanceWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowInstanceWrapperTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class WorkflowClassWrapperTest {
+public class WorkflowInstanceWrapperTest {
   public static class TestWorkflow implements Workflow {
     @Override
     public WorkflowStub create() {
@@ -35,18 +35,18 @@ public class WorkflowClassWrapperTest {
 
   @Test
   public void getName() {
-    WorkflowClassWrapper<TestWorkflow> wrapper = new WorkflowClassWrapper<>(TestWorkflow.class);
+    WorkflowInstanceWrapper<TestWorkflow> wrapper = new WorkflowInstanceWrapper<>(new TestWorkflow());
 
     assertEquals(
-        "io.dapr.workflows.runtime.WorkflowClassWrapperTest.TestWorkflow",
+        "io.dapr.workflows.runtime.WorkflowInstanceWrapperTest.TestWorkflow",
         wrapper.getName()
     );
   }
 
   @Test
-  public void createWithClass() {
+  public void createWithInstance() {
     TaskOrchestrationContext mockContext = mock(TaskOrchestrationContext.class);
-    WorkflowClassWrapper<TestWorkflow> wrapper = new WorkflowClassWrapper<>(TestWorkflow.class);
+    WorkflowInstanceWrapper<TestWorkflow> wrapper = new WorkflowInstanceWrapper<>(new TestWorkflow());
 
     when(mockContext.getInstanceId()).thenReturn("uuid");
     wrapper.create().run(mockContext);

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
@@ -12,16 +12,18 @@ limitations under the License.
 */
 package io.dapr.workflows.runtime;
 
-
 import io.dapr.workflows.Workflow;
 import io.dapr.workflows.WorkflowActivity;
 import io.dapr.workflows.WorkflowActivityContext;
 import io.dapr.workflows.WorkflowStub;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -63,19 +65,20 @@ public class WorkflowRuntimeBuilderTest {
     ByteArrayOutputStream outStreamCapture = new ByteArrayOutputStream();
     System.setOut(new PrintStream(outStreamCapture));
 
-    Logger testLogger = Mockito.mock(Logger.class);
+    Logger testLogger = mock(Logger.class);
 
     assertDoesNotThrow(() -> new WorkflowRuntimeBuilder(testLogger).registerWorkflow(TestWorkflow.class));
     assertDoesNotThrow(() -> new WorkflowRuntimeBuilder(testLogger).registerActivity(TestActivity.class));
 
-    WorkflowRuntimeBuilder wfRuntime = new WorkflowRuntimeBuilder();
+    WorkflowRuntimeBuilder workflowRuntimeBuilder = new WorkflowRuntimeBuilder();
 
-    wfRuntime.build();
+    workflowRuntimeBuilder.build();
 
-    Mockito.verify(testLogger, Mockito.times(1))
-        .info(Mockito.eq("Registered Workflow: TestWorkflow"));
-    Mockito.verify(testLogger, Mockito.times(1))
-        .info(Mockito.eq("Registered Activity: TestActivity"));
+    verify(testLogger, times(1))
+        .info(eq("Registered Workflow: {}"), eq("TestWorkflow"));
+
+    verify(testLogger, times(1))
+        .info(eq("Registered Activity: {}"), eq("TestActivity"));
   }
 
 }

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
@@ -50,8 +50,18 @@ public class WorkflowRuntimeBuilderTest {
   }
 
   @Test
+  public void registerValidWorkflowInstance() {
+    assertDoesNotThrow(() -> new WorkflowRuntimeBuilder().registerWorkflow(new TestWorkflow()));
+  }
+
+  @Test
   public void registerValidWorkflowActivityClass() {
     assertDoesNotThrow(() -> new WorkflowRuntimeBuilder().registerActivity(TestActivity.class));
+  }
+
+  @Test
+  public void registerValidWorkflowActivityInstance() {
+    assertDoesNotThrow(() -> new WorkflowRuntimeBuilder().registerActivity(new TestActivity()));
   }
 
   @Test

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
@@ -66,7 +66,13 @@ public class WorkflowRuntimeBuilderTest {
 
   @Test
   public void buildTest() {
-    assertDoesNotThrow(() -> new WorkflowRuntimeBuilder().build());
+    assertDoesNotThrow(() -> {
+      try (WorkflowRuntime runtime = new WorkflowRuntimeBuilder().build()) {
+        System.out.println("WorkflowRuntime created");
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Test
@@ -82,13 +88,13 @@ public class WorkflowRuntimeBuilderTest {
 
     WorkflowRuntimeBuilder workflowRuntimeBuilder = new WorkflowRuntimeBuilder();
 
-    workflowRuntimeBuilder.build();
+    try (WorkflowRuntime runtime = workflowRuntimeBuilder.build()) {
+      verify(testLogger, times(1))
+          .info(eq("Registered Workflow: {}"), eq("TestWorkflow"));
 
-    verify(testLogger, times(1))
-        .info(eq("Registered Workflow: {}"), eq("TestWorkflow"));
-
-    verify(testLogger, times(1))
-        .info(eq("Registered Activity: {}"), eq("TestActivity"));
+      verify(testLogger, times(1))
+          .info(eq("Registered Activity: {}"), eq("TestActivity"));
+    }
   }
 
 }


### PR DESCRIPTION
# Description

This is an alternative implementation for #1197, the main idea is to be able to register workflow and activities either using `Class<T>` aka class or just `T` aka instance. The instance part is important when workflows and activities are created by a DI container like Spring, but it should be usable in other places like Quarkus for example. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1198 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
