### PR TITLE
Ensure ActorRuntime can be instantiated using Properties

### DIFF
--- a/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/ActorClient.java
@@ -15,11 +15,10 @@ package io.dapr.actors.client;
 
 import io.dapr.client.resiliency.ResiliencyOptions;
 import io.dapr.config.Properties;
-import io.dapr.utils.Version;
+import io.dapr.utils.NetworkUtils;
 import io.dapr.v1.DaprGrpc;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import reactor.core.publisher.Mono;
 
 import java.util.Collections;
@@ -83,7 +82,7 @@ public class ActorClient implements AutoCloseable {
    * @param resiliencyOptions Client resiliency options.
    */
   public ActorClient(Properties overrideProperties, Map<String, String> metadata, ResiliencyOptions resiliencyOptions) {
-    this(buildManagedChannel(overrideProperties),
+    this(NetworkUtils.buildGrpcManagedChannel(overrideProperties),
         metadata,
         resiliencyOptions,
         overrideProperties.getValue(Properties.API_TOKEN));
@@ -127,26 +126,6 @@ public class ActorClient implements AutoCloseable {
     if (grpcManagedChannel != null && !grpcManagedChannel.isShutdown()) {
       grpcManagedChannel.shutdown();
     }
-  }
-
-  /**
-   * Creates a GRPC managed channel (or null, if not applicable).
-   *
-   * @param overrideProperties Overrides
-   * @return GRPC managed channel or null.
-   */
-  private static ManagedChannel buildManagedChannel(Properties overrideProperties) {
-    int port = overrideProperties.getValue(Properties.GRPC_PORT);
-    if (port <= 0) {
-      throw new IllegalArgumentException("Invalid port.");
-    }
-
-    var sidecarHost = overrideProperties.getValue(Properties.SIDECAR_IP);
-
-    return ManagedChannelBuilder.forAddress(sidecarHost, port)
-      .usePlaintext()
-      .userAgent(Version.getSdkVersion())
-      .build();
   }
 
   /**


### PR DESCRIPTION
# Description

This tiny PR extends the `ActorRuntime` by adding and overload `getInstance(Properties properties)` that allows us to provide the Dapr ports during instantiation, this is especially useful in integration tests and when integrating with Testcontainers.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1202 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
