### PR TITLE
feat: Adding basic HTTPEndpoint configuration support in testcontainers module

### DIFF
--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -15,6 +15,7 @@ package io.dapr.testcontainers;
 
 import io.dapr.testcontainers.converter.ComponentYamlConverter;
 import io.dapr.testcontainers.converter.ConfigurationYamlConverter;
+import io.dapr.testcontainers.converter.HttpEndpointYamlConverter;
 import io.dapr.testcontainers.converter.SubscriptionYamlConverter;
 import io.dapr.testcontainers.converter.YamlConverter;
 import io.dapr.testcontainers.converter.YamlMapperFactory;
@@ -48,6 +49,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
   private static final Yaml YAML_MAPPER = YamlMapperFactory.create();
   private static final YamlConverter<Component> COMPONENT_CONVERTER = new ComponentYamlConverter(YAML_MAPPER);
   private static final YamlConverter<Subscription> SUBSCRIPTION_CONVERTER = new SubscriptionYamlConverter(YAML_MAPPER);
+  private static final YamlConverter<HttpEndpoint> HTTPENDPOINT_CONVERTER = new HttpEndpointYamlConverter(YAML_MAPPER);
   private static final YamlConverter<Configuration> CONFIGURATION_CONVERTER = new ConfigurationYamlConverter(
       YAML_MAPPER);
   private static final WaitStrategy WAIT_STRATEGY = Wait.forHttp("/v1.0/healthz/outbound")
@@ -56,6 +58,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
 
   private final Set<Component> components = new HashSet<>();
   private final Set<Subscription> subscriptions = new HashSet<>();
+  private final Set<HttpEndpoint> httpEndpoints = new HashSet<>();
   private DaprLogLevel daprLogLevel = DaprLogLevel.INFO;
   private String appChannelAddress = "localhost";
   private String placementService = "placement";
@@ -131,6 +134,11 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
 
   public DaprContainer withSubscription(Subscription subscription) {
     subscriptions.add(subscription);
+    return this;
+  }
+
+  public DaprContainer withHttpEndpoint(HttpEndpoint httpEndpoint) {
+    httpEndpoints.add(httpEndpoint);
     return this;
   }
 
@@ -289,6 +297,15 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
       LOGGER.info("\t\n" + subscriptionYaml + "\n");
 
       withCopyToContainer(Transferable.of(subscriptionYaml), "/dapr-resources/" + subscription.getName() + ".yaml");
+    }
+
+    for (HttpEndpoint endpoint : httpEndpoints) {
+      String endpointYaml = HTTPENDPOINT_CONVERTER.convert(endpoint);
+
+      LOGGER.info("> HTTPEndpoint YAML: \n");
+      LOGGER.info("\t\n" + endpointYaml + "\n");
+
+      withCopyToContainer(Transferable.of(endpointYaml), "/dapr-resources/" + endpoint.getName() + ".yaml");
     }
 
     dependsOn(placementContainer);

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -102,6 +102,10 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
     return subscriptions;
   }
 
+  public Set<HttpEndpoint> getHttpEndpoints() {
+    return httpEndpoints;
+  }
+
   public DaprContainer withAppPort(Integer port) {
     this.appPort = port;
     return this;

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/HttpEndpoint.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/HttpEndpoint.java
@@ -1,0 +1,19 @@
+package io.dapr.testcontainers;
+
+public class HttpEndpoint {
+  private String name;
+  private String baseUrl;
+
+  public HttpEndpoint(String name, String baseUrl) {
+    this.name = name;
+    this.baseUrl = baseUrl;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+}

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/converter/HttpEndpointYamlConverter.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/converter/HttpEndpointYamlConverter.java
@@ -1,0 +1,32 @@
+package io.dapr.testcontainers.converter;
+
+import io.dapr.testcontainers.HttpEndpoint;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class HttpEndpointYamlConverter implements YamlConverter<HttpEndpoint> {
+  private final Yaml mapper;
+
+  public HttpEndpointYamlConverter(Yaml mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public String convert(HttpEndpoint endpoint) {
+    Map<String, Object> endpointProps = new LinkedHashMap<>();
+    endpointProps.put("apiVersion", "dapr.io/v1alpha1");
+    endpointProps.put("kind", "HTTPEndpoint");
+
+    Map<String, String> endpointMetadata = new LinkedHashMap<>();
+    endpointMetadata.put("name", endpoint.getName());
+    endpointProps.put("metadata", endpointMetadata);
+
+    Map<String, Object> endpointSpec = new LinkedHashMap<>();
+    endpointSpec.put("baseUrl", endpoint.getBaseUrl());
+    endpointProps.put("spec", endpointSpec);
+
+    return mapper.dumpAsMap(endpointProps);
+  }
+}

--- a/testcontainers-dapr/src/test/java/io/dapr/testcontainers/converter/HttpEndpointYamlConverterTest.java
+++ b/testcontainers-dapr/src/test/java/io/dapr/testcontainers/converter/HttpEndpointYamlConverterTest.java
@@ -1,0 +1,40 @@
+package io.dapr.testcontainers.converter;
+
+import io.dapr.testcontainers.DaprContainer;
+import io.dapr.testcontainers.HttpEndpoint;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpEndpointYamlConverterTest {
+  private final Yaml MAPPER = YamlMapperFactory.create();
+
+  private final HttpEndpointYamlConverter converter = new HttpEndpointYamlConverter(MAPPER);
+
+  @Test
+  void testHttpEndpointToYaml() {
+     DaprContainer dapr = new DaprContainer("daprio/daprd")
+         .withAppName("dapr-app")
+         .withAppPort(8081)
+         .withHttpEndpoint(new HttpEndpoint("my-endpoint", "http://localhost:8080"))
+         .withAppChannelAddress("host.testcontainers.internal");
+
+     Set<HttpEndpoint> endpoints = dapr.getHttpEndpoints();
+     assertEquals(1, endpoints.size());
+
+     HttpEndpoint endpoint = endpoints.iterator().next();
+     String endpointYaml = converter.convert(endpoint);
+     String expectedEndpointYaml =
+           "apiVersion: dapr.io/v1alpha1\n"
+         + "kind: HTTPEndpoint\n"
+         + "metadata:\n"
+         + "  name: my-endpoint\n"
+         + "spec:\n"
+         + "  baseUrl: http://localhost:8080\n";
+
+     assertEquals(expectedEndpointYaml, endpointYaml);
+  }
+}


### PR DESCRIPTION
This is the implementation of the #1209 proposal issue.

# Description

* Added `HttpEndpoint` and `HttpEndpointYamlConverter` as done before for Subscriptions and Components,
* Added a `withHttpEndpoint(HttpEndpoint endpoint)` method on `DaprContainer`

When `HTTPEndpoints` are registered, the test containers module creates Yaml files within the `/dapr-resources` folder, which is mounted into the sidecar container.

## Issue reference

See #1209 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
