### PR TITLE
Add app health check support to Dapr Testcontainer

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/spring/messaging/DaprSpringMessagingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/messaging/DaprSpringMessagingIT.java
@@ -20,6 +20,7 @@ import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -80,10 +81,14 @@ public class DaprSpringMessagingIT {
     org.testcontainers.Testcontainers.exposeHostPorts(APP_PORT);
   }
 
+  @BeforeEach
+  public void beforeEach() {
+    // Ensure the subscriptions are registered
+    Wait.forLogMessage(SUBSCRIPTION_MESSAGE_PATTERN, 1).waitUntilReady(DAPR_CONTAINER);
+  }
+
   @Test
   public void testDaprMessagingTemplate() throws InterruptedException {
-    Wait.forLogMessage(SUBSCRIPTION_MESSAGE_PATTERN, 1).waitUntilReady(DAPR_CONTAINER);
-
     for (int i = 0; i < 10; i++) {
       var msg = "ProduceAndReadWithPrimitiveMessageType:" + i;
 

--- a/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestRestController.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestRestController.java
@@ -34,7 +34,7 @@ public class TestRestController {
   private final List<CloudEvent<String>> events = new ArrayList<>();
 
   @GetMapping("/ready")
-  public String ok() throws InterruptedException {
+  public String ok() {
     return "OK";
   }
 

--- a/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestRestController.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/messaging/TestRestController.java
@@ -33,8 +33,8 @@ public class TestRestController {
   private static final Logger LOG = LoggerFactory.getLogger(TestRestController.class);
   private final List<CloudEvent<String>> events = new ArrayList<>();
 
-  @GetMapping("/")
-  public String ok() {
+  @GetMapping("/ready")
+  public String ok() throws InterruptedException {
     return "OK";
   }
 

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -68,6 +68,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
   private DaprPlacementContainer placementContainer;
   private String appName;
   private Integer appPort;
+  private String appHealthCheckPath;
   private boolean shouldReusePlacement;
 
   /**
@@ -113,6 +114,11 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
 
   public DaprContainer withAppChannelAddress(String appChannelAddress) {
     this.appChannelAddress = appChannelAddress;
+    return this;
+  }
+
+  public DaprContainer withAppHealthCheckPath(String appHealthCheckPath) {
+    this.appHealthCheckPath = appHealthCheckPath;
     return this;
   }
 
@@ -173,7 +179,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
    */
   public DaprContainer withComponent(Path path) {
     try {
-      Map<String, Object> component = this.YAML_MAPPER.loadAs(Files.newInputStream(path), Map.class);
+      Map<String, Object> component = YAML_MAPPER.loadAs(Files.newInputStream(path), Map.class);
 
       String type = (String) component.get("type");
       Map<String, Object> metadata = (Map<String, Object>) component.get("metadata");
@@ -233,13 +239,14 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
 
     List<String> cmds = new ArrayList<>();
     cmds.add("./daprd");
-    cmds.add("-app-id");
+    cmds.add("--app-id");
     cmds.add(appName);
     cmds.add("--dapr-listen-addresses=0.0.0.0");
     cmds.add("--app-protocol");
     cmds.add(DAPR_PROTOCOL.getName());
-    cmds.add("-placement-host-address");
+    cmds.add("--placement-host-address");
     cmds.add(placementService + ":50005");
+    cmds.add("--enable-app-health-check");
 
     if (appChannelAddress != null && !appChannelAddress.isEmpty()) {
       cmds.add("--app-channel-address");
@@ -249,6 +256,12 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
     if (appPort != null) {
       cmds.add("--app-port");
       cmds.add(Integer.toString(appPort));
+    }
+
+    if (appHealthCheckPath != null && !appHealthCheckPath.isEmpty()) {
+      cmds.add("--enable-app-health-check");
+      cmds.add("--app-health-check-path");
+      cmds.add(appHealthCheckPath);
     }
 
     if (configuration != null) {

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -246,7 +246,6 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
     cmds.add(DAPR_PROTOCOL.getName());
     cmds.add("--placement-host-address");
     cmds.add(placementService + ":50005");
-    cmds.add("--enable-app-health-check");
 
     if (appChannelAddress != null && !appChannelAddress.isEmpty()) {
       cmds.add("--app-channel-address");


### PR DESCRIPTION
# Description

Although we added support for Dapr Testcontainer sometimes we see race conditions between Dapr daemon and the application that should be run by Dapr. This leads to flaky tests and poor user experience.

The purpose of this PR is to add support for Dapr app health checks. The `DaprContainer` has been enhanced with a new property named `appHealthCheckPath`. If the `withAppHealthCheckPath(...)` builder method is invoked we will add the following CLI args to Dapr daemon:
```
--enable-app-health-check
--app-health-check-path <path to health endpoint>
```
App health checks CLI args are not enough though. What we have observed is that both the app and the Dapr daemon are up and running, but not all the components are setup or ready. We have tried multiple strategies and none of them work correctly. Currently instead of using "dumb" `Thread.sleep(...)` the proposal is to leverage Testcontainer `WaitStrategy` to lookout for Dapr logs that tells us when things have been properly bootstrapped. Here is a sample:
```java
Wait.forLogMessage(SUBSCRIPTION_MESSAGE_PATTERN, 1).waitUntilReady(DAPR_CONTAINER);
```
The downside of this approach is that users will have to add this wait strategy to their tests, but it is definitely better than `Thread.sleep`. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1212 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
