### PR TITLE
DaprBot pushing tag or to branch already triggers build.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -54,21 +54,3 @@ jobs:
           # Copy first to allow automation to use the latest version and not the release branch's version.
           cp -R ./.github/scripts ${RUNNER_TEMP}/
           ${RUNNER_TEMP}/scripts/create-release.sh ${{ inputs.rel_version }}
-  trigger:
-    name: Triggers the Dapr SDK build
-    runs-on: ubuntu-latest
-    needs: create-release
-    steps:
-      - name: Identify build ref to trigger build and release.
-        run: |
-          if [[ "${{ inputs.rel_version }}" == *"SNAPSHOT"* ]]; then
-            echo "BUILD_GIT_REF=master" >> $GITHUB_ENV
-          else
-            echo "BUILD_GIT_REF=v${{ inputs.rel_version }}" >> $GITHUB_ENV
-          fi
-      - name: Triggers the build and release.
-        if: env.BUILD_GIT_REF != 'master'
-        env:
-          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
-        run: |
-          gh workflow run build.yml --repo ${GITHUB_REPOSITORY} --ref '${{ env.BUILD_GIT_REF }}'


### PR DESCRIPTION
# Description

DaprBot pushing tag or to branch already triggers build, so starting the build after code or tag is pushed causes duplicates.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
