### PR TITLE
Consolidate SpringBoot Versions & Fix Release Pipeline

### DIFF
--- a/spring-boot-examples/consumer-app/pom.xml
+++ b/spring-boot-examples/consumer-app/pom.xml
@@ -12,9 +12,6 @@
   <name>consumer-app</name>
   <description>Spring Boot, Testcontainers and Dapr Integration Examples :: Consumer App</description>
 
-  <properties>
-    <springboot.version>3.2.6</springboot.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>
@@ -37,12 +34,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.dapr.spring</groupId>
-      <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr-java-sdk.alpha-version}</version>
-    </dependency>
-
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>

--- a/spring-boot-examples/consumer-app/pom.xml
+++ b/spring-boot-examples/consumer-app/pom.xml
@@ -95,14 +95,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>

--- a/spring-boot-examples/pom.xml
+++ b/spring-boot-examples/pom.xml
@@ -23,6 +23,15 @@
   </modules>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${springboot.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/spring-boot-examples/pom.xml
+++ b/spring-boot-examples/pom.xml
@@ -13,6 +13,10 @@
   <version>0.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <modules>
     <module>producer-app</module>
     <module>consumer-app</module>
@@ -20,14 +24,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>

--- a/spring-boot-examples/producer-app/pom.xml
+++ b/spring-boot-examples/producer-app/pom.xml
@@ -13,9 +13,6 @@
   <name>producer-app</name>
   <description>Spring Boot, Testcontainers and Dapr Integration Examples :: Producer App</description>
 
-  <properties>
-    <springboot.version>3.2.6</springboot.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>

--- a/spring-boot-examples/producer-app/pom.xml
+++ b/spring-boot-examples/producer-app/pom.xml
@@ -82,14 +82,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>


### PR DESCRIPTION
- Proper Maven inheritance is utilized
- No redundant configurations in child POMs. [Child POMs automatically inherit this property from the parent POM according to the docs here.](https://howtodoinjava.com/maven/maven-parent-child-pom-example/#:~:text=Now%20child%20POM%20needs%20to,sub%2Dproject%2Dspecific%20dependencies.)
- [Consistent versioning across modules](https://github.com/dapr/java-sdk/blob/master/pom.xml#L48)
- Example modules are properly skipped during deployment

- Fix the nexus staging error in the [Publish step here](https://github.com/dapr/java-sdk/actions/runs/13707874378/job/38338752938#step:8:3585) by adding `<maven.deploy.skip>true</maven.deploy.skip>` to the properties section of the `spring-boot-examples` parent POM:
```
Error:  Rule failure while trying to close staging repository with ID "iodapr-1082".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
Error:  Repository "iodapr-1082" failures
Error:    Rule "sources-staging" failures
Error:      * Missing: no sources jar found in folder '/io/dapr/producer-app/0.14.0-rc-3'
Error:      * Missing: no sources jar found in folder '/io/dapr/dapr-sdk-examples/1.14.0-rc-3'
Error:      * Missing: no sources jar found in folder '/io/dapr/consumer-app/0.14.0-rc-3'
Error:    Rule "javadoc-staging" failures
Error:      * Missing: no javadoc jar found in folder '/io/dapr/producer-app/0.14.0-rc-3'
Error:      * Missing: no javadoc jar found in folder '/io/dapr/dapr-sdk-examples/1.14.0-rc-3'
Error:      * Missing: no javadoc jar found in folder '/io/dapr/consumer-app/0.14.0-rc-3'
Error:  
Error:  
Error:  Cleaning up local stage directory after a Rule failure during close of staging repositories: [iodapr-1082]
Error:   * Deleting context 59243a4bfe8d4.properties
Error:  Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [iodapr-1082]
Error:   * Dropping failed staging repository with ID "iodapr-1082" (Rule failure during close of staging repositories: [iodapr-1082]).

```

- Fix springboot version warning by adding the pluginManagement section to the `spring-boot-examples` parent POM:
```
Warning:  
Warning:  Some problems were encountered while building the effective model for io.dapr:producer-app:jar:0.14.0-rc-3
Warning:  'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 79, column 15
Warning:  
Warning:  Some problems were encountered while building the effective model for io.dapr:consumer-app:jar:0.14.0-rc-3
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dapr.spring:dapr-spring-boot-starter:jar -> version ${dapr-java-sdk.alpha-version} vs ${dapr.sdk.alpha.version} @ line 46, column 17
Warning:  'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 92, column 15
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:  
```
