### PR TITLE
Fixing argument order for deploy profile option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,4 +181,4 @@ jobs:
           echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d > private-key.gpg
           export GPG_TTY=$(tty)
           gpg --batch --import private-key.gpg
-          ./mvnw -V -B -Dgpg.skip=false -s settings.xml deploy -Pdeploy-profile
+          ./mvnw -V -B -Dgpg.skip=false -s settings.xml -Pdeploy-profile deploy


### PR DESCRIPTION
# Description

Setting the profile is a maven option that should go before the maven goal, in this case deploy. 

```
mvn [options] [<goal(s)>] [<phase(s)>]
```
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
