### PR TITLE
Using nexus staging plugig to deploy and skip deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,4 +181,4 @@ jobs:
           echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d > private-key.gpg
           export GPG_TTY=$(tty)
           gpg --batch --import private-key.gpg
-          ./mvnw -V -B -Dgpg.skip=false -s settings.xml -Pdeploy-profile deploy
+          ./mvnw -V -B -Dgpg.skip=false -s settings.xml deploy

--- a/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
@@ -75,5 +75,12 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter-test/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter-test/pom.xml
@@ -40,5 +40,12 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
 </project>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter/pom.xml
@@ -47,4 +47,12 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dapr-spring/dapr-spring-boot-tests/pom.xml
+++ b/dapr-spring/dapr-spring-boot-tests/pom.xml
@@ -41,5 +41,12 @@
       <version>${dapr.sdk.alpha.version}</version>
     </dependency>
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dapr-spring/dapr-spring-data/pom.xml
+++ b/dapr-spring/dapr-spring-data/pom.xml
@@ -21,4 +21,12 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dapr-spring/dapr-spring-messaging/pom.xml
+++ b/dapr-spring/dapr-spring-messaging/pom.xml
@@ -14,4 +14,12 @@
   <description>Dapr Spring Messaging</description>
   <packaging>jar</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dapr-spring/dapr-spring-workflows/pom.xml
+++ b/dapr-spring/dapr-spring-workflows/pom.xml
@@ -21,4 +21,12 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>  
 </project>

--- a/dapr-spring/pom.xml
+++ b/dapr-spring/pom.xml
@@ -93,6 +93,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.3.1</version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,6 @@
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.deploy.skip>true</maven.deploy.skip>
     <spotbugs.fail>false</spotbugs.fail>
     <opentelemetry.version>0.14.0</opentelemetry.version>
   </properties>
@@ -182,14 +181,6 @@
         <version>3.13.0</version>
         <configuration>
           <release>${java.version}</release>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <testcontainers.version>1.20.0</testcontainers.version>
     <springboot.version>3.4.3</springboot.version>
+    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
   </properties>
 
   <distributionManagement>
@@ -162,10 +163,20 @@
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>${nexus-staging-maven-plugin.version}</version>
+          <extensions>true</extensions>
+        </plugin>
       </plugins>
     </pluginManagement>
-
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <inherited>false</inherited>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -343,19 +354,6 @@
   </modules>
 
   <profiles>
-    <profile>
-      <id>deploy-profile</id>
-      <modules>
-        <!-- Include only the modules to be deployed -->
-        <module>sdk-autogen</module>
-        <module>sdk</module>
-        <module>sdk-actors</module>
-        <module>sdk-springboot</module>
-        <module>sdk-workflows</module>
-        <module>testcontainers-dapr</module>
-        <module>dapr-spring</module>
-      </modules>
-    </profile>
     <profile>
       <id>integration-tests</id>
       <modules>

--- a/sdk-actors/pom.xml
+++ b/sdk-actors/pom.xml
@@ -71,6 +71,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.2.1</version>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -65,6 +65,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
         <version>1.6.0</version>

--- a/sdk-springboot/pom.xml
+++ b/sdk-springboot/pom.xml
@@ -16,10 +16,6 @@
   <name>dapr-sdk-springboot</name>
   <description>SDK extension for Springboot</description>
 
-  <properties>
-    <maven.deploy.skip>false</maven.deploy.skip>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -85,6 +81,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/sdk-workflows/pom.xml
+++ b/sdk-workflows/pom.xml
@@ -16,10 +16,6 @@
   <name>dapr-sdk-workflows</name>
   <description>SDK for Workflows on Dapr</description>
 
-  <properties>
-    <maven.deploy.skip>false</maven.deploy.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.dapr</groupId>
@@ -82,6 +78,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -148,6 +148,10 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>

--- a/spring-boot-examples/consumer-app/pom.xml
+++ b/spring-boot-examples/consumer-app/pom.xml
@@ -92,14 +92,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/spring-boot-examples/pom.xml
+++ b/spring-boot-examples/pom.xml
@@ -23,28 +23,11 @@
   </modules>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>${springboot.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.12.1</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/spring-boot-examples/producer-app/pom.xml
+++ b/spring-boot-examples/producer-app/pom.xml
@@ -76,6 +76,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${springboot.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -90,14 +91,6 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <!-- Skip checkstyle for auto-generated code -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
           <skip>true</skip>
         </configuration>
       </plugin>

--- a/testcontainers-dapr/pom.xml
+++ b/testcontainers-dapr/pom.xml
@@ -46,6 +46,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>


### PR DESCRIPTION
# Description

The builds were swapping the plugin to deploy, hence the configurations were not being picked up. 
You can check in the failing publish pipeline the note: 

```
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 19 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
```

This PR switch to use the `nexus-staging-maven-plugin` and remove the deploy-profile.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
