### PR TITLE
[WIP] feat: Add missing sendEvent

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/TestDaprWorkflowsConfiguration.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/TestDaprWorkflowsConfiguration.java
@@ -56,6 +56,7 @@ public class TestDaprWorkflowsConfiguration {
     WorkflowRuntimeBuilder builder = new WorkflowRuntimeBuilder(new Properties(overrides));
 
     builder.registerWorkflow(TestWorkflow.class);
+    builder.registerWorkflow(TestSenderWorkflow.class);
     builder.registerActivity(FirstActivity.class);
     builder.registerActivity(SecondActivity.class);
 

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/TestSenderWorkflowPayload.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/TestSenderWorkflowPayload.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.it.testcontainers;
+
+import java.util.List;
+
+public class TestSenderWorkflowPayload extends TestWorkflowPayload {
+  private String sendToworkflowId;
+
+  public TestSenderWorkflowPayload() {
+    super();
+  }
+
+  public TestSenderWorkflowPayload(List<String> payloads, String workflowId) {
+    super(payloads, workflowId);
+  }
+
+  public TestSenderWorkflowPayload(String sendToworkflowId, List<String> payloads) {
+    super(payloads);
+    this.sendToworkflowId = sendToworkflowId;
+  }
+
+  public String getSendToworkflowId() {
+    return sendToworkflowId;
+  }
+
+  public void setSendToworkflowId(String sendToworkflowId) {
+    this.sendToworkflowId = sendToworkflowId;
+  }
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowContext.java
@@ -117,7 +117,7 @@ public interface WorkflowContext {
    * @return a new {@link Task} that completes when the external event is received
    */
   <V> Task<Void> waitForExternalEvent(String name) throws TaskCanceledException;
-
+  
   /**
    * Waits for an event to be raised named {@code name} and returns a {@link Task} that completes when the event is
    * received.
@@ -137,6 +137,25 @@ public interface WorkflowContext {
       throw new RuntimeException("An unexpected exception was throw while waiting for an external event.", e);
     }
   }
+
+  /**
+    * Sends an external event to another orchestration instance.
+    * 
+    * @param instanceID the instance ID of the workflow to send the event to
+    * @param eventName the name of the event to send
+    */
+  default void sendEvent(String instanceID, String eventName) {
+    this.sendEvent(instanceID, eventName, null);
+  }
+
+  /**
+   * Sends an external event to another orchestration instance.
+   * 
+   * @param instanceID the instance ID of the workflow to send the event to
+   * @param eventName the name of the event to send
+   * @param data the data to send to the workflow
+   */
+  void sendEvent(String instanceID, String eventName, Object data);
 
   /**
    * Asynchronously invokes an activity by name and with the specified input value and returns a new {@link Task}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
@@ -244,4 +244,9 @@ public class DefaultWorkflowContext implements WorkflowContext {
 
     return new TaskOptions(retryPolicy);
   }
+
+  @Override
+  public void sendEvent(String instanceID, String eventName, Object data) {
+    this.innerContext.sendEvent(instanceID, eventName, data);
+  }
 }

--- a/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,6 +52,7 @@ public class DefaultWorkflowContextTest {
   public void setUp() {
     mockInnerContext = mock(TaskOrchestrationContext.class);
     context = new DefaultWorkflowContext(mockInnerContext);
+    
     testWorkflowContext = new WorkflowContext() {
       @Override
       public Logger getLogger() {
@@ -133,6 +133,10 @@ public class DefaultWorkflowContextTest {
 
       @Override
       public void continueAsNew(Object input, boolean preserveUnprocessedEvents) {
+      }
+
+      @Override
+      public void sendEvent(String instanceID, String eventName, Object data) {
       }
     };
   }
@@ -326,5 +330,23 @@ public class DefaultWorkflowContextTest {
     RuntimeException runtimeException = assertThrows(RuntimeException.class, testWorkflowContext::newUuid);
     String expectedMessage = "No implementation found.";
     assertEquals(expectedMessage, runtimeException.getMessage());
+  }
+
+  @Test
+  public void sendEmptyEventTest() {
+    String expectedInstanceId = "TestInstanceId";
+    String expectedEventName = "TestEventName";
+    context.sendEvent(expectedInstanceId, expectedEventName);
+    verify(mockInnerContext, times(1)).sendEvent(expectedInstanceId, expectedEventName, null);
+  }
+
+  @Test
+  public void sendEventTest() {
+    String expectedInstanceId = "TestInstanceId";
+    String expectedEventName = "TestEventName";
+    Object expectedData = "TestData";
+
+    context.sendEvent(expectedInstanceId, expectedEventName, expectedData);
+    verify(mockInnerContext, times(1)).sendEvent(expectedInstanceId, expectedEventName, expectedData);
   }
 }


### PR DESCRIPTION
Durabletask-java library supports the feature for a Workflow to raise an event directly to another Workflow

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
