### PR TITLE
[1.14] Fix kotlin-stdlib vuln

### DIFF
--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>3.9.1</version>
+      <version>3.11.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[Cherry-pick this PR to 1.14](https://github.com/dapr/java-sdk/pull/1354)