### PR TITLE
Feat Add TLS & mTLS support for gRPC with root CA and insecure mode

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -144,6 +144,11 @@
       <version>1.70</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -132,6 +132,18 @@
       <artifactId>assertj-core</artifactId>
       <version>${assertj.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -119,14 +119,23 @@ public class Properties {
       null);
 
   /**
-   * Path to the TLS CA certificate for gRPC communication after checking system property
-   * and environment variable.
+   * GRPC TLS CA cert path for Dapr after checking system property and environment variable.
+   * This is used for TLS connections to servers with self-signed certificates.
    */
   public static final Property<String> GRPC_TLS_CA_PATH = new StringProperty(
       "dapr.grpc.tls.ca.path",
       "DAPR_GRPC_TLS_CA_PATH",
       null);
-      
+
+  /**
+   * Force insecure (plaintext) mode for gRPC communication, regardless of other TLS settings.
+   * This should only be used for testing or in secure environments.
+   */
+  public static final Property<Boolean> GRPC_INSECURE = new BooleanProperty(
+      "dapr.grpc.insecure",
+      "DAPR_GRPC_INSECURE",
+      false);
+
   /**
    * GRPC endpoint for remote sidecar connectivity.
    */

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -117,6 +117,15 @@ public class Properties {
       "dapr.grpc.tls.key.path",
       "DAPR_GRPC_TLS_KEY_PATH",
       null);
+
+  /**
+   * Path to the TLS CA certificate for gRPC communication after checking system property
+   * and environment variable.
+   */
+  public static final Property<String> GRPC_TLS_CA_PATH = new StringProperty(
+      "dapr.grpc.tls.ca.path",
+      "DAPR_GRPC_TLS_CA_PATH",
+      null);
       
   /**
    * GRPC endpoint for remote sidecar connectivity.

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -103,6 +103,22 @@ public class Properties {
       DEFAULT_GRPC_PORT);
 
   /**
+   * GRPC TLS cert path for Dapr after checking system property and environment variable.
+   */
+  public static final Property<String> GRPC_TLS_CERT_PATH = new StringProperty(
+      "dapr.grpc.tls.cert.path",
+      "DAPR_GRPC_TLS_CERT_PATH",
+      null);
+
+  /**
+   * GRPC TLS key path for Dapr after checking system property and environment variable.
+   */
+  public static final Property<String> GRPC_TLS_KEY_PATH = new StringProperty(
+      "dapr.grpc.tls.key.path",
+      "DAPR_GRPC_TLS_KEY_PATH",
+      null);
+      
+  /**
    * GRPC endpoint for remote sidecar connectivity.
    */
   public static final Property<String> GRPC_ENDPOINT = new StringProperty(

--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -128,12 +128,13 @@ public class Properties {
       null);
 
   /**
-   * Force insecure (plaintext) mode for gRPC communication, regardless of other TLS settings.
+   * Use insecure TLS mode which still uses TLS but doesn't verify certificates.
+   * This uses InsecureTrustManagerFactory to trust all certificates.
    * This should only be used for testing or in secure environments.
    */
-  public static final Property<Boolean> GRPC_INSECURE = new BooleanProperty(
-      "dapr.grpc.insecure",
-      "DAPR_GRPC_INSECURE",
+  public static final Property<Boolean> GRPC_TLS_INSECURE = new BooleanProperty(
+      "dapr.grpc.tls.insecure",
+      "DAPR_GRPC_TLS_INSECURE",
       false);
 
   /**

--- a/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
+++ b/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
@@ -33,9 +33,9 @@ import java.util.regex.Pattern;
 
 import static io.dapr.config.Properties.GRPC_ENDPOINT;
 import static io.dapr.config.Properties.GRPC_PORT;
+import static io.dapr.config.Properties.GRPC_TLS_CA_PATH;
 import static io.dapr.config.Properties.GRPC_TLS_CERT_PATH;
 import static io.dapr.config.Properties.GRPC_TLS_KEY_PATH;
-import static io.dapr.config.Properties.GRPC_TLS_CA_PATH;
 import static io.dapr.config.Properties.SIDECAR_IP;
 
 /**
@@ -182,7 +182,8 @@ public final class NetworkUtils {
     final String tlsCertPath;
     final String tlsCaPath;
 
-    private GrpcEndpointSettings(String endpoint, boolean secure, String tlsPrivateKeyPath, String tlsCertPath, String tlsCaPath) {
+    private GrpcEndpointSettings(
+            String endpoint, boolean secure, String tlsPrivateKeyPath, String tlsCertPath, String tlsCaPath) {
       this.endpoint = endpoint;
       this.secure = secure;
       this.tlsPrivateKeyPath = tlsPrivateKeyPath;

--- a/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
+++ b/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
@@ -127,7 +127,6 @@ public final class NetworkUtils {
     String clientCertPath = settings.tlsCertPath;
 
     ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forTarget(settings.endpoint);
-
     if (clientCertPath != null && clientKeyPath != null) {
       try {
         InputStream clientCertInputStream = new FileInputStream(clientCertPath);
@@ -136,18 +135,18 @@ public final class NetworkUtils {
         ChannelCredentials credentials = TlsChannelCredentials.newBuilder()
             .keyManager(clientCertInputStream, clientKeyInputStream)
             .build();
+
         builder = Grpc.newChannelBuilder(settings.endpoint, credentials);
       } catch (IOException e) {
         throw new DaprException(
             new DaprError().setErrorCode("TLS_CREDENTIALS_ERROR").setMessage("Failed to create TLS credentials"), e);
       }
+    } else if (!settings.secure) {
+      builder = builder.usePlaintext();
     }
 
     builder.userAgent(Version.getSdkVersion());
 
-    if (!settings.secure) {
-      builder = builder.usePlaintext();
-    }
     if (interceptors != null && interceptors.length > 0) {
       builder = builder.intercept(interceptors);
     }
@@ -173,7 +172,6 @@ public final class NetworkUtils {
       int port = properties.getValue(GRPC_PORT);
       String clientKeyPath = properties.getValue(GRPC_TLS_KEY_PATH);
       String clientCertPath = properties.getValue(GRPC_TLS_CERT_PATH);
-
 
       boolean secure = false;
       String grpcEndpoint = properties.getValue(GRPC_ENDPOINT);
@@ -226,7 +224,6 @@ public final class NetworkUtils {
 
       return new GrpcEndpointSettings(String.format("dns:///%s:%d", address, port), secure, clientKeyPath, clientCertPath);
     }
-
   }
 
   private static void callWithRetry(Runnable function, long retryTimeoutMilliseconds) throws InterruptedException {

--- a/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
+++ b/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
@@ -142,13 +142,12 @@ public final class NetworkUtils {
         throw new DaprException(
             new DaprError().setErrorCode("TLS_CREDENTIALS_ERROR").setMessage("Failed to create TLS credentials"), e);
       }
+    } else if (!settings.secure) {
+      builder = builder.usePlaintext();
     }
 
     builder.userAgent(Version.getSdkVersion());
 
-    if (!settings.secure) {
-      builder = builder.usePlaintext();
-    }
     if (interceptors != null && interceptors.length > 0) {
       builder = builder.intercept(interceptors);
     }

--- a/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
+++ b/sdk/src/main/java/io/dapr/utils/NetworkUtils.java
@@ -32,8 +32,8 @@ import java.net.Socket;
 import java.util.regex.Pattern;
 
 import static io.dapr.config.Properties.GRPC_ENDPOINT;
-import static io.dapr.config.Properties.GRPC_PORT;
 import static io.dapr.config.Properties.GRPC_INSECURE;
+import static io.dapr.config.Properties.GRPC_PORT;
 import static io.dapr.config.Properties.GRPC_TLS_CA_PATH;
 import static io.dapr.config.Properties.GRPC_TLS_CERT_PATH;
 import static io.dapr.config.Properties.GRPC_TLS_KEY_PATH;

--- a/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
@@ -1,19 +1,75 @@
 package io.dapr.utils;
 
 import io.dapr.config.Properties;
+import io.dapr.exceptions.DaprException;
 import io.grpc.ManagedChannel;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.Map;
-
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 public class NetworkUtilsTest {
   private final int defaultGrpcPort = 50001;
   private final String defaultSidecarIP = "127.0.0.1";
   private ManagedChannel channel;
+
+  // Helper method to generate a self-signed certificate for testing
+  private static KeyPair generateKeyPair() throws Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048);
+    return keyPairGenerator.generateKeyPair();
+  }
+
+  private static X509Certificate generateCertificate(KeyPair keyPair) throws Exception {
+    X500Name issuer = new X500Name("CN=Test Certificate");
+    X500Name subject = new X500Name("CN=Test Certificate");
+    Date notBefore = new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000);
+    Date notAfter = new Date(System.currentTimeMillis() + 365 * 24 * 60 * 60 * 1000L);
+    SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
+    X509v3CertificateBuilder certBuilder = new X509v3CertificateBuilder(
+        issuer,
+        java.math.BigInteger.valueOf(System.currentTimeMillis()),
+        notBefore,
+        notAfter,
+        subject,
+        publicKeyInfo
+    );
+
+    ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate());
+    X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certBuilder.build(signer));
+    return cert;
+  }
+
+  private static void writeCertificateToFile(X509Certificate cert, File file) throws Exception {
+    String certPem = "-----BEGIN CERTIFICATE-----\n" +
+        java.util.Base64.getEncoder().encodeToString(cert.getEncoded()) +
+        "\n-----END CERTIFICATE-----";
+    Files.write(file.toPath(), certPem.getBytes());
+  }
+
+  private static void writePrivateKeyToFile(KeyPair keyPair, File file) throws Exception {
+    String keyPem = "-----BEGIN PRIVATE KEY-----\n" +
+        java.util.Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()) +
+        "\n-----END PRIVATE KEY-----";
+    Files.write(file.toPath(), keyPem.getBytes());
+  }
 
   @AfterEach
   public void tearDown() {
@@ -64,6 +120,134 @@ public class NetworkUtilsTest {
 
     String expectedAuthority = "example.com:3000";
     Assertions.assertEquals(expectedAuthority, channel.authority());
+  }
+
+  @Test
+  public void testBuildGrpcManagedChannelWithTls() throws Exception {
+    // Generate test certificate and key
+    KeyPair keyPair = generateKeyPair();
+    X509Certificate cert = generateCertificate(keyPair);
+    
+    File certFile = File.createTempFile("test-cert", ".pem");
+    File keyFile = File.createTempFile("test-key", ".pem");
+    try {
+      writeCertificateToFile(cert, certFile);
+      writePrivateKeyToFile(keyPair, keyFile);
+
+      var properties = new Properties(Map.of(
+          Properties.GRPC_TLS_CERT_PATH.getName(), certFile.getAbsolutePath(),
+          Properties.GRPC_TLS_KEY_PATH.getName(), keyFile.getAbsolutePath()
+      ));
+
+      channel = NetworkUtils.buildGrpcManagedChannel(properties);
+      String expectedAuthority = String.format("%s:%s", defaultSidecarIP, defaultGrpcPort);
+      Assertions.assertEquals(expectedAuthority, channel.authority());
+    } finally {
+      certFile.delete();
+      keyFile.delete();
+    }
+  }
+
+  @Test
+  public void testBuildGrpcManagedChannelWithTlsAndEndpoint() throws Exception {
+    // Generate test certificate and key
+    KeyPair keyPair = generateKeyPair();
+    X509Certificate cert = generateCertificate(keyPair);
+    
+    File certFile = File.createTempFile("test-cert", ".pem");
+    File keyFile = File.createTempFile("test-key", ".pem");
+    try {
+      writeCertificateToFile(cert, certFile);
+      writePrivateKeyToFile(keyPair, keyFile);
+
+      var properties = new Properties(Map.of(
+          Properties.GRPC_TLS_CERT_PATH.getName(), certFile.getAbsolutePath(),
+          Properties.GRPC_TLS_KEY_PATH.getName(), keyFile.getAbsolutePath(),
+          Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"
+      ));
+
+      channel = NetworkUtils.buildGrpcManagedChannel(properties);
+      Assertions.assertEquals("example.com:443", channel.authority());
+    } finally {
+      certFile.delete();
+      keyFile.delete();
+    }
+  }
+
+  @Test
+  public void testBuildGrpcManagedChannelWithInvalidTlsCert() {
+    var properties = new Properties(Map.of(
+        Properties.GRPC_TLS_CERT_PATH.getName(), "/nonexistent/cert.pem",
+        Properties.GRPC_TLS_KEY_PATH.getName(), "/nonexistent/key.pem"
+    ));
+
+    Assertions.assertThrows(DaprException.class, () -> {
+      NetworkUtils.buildGrpcManagedChannel(properties);
+    });
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC}) // Unix domain sockets are only supported on Linux and macOS
+  public void testBuildGrpcManagedChannelWithTlsAndUnixSocket() throws Exception {
+    // Skip test if Unix domain sockets are not supported
+    Assumptions.assumeTrue(System.getProperty("os.name").toLowerCase().contains("linux") || 
+                          System.getProperty("os.name").toLowerCase().contains("mac"));
+
+    // Generate test certificate and key
+    KeyPair keyPair = generateKeyPair();
+    X509Certificate cert = generateCertificate(keyPair);
+    
+    File certFile = File.createTempFile("test-cert", ".pem");
+    File keyFile = File.createTempFile("test-key", ".pem");
+    try {
+      writeCertificateToFile(cert, certFile);
+      writePrivateKeyToFile(keyPair, keyFile);
+
+      var properties = new Properties(Map.of(
+          Properties.GRPC_TLS_CERT_PATH.getName(), certFile.getAbsolutePath(),
+          Properties.GRPC_TLS_KEY_PATH.getName(), keyFile.getAbsolutePath(),
+          Properties.GRPC_ENDPOINT.getName(), "unix:/tmp/test.sock"
+      ));
+
+      // For Unix sockets, we expect an exception if the platform doesn't support it
+      try {
+        channel = NetworkUtils.buildGrpcManagedChannel(properties);
+        // If we get here, Unix sockets are supported
+        Assertions.assertEquals("", channel.authority());
+      } catch (Exception e) {
+        // If we get here, Unix sockets are not supported
+        Assertions.assertTrue(e.getMessage().contains("DomainSocketAddress"));
+      }
+    } finally {
+      certFile.delete();
+      keyFile.delete();
+    }
+  }
+
+  @Test
+  public void testBuildGrpcManagedChannelWithTlsAndDnsAuthority() throws Exception {
+    // Generate test certificate and key
+    KeyPair keyPair = generateKeyPair();
+    X509Certificate cert = generateCertificate(keyPair);
+    
+    File certFile = File.createTempFile("test-cert", ".pem");
+    File keyFile = File.createTempFile("test-key", ".pem");
+    try {
+      writeCertificateToFile(cert, certFile);
+      writePrivateKeyToFile(keyPair, keyFile);
+
+      var properties = new Properties(Map.of(
+          Properties.GRPC_TLS_CERT_PATH.getName(), certFile.getAbsolutePath(),
+          Properties.GRPC_TLS_KEY_PATH.getName(), keyFile.getAbsolutePath(),
+          Properties.GRPC_ENDPOINT.getName(), "dns://authority:53/example.com:443"
+      ));
+
+      channel = NetworkUtils.buildGrpcManagedChannel(properties);
+      Assertions.assertEquals("example.com:443", channel.authority());
+    } finally {
+      certFile.delete();
+      keyFile.delete();
+    }
   }
 
   @Test

--- a/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
@@ -516,7 +516,26 @@ public class NetworkUtilsTest {
   }
 
   @Test
-  public void testBuildGrpcManagedChannelWithForceInsecure() throws Exception {
+  public void testBuildGrpcManagedChannelWithInsecureTls() throws Exception {
+    // Test insecure TLS mode with HTTPS endpoint
+    var properties = new Properties(Map.of(
+        Properties.GRPC_TLS_INSECURE.getName(), "true",
+        Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"  // Using HTTPS to ensure TLS is used
+    ));
+
+    channel = NetworkUtils.buildGrpcManagedChannel(properties);
+    channels.add(channel);
+    
+    // Verify the channel is created with the correct authority
+    Assertions.assertEquals("example.com:443", channel.authority());
+    
+    // Verify the channel is active and using TLS (not plaintext)
+    Assertions.assertFalse(channel.isTerminated(), "Channel should be active");
+  }
+
+  @Test
+  public void testBuildGrpcManagedChannelWithInsecureTlsAndMtls() throws Exception {
+    // Generate test certificates
     KeyPair caKeyPair = generateKeyPair();
     X509Certificate caCert = generateCertificate(caKeyPair);
     KeyPair clientKeyPair = generateKeyPair();
@@ -530,13 +549,14 @@ public class NetworkUtilsTest {
       writeCertificateToFile(clientCert, clientCertFile);
       writePrivateKeyToFile(clientKeyPair, clientKeyFile);
 
-      // Force insecure overrides all TLS settings
+      // Test that insecure TLS still works with mTLS settings
+      // The client certs should be ignored since we're using InsecureTrustManagerFactory
       var properties = new Properties(Map.of(
-          Properties.GRPC_INSECURE.getName(), "true",
+          Properties.GRPC_TLS_INSECURE.getName(), "true",
           Properties.GRPC_TLS_CA_PATH.getName(), caCertFile.getAbsolutePath(),
           Properties.GRPC_TLS_CERT_PATH.getName(), clientCertFile.getAbsolutePath(),
           Properties.GRPC_TLS_KEY_PATH.getName(), clientKeyFile.getAbsolutePath(),
-          Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"  // Even with HTTPS
+          Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"
       ));
 
       channel = NetworkUtils.buildGrpcManagedChannel(properties);
@@ -545,6 +565,7 @@ public class NetworkUtilsTest {
       // Verify the channel is created with the correct authority
       Assertions.assertEquals("example.com:443", channel.authority());
       
+      // Verify the channel is active and using TLS (not plaintext)
       Assertions.assertFalse(channel.isTerminated(), "Channel should be active");
     } finally {
       caCertFile.delete();
@@ -554,20 +575,20 @@ public class NetworkUtilsTest {
   }
 
   @Test
-  public void testBuildGrpcManagedChannelWithInsecureOnly() {
-    // Test insecure mode with no TLS settings
+  public void testBuildGrpcManagedChannelWithInsecureTlsAndCustomEndpoint() throws Exception {
+    // Test insecure TLS with a custom endpoint that would normally require TLS
     var properties = new Properties(Map.of(
-        Properties.GRPC_INSECURE.getName(), "true"
+        Properties.GRPC_TLS_INSECURE.getName(), "true",
+        Properties.GRPC_ENDPOINT.getName(), "dns://authority:53/example.com:443?tls=true"
     ));
 
     channel = NetworkUtils.buildGrpcManagedChannel(properties);
     channels.add(channel);
     
-    // Verify the channel is created with the default authority
-    String expectedAuthority = String.format("%s:%s", defaultSidecarIP, defaultGrpcPort);
-    Assertions.assertEquals(expectedAuthority, channel.authority());
+    // Verify the channel is created with the correct authority
+    Assertions.assertEquals("example.com:443", channel.authority());
     
-    // Verify the channel is active
+    // Verify the channel is active and using TLS (not plaintext)
     Assertions.assertFalse(channel.isTerminated(), "Channel should be active");
   }
 }

--- a/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
@@ -517,10 +517,10 @@ public class NetworkUtilsTest {
 
   @Test
   public void testBuildGrpcManagedChannelWithInsecureTls() throws Exception {
-    // Test insecure TLS mode with HTTPS endpoint
+    // Test insecure TLS mode with a secure endpoint
     var properties = new Properties(Map.of(
         Properties.GRPC_TLS_INSECURE.getName(), "true",
-        Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"  // Using HTTPS to ensure TLS is used
+        Properties.GRPC_ENDPOINT.getName(), "dns:///example.com:443?tls=true"
     ));
 
     channel = NetworkUtils.buildGrpcManagedChannel(properties);
@@ -556,7 +556,7 @@ public class NetworkUtilsTest {
           Properties.GRPC_TLS_CA_PATH.getName(), caCertFile.getAbsolutePath(),
           Properties.GRPC_TLS_CERT_PATH.getName(), clientCertFile.getAbsolutePath(),
           Properties.GRPC_TLS_KEY_PATH.getName(), clientKeyFile.getAbsolutePath(),
-          Properties.GRPC_ENDPOINT.getName(), "https://example.com:443"
+          Properties.GRPC_ENDPOINT.getName(), "dns:///example.com:443?tls=true"
       ));
 
       channel = NetworkUtils.buildGrpcManagedChannel(properties);


### PR DESCRIPTION
[cherrypick this initial PR and add tests](https://github.com/dapr/java-sdk/pull/1360/files)

add support for 
- tls with root ca certs for server auth
- mtls with client certs
- insecure (plaintext) mode

