### PR TITLE
Fix component spec parsing

### DIFF
--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -222,7 +222,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
       ArrayList<MetadataEntry> metadataEntries = new ArrayList<>();
 
       for (Map<String, String> specMetadataItem : specMetadata) {
-          metadataEntries.add(new MetadataEntry(specMetadataItem.get("name"), specMetadataItem.get("value")));
+        metadataEntries.add(new MetadataEntry(specMetadataItem.get("name"), specMetadataItem.get("value")));
       }
 
       return withComponent(new Component(name, type, version, metadataEntries));

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -210,11 +210,11 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
     try {
       Map<String, Object> component = YAML_MAPPER.loadAs(Files.newInputStream(path), Map.class);
 
-      String type = (String) component.get("type");
       Map<String, Object> metadata = (Map<String, Object>) component.get("metadata");
       String name = (String) metadata.get("name");
 
       Map<String, Object> spec = (Map<String, Object>) component.get("spec");
+      String type = (String) spec.get("type");
       String version = (String) spec.get("version");
       List<Map<String, String>> specMetadata =
           (List<Map<String, String>>) spec.getOrDefault("metadata", Collections.emptyMap());

--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -217,14 +217,12 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
       String type = (String) spec.get("type");
       String version = (String) spec.get("version");
       List<Map<String, String>> specMetadata =
-          (List<Map<String, String>>) spec.getOrDefault("metadata", Collections.emptyMap());
+          (List<Map<String, String>>) spec.getOrDefault("metadata", Collections.emptyList());
 
       ArrayList<MetadataEntry> metadataEntries = new ArrayList<>();
 
       for (Map<String, String> specMetadataItem : specMetadata) {
-        for (Map.Entry<String, String> metadataItem : specMetadataItem.entrySet()) {
-          metadataEntries.add(new MetadataEntry(metadataItem.getKey(), metadataItem.getValue()));
-        }
+          metadataEntries.add(new MetadataEntry(specMetadataItem.get("name"), specMetadataItem.get("value")));
       }
 
       return withComponent(new Component(name, type, version, metadataEntries));

--- a/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
+++ b/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
@@ -69,7 +69,7 @@ public class DaprComponentTest {
         + "metadata:\n"
         + "  name: statestore\n"
         + "spec:\n"
-        + "  type: null\n"
+        + "  type: state.redis\n"
         + "  version: v1\n"
         + "  metadata:\n"
         + "  - name: name\n"

--- a/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
+++ b/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprComponentTest.java
@@ -72,17 +72,11 @@ public class DaprComponentTest {
         + "  type: state.redis\n"
         + "  version: v1\n"
         + "  metadata:\n"
-        + "  - name: name\n"
-        + "    value: keyPrefix\n"
-        + "  - name: value\n"
+        + "  - name: keyPrefix\n"
         + "    value: name\n"
-        + "  - name: name\n"
-        + "    value: redisHost\n"
-        + "  - name: value\n"
+        + "  - name: redisHost\n"
         + "    value: redis:6379\n"
-        + "  - name: name\n"
-        + "    value: redisPassword\n"
-        + "  - name: value\n"
+        + "  - name: redisPassword\n"
         + "    value: ''\n";
 
     assertEquals(expectedComponentYaml, componentYaml);


### PR DESCRIPTION
# Description

This PR resolves the issue described in #1368 by updating the parsing logic in `DaprContainer.withComponent(path)`.

Previously, the `type` field was incorrectly read from the root level of the component YAML. This caused the `type` to be `null`, even though it was correctly defined under the `spec` section.

The logic has now been fixed to correctly extract `type` and `metadata` from within `spec`.

The corresponding test has also been updated to validate against the expected YAML structure, including `type: state.redis` and accurate `metadata`.

## Issue reference

Closes #1368

## Checklist

* [x] Code compiles correctly  
* [x] Created/updated tests  
* [ ] Extended the documentation (if applicable)
