### PR TITLE
[1.15] use durabletask-java 1.5.3

### DIFF
--- a/sdk-workflows/pom.xml
+++ b/sdk-workflows/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>durabletask-client</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.3</version>
     </dependency>
     <!--
     manually declare durabletask-client's jackson dependencies


### PR DESCRIPTION
[same diff from this PR, but for the release branch](https://github.com/dapr/java-sdk/pull/1371)