### PR TITLE
Ensure OTEL version from examples aligns with SDK and ITs

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spotbugs.fail>false</spotbugs.fail>
-    <opentelemetry.version>0.14.0</opentelemetry.version>
+    <opentelemetry.version>1.14.0</opentelemetry.version>
     <opentelemetry-sdk-metrics.version>1.41.0</opentelemetry-sdk-metrics.version>
     <zipkin.version>2.16.3</zipkin.version>
   </properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,8 +22,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spotbugs.fail>false</spotbugs.fail>
-    <opentelemetry.version>1.14.0</opentelemetry.version>
-    <opentelemetry-sdk-metrics.version>1.41.0</opentelemetry-sdk-metrics.version>
+    <opentelemetry.version>1.41.0</opentelemetry.version>
     <zipkin.version>2.16.3</zipkin.version>
   </properties>
 
@@ -87,7 +86,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-metrics</artifactId>
-      <version>${opentelemetry-sdk-metrics.version}</version>
+      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spotbugs.fail>false</spotbugs.fail>
     <opentelemetry.version>1.41.0</opentelemetry.version>
-    <zipkin.version>2.16.3</zipkin.version>
+    <zipkin.version>3.4.0</zipkin.version>
   </properties>
 
   <dependencies>
@@ -80,17 +80,22 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-exporter-zipkin</artifactId>
+      <artifactId>opentelemetry-sdk-metrics</artifactId>
       <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-sdk-metrics</artifactId>
+      <artifactId>opentelemetry-exporter-zipkin</artifactId>
       <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${zipkin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>

--- a/examples/src/main/java/io/dapr/examples/OpenTelemetryInterceptor.java
+++ b/examples/src/main/java/io/dapr/examples/OpenTelemetryInterceptor.java
@@ -15,6 +15,7 @@ package io.dapr.examples;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,8 +35,8 @@ public class OpenTelemetryInterceptor implements HandlerInterceptor {
   @Autowired
   private OpenTelemetry openTelemetry;
 
-  private static final TextMapPropagator.Getter<HttpServletRequest> HTTP_SERVLET_REQUEST_GETTER =
-      new TextMapPropagator.Getter<>() {
+  private static final TextMapGetter<HttpServletRequest> HTTP_SERVLET_REQUEST_GETTER =
+      new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(HttpServletRequest carrier) {
           return Collections.list(carrier.getHeaderNames());

--- a/examples/src/main/java/io/dapr/examples/pubsub/BulkPublisher.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/BulkPublisher.java
@@ -21,6 +21,7 @@ import io.dapr.client.domain.BulkPublishResponseFailedEntry;
 import io.dapr.examples.OpenTelemetryConfig;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -55,28 +56,34 @@ public class BulkPublisher {
    * @throws Exception any exception
    */
   public static void main(String[] args) throws Exception {
-    OpenTelemetry openTelemetry = OpenTelemetryConfig.createOpenTelemetry();
-    Tracer tracer = openTelemetry.getTracer(BulkPublisher.class.getCanonicalName());
-    Span span = tracer.spanBuilder("Bulk Publisher's Main").setSpanKind(Span.Kind.CLIENT).startSpan();
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetryConfig.createOpenTelemetry();
+    Tracer tracer = openTelemetrySdk.getTracer(BulkPublisher.class.getCanonicalName());
+    Span span = tracer.spanBuilder("Bulk Publisher's Main").setSpanKind(SpanKind.CLIENT).startSpan();
+
     try (DaprPreviewClient client = (new DaprClientBuilder()).buildPreviewClient()) {
       DaprClient c = (DaprClient) client;
       c.waitForSidecar(10000);
+
       try (Scope scope = span.makeCurrent()) {
         System.out.println("Using preview client...");
         List<String> messages = new ArrayList<>();
         System.out.println("Constructing the list of messages to publish");
+
         for (int i = 0; i < NUM_MESSAGES; i++) {
           String message = String.format("This is message #%d", i);
           messages.add(message);
           System.out.println("Going to publish message : " + message);
         }
+
         BulkPublishResponse<?> res = client.publishEvents(PUBSUB_NAME, TOPIC_NAME, "text/plain", messages)
             .contextWrite(getReactorContext()).block();
         System.out.println("Published the set of messages in a single call to Dapr");
+
         if (res != null) {
           if (res.getFailedEntries().size() > 0) {
             // Ideally this condition will not happen in examples
             System.out.println("Some events failed to be published");
+
             for (BulkPublishResponseFailedEntry<?> entry : res.getFailedEntries()) {
               System.out.println("EntryId : " + entry.getEntry().getEntryId()
                   + " Error message : " + entry.getErrorMessage());
@@ -92,10 +99,9 @@ public class BulkPublisher {
       // Allow plenty of time for Dapr to export all relevant spans to the tracing infra.
       Thread.sleep(10000);
       // Shutdown the OpenTelemetry tracer.
-      OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+      openTelemetrySdk.getSdkTracerProvider().shutdown();
 
       System.out.println("Done");
     }
   }
 }
-

--- a/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
@@ -18,6 +18,7 @@ import io.dapr.client.DaprClientBuilder;
 import io.dapr.examples.OpenTelemetryConfig;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -51,9 +52,9 @@ public class PublisherWithTracing {
    * @throws Exception A startup Exception.
    */
   public static void main(String[] args) throws Exception {
-    OpenTelemetry openTelemetry = OpenTelemetryConfig.createOpenTelemetry();
-    Tracer tracer = openTelemetry.getTracer(PublisherWithTracing.class.getCanonicalName());
-    Span span = tracer.spanBuilder("Publisher's Main").setSpanKind(Span.Kind.CLIENT).startSpan();
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetryConfig.createOpenTelemetry();
+    Tracer tracer = openTelemetrySdk.getTracer(PublisherWithTracing.class.getCanonicalName());
+    Span span = tracer.spanBuilder("Publisher's Main").setSpanKind(SpanKind.CLIENT).startSpan();
 
     try (DaprClient client = new DaprClientBuilder().build()) {
       try (Scope scope = span.makeCurrent()) {
@@ -80,7 +81,7 @@ public class PublisherWithTracing {
       span.end();
 
       // Shutdown the OpenTelemetry tracer.
-      OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+      openTelemetrySdk.getSdkTracerProvider().shutdown();
 
       // This is an example, so for simplicity we are just exiting here.
       // Normally a dapr app would be a web service and not exit main.

--- a/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
@@ -16,7 +16,6 @@ package io.dapr.examples.pubsub;
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.dapr.examples.OpenTelemetryConfig;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
@@ -60,11 +59,13 @@ public class PublisherWithTracing {
       try (Scope scope = span.makeCurrent()) {
         for (int i = 0; i < NUM_MESSAGES; i++) {
           String message = String.format("This is message #%d", i);
+
           // Publishing messages, notice the use of subscriberContext() for tracing.
           client.publishEvent(
               PUBSUB_NAME,
               TOPIC_NAME,
               message).contextWrite(getReactorContext()).block();
+
           System.out.println("Published message: " + message);
 
           try {
@@ -72,19 +73,14 @@ public class PublisherWithTracing {
           } catch (InterruptedException e) {
             e.printStackTrace();
             Thread.currentThread().interrupt();
+
             return;
           }
         }
       }
 
-      // Close the span.
       span.end();
-
-      // Shutdown the OpenTelemetry tracer.
       openTelemetrySdk.getSdkTracerProvider().shutdown();
-
-      // This is an example, so for simplicity we are just exiting here.
-      // Normally a dapr app would be a web service and not exit main.
       System.out.println("Done.");
     }
   }

--- a/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
@@ -19,7 +19,6 @@ import io.dapr.client.domain.HttpExtension;
 import io.dapr.client.domain.InvokeMethodRequest;
 import io.dapr.examples.OpenTelemetryConfig;
 import io.dapr.utils.TypeRef;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
@@ -49,10 +48,10 @@ public class InvokeClient {
    * @param args Messages to be sent as request for the invoke API.
    */
   public static void main(String[] args) throws Exception {
-    final OpenTelemetrySdk openTelemetrySdk = OpenTelemetryConfig.createOpenTelemetry();
-    final Tracer tracer = openTelemetrySdk.getTracer(InvokeClient.class.getCanonicalName());
-
+    OpenTelemetrySdk openTelemetrySdk = OpenTelemetryConfig.createOpenTelemetry();
+    Tracer tracer = openTelemetrySdk.getTracer(InvokeClient.class.getCanonicalName());
     Span span = tracer.spanBuilder("Example's Main").setSpanKind(SpanKind.CLIENT).startSpan();
+
     try (DaprClient client = (new DaprClientBuilder()).build()) {
       for (String message : args) {
         try (Scope scope = span.makeCurrent()) {
@@ -72,12 +71,13 @@ public class InvokeClient {
         }
       }
     }
+
     span.end();
     shutdown(openTelemetrySdk);
     System.out.println("Done");
   }
 
-  private static void shutdown(OpenTelemetrySdk openTelemetrySdk) throws Exception {
+  private static void shutdown(OpenTelemetrySdk openTelemetrySdk) {
     openTelemetrySdk.getSdkTracerProvider().shutdown();
 
     Validation.validate();

--- a/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
@@ -21,6 +21,7 @@ import io.dapr.examples.OpenTelemetryConfig;
 import io.dapr.utils.TypeRef;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -48,10 +49,10 @@ public class InvokeClient {
    * @param args Messages to be sent as request for the invoke API.
    */
   public static void main(String[] args) throws Exception {
-    final OpenTelemetry openTelemetry = OpenTelemetryConfig.createOpenTelemetry();
-    final Tracer tracer = openTelemetry.getTracer(InvokeClient.class.getCanonicalName());
+    final OpenTelemetrySdk openTelemetrySdk = OpenTelemetryConfig.createOpenTelemetry();
+    final Tracer tracer = openTelemetrySdk.getTracer(InvokeClient.class.getCanonicalName());
 
-    Span span = tracer.spanBuilder("Example's Main").setSpanKind(Span.Kind.CLIENT).startSpan();
+    Span span = tracer.spanBuilder("Example's Main").setSpanKind(SpanKind.CLIENT).startSpan();
     try (DaprClient client = (new DaprClientBuilder()).build()) {
       for (String message : args) {
         try (Scope scope = span.makeCurrent()) {
@@ -72,12 +73,13 @@ public class InvokeClient {
       }
     }
     span.end();
-    shutdown();
+    shutdown(openTelemetrySdk);
     System.out.println("Done");
   }
 
-  private static void shutdown() throws Exception {
-    OpenTelemetrySdk.getGlobalTracerManagement().shutdown();
+  private static void shutdown(OpenTelemetrySdk openTelemetrySdk) throws Exception {
+    openTelemetrySdk.getSdkTracerProvider().shutdown();
+
     Validation.validate();
   }
 

--- a/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
@@ -70,17 +70,11 @@ public class InvokeClient {
               }).contextWrite(getReactorContext()).block();
         }
       }
+
+      span.end();
+      openTelemetrySdk.getSdkTracerProvider().shutdown();
+      Validation.validate();
+      System.out.println("Done");
     }
-
-    span.end();
-    shutdown(openTelemetrySdk);
-    System.out.println("Done");
   }
-
-  private static void shutdown(OpenTelemetrySdk openTelemetrySdk) {
-    openTelemetrySdk.getSdkTracerProvider().shutdown();
-
-    Validation.validate();
-  }
-
 }


### PR DESCRIPTION
# Description

Currently we have some discrepancies in the versioning of SDK and SDK ITs vs SDK examples, this is problematic since the production code diverges from the examples. The purpose of this PR is to update the OTEL version in the examples and fix the oudated classes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
