### PR TITLE
Add retry handler support

### DIFF
--- a/sdk-workflows/pom.xml
+++ b/sdk-workflows/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>durabletask-client</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
     <!--
     manually declare durabletask-client's jackson dependencies

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskFailureDetails.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskFailureDetails.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.workflows;
+
+public class WorkflowTaskFailureDetails {
+  private final String errorType;
+  private final String errorMessage;
+  private final String stackTrace;
+
+  /**
+   * Constructor for WorkflowTaskFailureDetails.
+   *
+   * @param errorType The type of error
+   * @param errorMessage The error message
+   * @param stackTrace The stacktrace of the error
+   */
+  public WorkflowTaskFailureDetails(
+          String errorType,
+          String errorMessage,
+          String stackTrace) {
+    this.errorType = errorType;
+    this.errorMessage = errorMessage;
+    this.stackTrace = stackTrace;
+  }
+
+  /**
+   * Gets the exception class name if the failure was caused by an unhandled exception. Otherwise, gets a symbolic
+   * name that describes the general type of error that was encountered.
+   *
+   * @return the error type as a {@code String} value
+   */
+  public String getErrorType() {
+    return this.errorType;
+  }
+
+  /**
+   * Gets a summary description of the error that caused this failure. If the failure was caused by an exception, the
+   * exception message is returned.
+   *
+   * @return a summary description of the error
+   */
+  public String getErrorMessage() {
+    return this.errorMessage;
+  }
+
+  /**
+   * Gets the stack trace of the exception that caused this failure, or {@code null} if the failure was caused by
+   * a non-exception error.
+   *
+   * @return the stack trace of the failure exception or {@code null} if the failure was not caused by an exception
+   */
+  public String getStackTrace() {
+    return this.stackTrace;
+  }
+
+  /**
+   * Returns {@code true} if the task failure was provided by the specified exception type, otherwise {@code false}.
+   *
+   * <p>This method allows checking if a task failed due to a specific exception type by attempting to load the class
+   * specified in {@link #getErrorType()}. If the exception class cannot be loaded for any reason, this method will
+   * return {@code false}. Base types are supported by this method, as shown in the following example:
+   * <pre>{@code
+   * boolean isRuntimeException = failureDetails.isCausedBy(RuntimeException.class);
+   * }</pre>
+   *
+   * @param exceptionClass the class representing the exception type to test
+   * @return {@code true} if the task failure was provided by the specified exception type, otherwise {@code false}
+   */
+  public boolean isCausedBy(Class<? extends Exception> exceptionClass) {
+    String actualClassName = this.getErrorType();
+    try {
+      // Try using reflection to load the failure's class type and see if it's a subtype of the specified
+      // exception. For example, this should always succeed if exceptionClass is System.Exception.
+      Class<?> actualExceptionClass = Class.forName(actualClassName);
+      return exceptionClass.isAssignableFrom(actualExceptionClass);
+    } catch (ClassNotFoundException ex) {
+      // Can't load the class and thus can't tell if it's related
+      return false;
+    }
+  }
+
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskFailureDetails.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskFailureDetails.java
@@ -17,6 +17,7 @@ public class WorkflowTaskFailureDetails {
   private final String errorType;
   private final String errorMessage;
   private final String stackTrace;
+  private final boolean isNonRetriable;
 
   /**
    * Constructor for WorkflowTaskFailureDetails.
@@ -24,14 +25,17 @@ public class WorkflowTaskFailureDetails {
    * @param errorType The type of error
    * @param errorMessage The error message
    * @param stackTrace The stacktrace of the error
+   * @param isNonRetriable Whether the failure is retriable or not
    */
   public WorkflowTaskFailureDetails(
           String errorType,
           String errorMessage,
-          String stackTrace) {
+          String stackTrace,
+          boolean isNonRetriable) {
     this.errorType = errorType;
     this.errorMessage = errorMessage;
     this.stackTrace = stackTrace;
+    this.isNonRetriable = isNonRetriable;
   }
 
   /**
@@ -62,6 +66,14 @@ public class WorkflowTaskFailureDetails {
    */
   public String getStackTrace() {
     return this.stackTrace;
+  }
+
+  /**
+   * Returns {@code true} if the failure doesn't permit retries, otherwise {@code false}.
+   * @return {@code true} if the failure doesn't permit retries, otherwise {@code false}.
+   */
+  public boolean isNonRetriable() {
+    return this.isNonRetriable;
   }
 
   /**

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskOptions.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskOptions.java
@@ -13,14 +13,12 @@ limitations under the License.
 
 package io.dapr.workflows;
 
-import io.dapr.durabletask.RetryHandler;
-
 public class WorkflowTaskOptions {
 
   private final WorkflowTaskRetryPolicy retryPolicy;
-  private final RetryHandler retryHandler;
+  private final WorkflowTaskRetryHandler retryHandler;
 
-  public WorkflowTaskOptions(WorkflowTaskRetryPolicy retryPolicy, RetryHandler retryHandler) {
+  public WorkflowTaskOptions(WorkflowTaskRetryPolicy retryPolicy, WorkflowTaskRetryHandler retryHandler) {
     this.retryPolicy = retryPolicy;
     this.retryHandler = retryHandler;
   }
@@ -29,7 +27,7 @@ public class WorkflowTaskOptions {
     this(retryPolicy, null);
   }
 
-  public WorkflowTaskOptions(RetryHandler retryHandler) {
+  public WorkflowTaskOptions(WorkflowTaskRetryHandler retryHandler) {
     this(null, retryHandler);
   }
 
@@ -37,7 +35,7 @@ public class WorkflowTaskOptions {
     return retryPolicy;
   }
 
-  public RetryHandler getRetryHandler() {
+  public WorkflowTaskRetryHandler getRetryHandler() {
     return retryHandler;
   }
 

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskOptions.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskOptions.java
@@ -13,16 +13,32 @@ limitations under the License.
 
 package io.dapr.workflows;
 
+import io.dapr.durabletask.RetryHandler;
+
 public class WorkflowTaskOptions {
 
   private final WorkflowTaskRetryPolicy retryPolicy;
+  private final RetryHandler retryHandler;
+
+  public WorkflowTaskOptions(WorkflowTaskRetryPolicy retryPolicy, RetryHandler retryHandler) {
+    this.retryPolicy = retryPolicy;
+    this.retryHandler = retryHandler;
+  }
 
   public WorkflowTaskOptions(WorkflowTaskRetryPolicy retryPolicy) {
-    this.retryPolicy = retryPolicy;
+    this(retryPolicy, null);
+  }
+
+  public WorkflowTaskOptions(RetryHandler retryHandler) {
+    this(null, retryHandler);
   }
 
   public WorkflowTaskRetryPolicy getRetryPolicy() {
     return retryPolicy;
+  }
+
+  public RetryHandler getRetryHandler() {
+    return retryHandler;
   }
 
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryContext.java
@@ -44,15 +44,15 @@ public class WorkflowTaskRetryContext {
   }
 
   /**
-   * Gets the context of the current orchestration.
+   * Gets the context of the current workflow.
    *
-   * <p>The orchestration context can be used in retry handlers to schedule timers (via the
+   * <p>The workflow context can be used in retry handlers to schedule timers (via the
    * {@link DefaultWorkflowContext#createTimer} methods) for implementing delays between retries. It can also be
    * used to implement time-based retry logic by using the {@link DefaultWorkflowContext#getCurrentInstant} method.
    *
-   * @return the context of the parent orchestration
+   * @return the context of the parent workflow
    */
-  public DefaultWorkflowContext getOrchestrationContext() {
+  public DefaultWorkflowContext getWorkflowContext() {
     return this.workflowContext;
   }
 

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.workflows;
+
+import io.dapr.workflows.runtime.DefaultWorkflowContext;
+
+import java.time.Duration;
+
+public class WorkflowTaskRetryContext {
+
+  private final DefaultWorkflowContext workflowContext;
+  private final int lastAttemptNumber;
+  private final WorkflowTaskFailureDetails lastFailure;
+  private final Duration totalRetryTime;
+
+  /**
+   * Constructor for WorkflowTaskRetryContext.
+   *
+   * @param workflowContext The workflow context
+   * @param lastAttemptNumber The number of the previous attempt
+   * @param lastFailure The failure details from the most recent failure
+   * @param totalRetryTime The amount of time spent retrying
+   */
+  public WorkflowTaskRetryContext(
+          DefaultWorkflowContext workflowContext,
+          int lastAttemptNumber,
+          WorkflowTaskFailureDetails lastFailure,
+          Duration totalRetryTime) {
+    this.workflowContext = workflowContext;
+    this.lastAttemptNumber = lastAttemptNumber;
+    this.lastFailure = lastFailure;
+    this.totalRetryTime = totalRetryTime;
+  }
+
+  /**
+   * Gets the context of the current orchestration.
+   *
+   * <p>The orchestration context can be used in retry handlers to schedule timers (via the
+   * {@link DefaultWorkflowContext#createTimer} methods) for implementing delays between retries. It can also be
+   * used to implement time-based retry logic by using the {@link DefaultWorkflowContext#getCurrentInstant} method.
+   *
+   * @return the context of the parent orchestration
+   */
+  public DefaultWorkflowContext getOrchestrationContext() {
+    return this.workflowContext;
+  }
+
+  /**
+   * Gets the details of the previous task failure, including the exception type, message, and callstack.
+   *
+   * @return the details of the previous task failure
+   */
+  public WorkflowTaskFailureDetails getLastFailure() {
+    return this.lastFailure;
+  }
+
+  /**
+   * Gets the previous retry attempt number. This number starts at 1 and increments each time the retry handler
+   * is invoked for a particular task failure.
+   *
+   * @return the previous retry attempt number
+   */
+  public int getLastAttemptNumber() {
+    return this.lastAttemptNumber;
+  }
+
+  /**
+   * Gets the total amount of time spent in a retry loop for the current task.
+   *
+   * @return the total amount of time spent in a retry loop for the current task
+   */
+  public Duration getTotalRetryTime() {
+    return this.totalRetryTime;
+  }
+
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryHandler.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowTaskRetryHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.workflows;
+
+public interface WorkflowTaskRetryHandler {
+
+  /**
+   * Invokes retry handler logic. Return value indicates whether to continue retrying.
+   *
+   * @param retryContext The context of the retry
+   * @return {@code true} to continue retrying or {@code false} to stop retrying.
+   */
+  boolean handle(WorkflowTaskRetryContext retryContext);
+
+}

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
@@ -14,6 +14,7 @@ limitations under the License.
 package io.dapr.workflows.runtime;
 
 import io.dapr.durabletask.CompositeTaskFailedException;
+import io.dapr.durabletask.RetryHandler;
 import io.dapr.durabletask.RetryPolicy;
 import io.dapr.durabletask.Task;
 import io.dapr.durabletask.TaskCanceledException;
@@ -233,17 +234,22 @@ public class DefaultWorkflowContext implements WorkflowContext {
       return null;
     }
 
-    WorkflowTaskRetryPolicy workflowTaskRetryPolicy = options.getRetryPolicy();
-    RetryPolicy retryPolicy = new RetryPolicy(
-        workflowTaskRetryPolicy.getMaxNumberOfAttempts(),
-        workflowTaskRetryPolicy.getFirstRetryInterval()
-    );
+    RetryPolicy retryPolicy = null;
+    RetryHandler retryHandler = options.getRetryHandler();
 
-    retryPolicy.setBackoffCoefficient(workflowTaskRetryPolicy.getBackoffCoefficient());
-    if (workflowTaskRetryPolicy.getRetryTimeout() != null) {
-      retryPolicy.setRetryTimeout(workflowTaskRetryPolicy.getRetryTimeout());
+    if (options.getRetryPolicy() != null) {
+      WorkflowTaskRetryPolicy workflowTaskRetryPolicy = options.getRetryPolicy();
+      retryPolicy = new RetryPolicy(
+              workflowTaskRetryPolicy.getMaxNumberOfAttempts(),
+              workflowTaskRetryPolicy.getFirstRetryInterval()
+      );
+
+      retryPolicy.setBackoffCoefficient(workflowTaskRetryPolicy.getBackoffCoefficient());
+      if (workflowTaskRetryPolicy.getRetryTimeout() != null) {
+        retryPolicy.setRetryTimeout(workflowTaskRetryPolicy.getRetryTimeout());
+      }
     }
 
-    return new TaskOptions(retryPolicy);
+    return new TaskOptions(retryPolicy, retryHandler);
   }
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
@@ -273,7 +273,8 @@ public class DefaultWorkflowContext implements WorkflowContext {
       WorkflowTaskFailureDetails workflowFailureDetails = new WorkflowTaskFailureDetails(
               failureDetails.getErrorType(),
               failureDetails.getErrorMessage(),
-              failureDetails.getStackTrace()
+              failureDetails.getStackTrace(),
+              failureDetails.isNonRetriable()
       );
       WorkflowTaskRetryContext workflowRetryContext = new WorkflowTaskRetryContext(
               this,

--- a/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
@@ -14,6 +14,9 @@ limitations under the License.
 package io.dapr.workflows;
 
 import io.dapr.durabletask.CompositeTaskFailedException;
+import io.dapr.durabletask.FailureDetails;
+import io.dapr.durabletask.RetryContext;
+import io.dapr.durabletask.RetryHandler;
 import io.dapr.durabletask.Task;
 import io.dapr.durabletask.TaskCanceledException;
 import io.dapr.durabletask.TaskOptions;
@@ -35,10 +38,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -278,7 +282,7 @@ public class DefaultWorkflowContextTest {
   }
 
   @Test
-  public void callChildWorkflowWithOptions() {
+  public void callChildWorkflowWithRetryPolicy() {
     String expectedName = "TestActivity";
     String expectedInput = "TestInput";
     String expectedInstanceId = "TestInstanceId";
@@ -305,6 +309,49 @@ public class DefaultWorkflowContextTest {
     assertEquals(retryPolicy.getMaxNumberOfAttempts(), taskOptions.getRetryPolicy().getMaxNumberOfAttempts());
     assertEquals(retryPolicy.getFirstRetryInterval(), taskOptions.getRetryPolicy().getFirstRetryInterval());
     assertEquals(Duration.ZERO, taskOptions.getRetryPolicy().getRetryTimeout());
+    assertNull(taskOptions.getRetryHandler());
+  }
+
+  @Test
+  public void callChildWorkflowWithRetryHandler() {
+    String expectedName = "TestActivity";
+    String expectedInput = "TestInput";
+    String expectedInstanceId = "TestInstanceId";
+
+    WorkflowTaskRetryHandler retryHandler = spy(new WorkflowTaskRetryHandler() {
+      @Override
+      public boolean handle(WorkflowTaskRetryContext retryContext) {
+        return true;
+      }
+    });
+
+    WorkflowTaskOptions executionOptions = new WorkflowTaskOptions(retryHandler);
+    ArgumentCaptor<TaskOptions> captor = ArgumentCaptor.forClass(TaskOptions.class);
+
+    context.callChildWorkflow(expectedName, expectedInput, expectedInstanceId, executionOptions, String.class);
+
+    verify(mockInnerContext, times(1))
+            .callSubOrchestrator(
+                    eq(expectedName),
+                    eq(expectedInput),
+                    eq(expectedInstanceId),
+                    captor.capture(),
+                    eq(String.class)
+            );
+
+    TaskOptions taskOptions = captor.getValue();
+
+    RetryHandler durableRetryHandler = taskOptions.getRetryHandler();
+    RetryContext retryContext = mock(RetryContext.class);
+
+    when(retryContext.getLastFailure()).thenReturn(mock(FailureDetails.class, invocationOnMock -> null));
+    when(retryContext.getLastAttemptNumber()).thenReturn(0);
+    when(retryContext.getOrchestrationContext()).thenReturn(null);
+    when(retryContext.getTotalRetryTime()).thenReturn(null);
+
+    durableRetryHandler.handle(retryContext);
+
+    verify(retryHandler, times(1)).handle(any());
   }
 
   @Test


### PR DESCRIPTION
# Description

This PR allows users to use the RetryHandler class from DurableTask for retrying tasks. RetryHandler allows for a lot more customization than the RetryPolicy class does

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1406 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

This PR is dependent upon this durabletask pr https://github.com/dapr/durabletask-java/pull/25
