### PR TITLE
Pull out createTimer logic

### DIFF
--- a/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/WorkflowContext.java
@@ -347,10 +347,7 @@ public interface WorkflowContext {
    * @param zonedDateTime timestamp with specific zone when the timer should expire
    * @return a new {@code Task} that completes after the specified delay
    */
-  default Task<Void> createTimer(ZonedDateTime zonedDateTime) {
-    throw new UnsupportedOperationException("This method is not implemented.");
-  }
-
+  Task<Void> createTimer(ZonedDateTime zonedDateTime);
 
   /**
    * Gets the deserialized input of the current task orchestration.

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DefaultWorkflowContext.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -184,6 +185,11 @@ public class DefaultWorkflowContext implements WorkflowContext {
    */
   public Task<Void> createTimer(Duration duration) {
     return this.innerContext.createTimer(duration);
+  }
+
+  @Override
+  public Task<Void> createTimer(ZonedDateTime zonedDateTime) {
+    return this.innerContext.createTimer(zonedDateTime);
   }
 
   /**

--- a/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/DefaultWorkflowContextTest.java
@@ -35,14 +35,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 public class DefaultWorkflowContextTest {
   private DefaultWorkflowContext context;
@@ -117,6 +113,11 @@ public class DefaultWorkflowContextTest {
 
       @Override
       public Task<Void> createTimer(Duration duration) {
+        return null;
+      }
+
+      @Override
+      public Task<Void> createTimer(ZonedDateTime zonedDateTime) {
         return null;
       }
 
@@ -265,8 +266,10 @@ public class DefaultWorkflowContextTest {
   }
 
   @Test
-  public void createTimerWithZonedDateTimeThrowsTest() {
-    assertThrows(UnsupportedOperationException.class, () -> context.createTimer(ZonedDateTime.now()));
+  public void createTimerWithZonedDateTimeTest() {
+    ZonedDateTime now = ZonedDateTime.now();
+    context.createTimer(now);
+    verify(mockInnerContext, times(1)).createTimer(now);
   }
 
   @Test


### PR DESCRIPTION
[Pull out logic from this PR to add it to the release quicker](https://github.com/dapr/java-sdk/pull/1413). Examples should still be added in the original PR, but the logic should be rebased since it will go thru in this PR