### PR TITLE
[1.14] grpc inbound msg

### DIFF
--- a/sdk/src/main/java/io/dapr/config/Properties.java
+++ b/sdk/src/main/java/io/dapr/config/Properties.java
@@ -175,6 +175,24 @@ public class Properties {
           "DAPR_HTTP_CLIENT_MAX_IDLE_CONNECTIONS",
           DEFAULT_HTTP_CLIENT_MAX_IDLE_CONNECTIONS);
 
+
+
+  /**
+   * Dapr's default maximum inbound message size for GRPC in bytes.
+   */
+  public static final Property<Integer> GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES = new IntegerProperty(
+      "dapr.grpc.max.inbound.message.size.bytes",
+      "DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES",
+      4194304);
+
+  /**
+   * Dapr's default maximum inbound metadata size for GRPC in bytes.
+   */
+  public static final Property<Integer> GRPC_MAX_INBOUND_METADATA_SIZE_BYTES = new IntegerProperty(
+        "dapr.grpc.max.inbound.metadata.size.bytes",
+        "DAPR_GRPC_MAX_INBOUND_METADATA_SIZE_BYTES",
+        8192);
+    
   /**
    * Mechanism to override properties set in a static context.
    */

--- a/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2025 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package io.dapr.utils;
 
 import io.dapr.config.Properties;
@@ -145,5 +158,28 @@ public class NetworkUtilsTest {
     } catch (IllegalArgumentException e) {
       // Expected
     }
+  }
+
+  @Test
+  public void testMaxDefaultInboundSize() throws Exception {
+    Properties properties = new Properties();
+
+    NetworkUtils.GrpcEndpointSettings settings = NetworkUtils.GrpcEndpointSettings.parse(properties);
+    Assertions.assertEquals(4194304, settings.maxInboundMessageSize);
+    Assertions.assertEquals(8192, settings.maxInboundMetadataSize);
+
+  }
+
+  @Test
+  public void testMaxInboundSize() throws Exception {
+    Properties properties = new Properties(Map.of(
+        Properties.GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES.getName(), "123456789",
+        Properties.GRPC_MAX_INBOUND_METADATA_SIZE_BYTES.getName(), "123456"
+    ));
+
+    NetworkUtils.GrpcEndpointSettings settings = NetworkUtils.GrpcEndpointSettings.parse(properties);
+    Assertions.assertEquals(123456789, settings.maxInboundMessageSize);
+    Assertions.assertEquals(123456, settings.maxInboundMetadataSize);
+
   }
 }


### PR DESCRIPTION
[cherrypick this PR](https://github.com/dapr/java-sdk/pull/1411) but only the inbound msg bits and leave out the rest