### PR TITLE
[1.14] Fix release pipeline: Migrate to Central Publisher Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <testcontainers.version>1.20.0</testcontainers.version>
     <springboot.version>3.4.3</springboot.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
   </properties>
 
   <distributionManagement>
@@ -56,7 +56,7 @@
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
     </repository>
     <site>
       <id>localDocsDirectory</id>
@@ -163,24 +163,20 @@
           <version>${maven-resources-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
           <extensions>true</extensions>
           <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <publishingServerId>central</publishingServerId>
+            <autoPublish>true</autoPublish>
+            <waitUntil>published</waitUntil>
           </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <inherited>false</inherited>
-      </plugin>
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,9 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
+      <id>central</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
-    </repository>
     <site>
       <id>localDocsDirectory</id>
       <url>file:${maven.multiModuleProjectDirectory}/docs/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -52,17 +52,16 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
+    </repository>
     <site>
       <id>localDocsDirectory</id>
       <url>file:${maven.multiModuleProjectDirectory}/docs/</url>
     </site>
-    <!-- Use default repository -->
-    <!-- <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository> -->
   </distributionManagement>
 
   <dependencyManagement>
@@ -170,7 +169,7 @@
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
             <autoReleaseAfterClose>true</autoReleaseAfterClose>
           </configuration>
         </plugin>

--- a/settings.xml
+++ b/settings.xml
@@ -1,5 +1,5 @@
 <!-- 
-OSSRH_USER_TOKEN and OSSRH-PWD_TOKEN: The username and password tokens for your OSSRH account
+OSSRH_USER_TOKEN and OSSRH_PWD_TOKEN: The username and password tokens for your OSSRH account
 GPG_KEY: the name of the GPG key file to use for signing e.g. F784FAB8
 GPG_PWD: the password to access the GPG key
 -->

--- a/settings.xml
+++ b/settings.xml
@@ -7,7 +7,7 @@ GPG_PWD: the password to access the GPG key
 <settings>
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.OSSRH_USER_TOKEN}</username>
       <password>${env.OSSRH_PWD_TOKEN}</password>
     </server>


### PR DESCRIPTION
Migrate from OSSRH to Central Publisher Portal

Fix release pipeline. Rn the publish step is [failing due to this error.](https://github.com/dapr/java-sdk/actions/runs/16599664210/job/46960091316)

We recently fixed the durabletask-java release pipeline [here with similar changes.](https://github.com/dapr/durabletask-java/pull/35)

These issues are due to the [OSSRH reaching its end of life on June 30, 2025](https://central.sonatype.org/pages/ossrh-eol/) and has been shut down causing CI failures and issues publishing releases.

Ive updated our maven config to use the new central publisher portal:
- [snapshots](https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-with-the-central-publishing-maven-plugin) go to: `https://central.sonatype.com/repository/maven-snapshots/`
- updated to use the [central-publishing-maven-plugin](https://central.sonatype.org/publish/publish-portal-maven/) with autopublish

