### PR TITLE
Trace propagation that depends on durabletask-java and durabletask-go

### DIFF
--- a/sdk-workflows/pom.xml
+++ b/sdk-workflows/pom.xml
@@ -47,7 +47,11 @@
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>durabletask-client</artifactId>
-      <version>1.5.6</version>
+      <version>1.5.8-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
     </dependency>
     <!--
     manually declare durabletask-client's jackson dependencies


### PR DESCRIPTION
# Description

Initial work to propagate the trace context on DaprWorkflowClient and surface TraceParentId on ActivityWorkflowContext.
This PR depends on these two other PRs: 
- https://github.com/dapr/durabletask-java/pull/39/ which depends on: 
  - https://github.com/dapr/durabletask-go/pull/39

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1478

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
