### PR TITLE
Unblock Snapshot

### DIFF
--- a/.github/scripts/update_sdk_version.sh
+++ b/.github/scripts/update_sdk_version.sh
@@ -26,6 +26,7 @@ mvn versions:set -DnewVersion=$DAPR_JAVA_SDK_ALPHA_VERSION -f testcontainers-dap
 
 # dapr-spring
 mvn versions:set -DnewVersion=$DAPR_JAVA_SDK_ALPHA_VERSION -DprocessDependencies=true -f dapr-spring/pom.xml
+mvn versions:set-property -Dproperty=dapr.spring.version -DnewVersion=$DAPR_JAVA_SDK_ALPHA_VERSION -f dapr-spring/pom.xml
 
 # spring-boot-examples
 mvn versions:set -DnewVersion=$DAPR_JAVA_SDK_ALPHA_VERSION -f spring-boot-examples/pom.xml

--- a/dapr-spring/pom.xml
+++ b/dapr-spring/pom.xml
@@ -33,7 +33,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <testcontainers.version>1.19.8</testcontainers.version>
     <junit.version>5.11.2</junit.version>
-    <dapr.spring.version>0.16.0-SNAPSHOT</dapr.spring.version>
+    <!-- WARNING: don't change this property unless you also update .github/scripts/update_sdk_version.sh -->
+    <dapr.spring.version>0.17.0-SNAPSHOT</dapr.spring.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Fix release script dependency version updates. The `-DprocessDependencies=true` flag does not appear to update the `dapr.spring.version` property, causing CI build failures. Added explicit property update to ensure all versions are synced.


[See failing CI run here](https://github.com/dapr/java-sdk/actions/runs/17043842860/job/48314269635)