### PR TITLE
Use xolstice protobuf Maven plugin

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -154,35 +154,21 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.11.4</version>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <protoSourceRoot>${protobuf.input.directory}</protoSourceRoot>
+        </configuration>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
-              <goal>run</goal>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
             </goals>
-            <configuration>
-              <protocVersion>${protobuf.version}</protocVersion>
-              <addProtoSources>inputs</addProtoSources>
-              <includeMavenTypes>direct</includeMavenTypes>
-              <includeStdTypes>true</includeStdTypes>
-              <inputDirectories>
-                <include>${protobuf.input.directory}</include>
-              </inputDirectories>
-              <outputTargets>
-                <outputTarget>
-                  <type>java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                </outputTarget>
-                <outputTarget>
-                  <type>grpc-java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</pluginArtifact>
-                </outputTarget>
-              </outputTargets>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.69.0</grpc.version>
     <protobuf.version>3.25.5</protobuf.version>
-    <protocCommand>java-sdk-protoc</protocCommand>
     <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.16.0-rc.5/dapr/proto</dapr.proto.baseurl>
     <dapr.sdk.version>1.17.0-SNAPSHOT</dapr.sdk.version>
     <dapr.sdk.alpha.version>0.17.0-SNAPSHOT</dapr.sdk.alpha.version>
@@ -376,6 +375,14 @@
   </dependencyManagement>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.1</version>
+      </extension>
+    </extensions>
+
     <pluginManagement>
       <plugins>
         <plugin>

--- a/sdk-autogen/pom.xml
+++ b/sdk-autogen/pom.xml
@@ -22,7 +22,6 @@
     <protobuf.input.directory>${project.build.directory}/proto</protobuf.input.directory>
     <maven.deploy.skip>false</maven.deploy.skip>
     <grpc.version>1.69.0</grpc.version>
-    <protocCommand>java-sdk-protoc</protocCommand>
     <protobuf.version>3.25.5</protobuf.version>
   </properties>
 
@@ -110,52 +109,21 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <protoSourceRoot>${protobuf.input.directory}</protoSourceRoot>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>detect</goal>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.11.4</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <protocCommand>java-sdk-protoc</protocCommand>
-              <protocVersion>${protobuf.version}</protocVersion>
-              <protocArtifact>com.google.protobuf:protoc:3.25.5</protocArtifact>
-              <addProtoSources>inputs</addProtoSources>
-              <includeMavenTypes>direct</includeMavenTypes>
-              <includeStdTypes>true</includeStdTypes>
-              <inputDirectories>
-                <include>${protobuf.input.directory}</include>
-              </inputDirectories>
-              <includeDirectories>
-                <include>${protobuf.input.directory}</include>
-              </includeDirectories>
-              <outputTargets>
-                <outputTarget>
-                  <type>java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                </outputTarget>
-                <outputTarget>
-                  <type>grpc-java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</pluginArtifact>
-                </outputTarget>
-              </outputTargets>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -267,35 +267,21 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.11.4</version>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <protoSourceRoot>${protobuf.input.directory}</protoSourceRoot>
+        </configuration>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
-              <goal>run</goal>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
             </goals>
-            <configuration>
-              <protocVersion>${protobuf.version}</protocVersion>
-              <addProtoSources>inputs</addProtoSources>
-              <includeMavenTypes>direct</includeMavenTypes>
-              <includeStdTypes>true</includeStdTypes>
-              <inputDirectories>
-                <include>${protobuf.input.directory}</include>
-              </inputDirectories>
-              <outputTargets>
-                <outputTarget>
-                  <type>java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                </outputTarget>
-                <outputTarget>
-                  <type>grpc-java</type>
-                  <outputDirectory>${protobuf.output.directory}</outputDirectory>
-                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</pluginArtifact>
-                </outputTarget>
-              </outputTargets>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
# Description

This PRs improves the Protobug codegen by using org.xolstice Maven plugin. It properly detects OS and uses the right protoc binary that doesn't conflict with host binary. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1535 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
