### PR TITLE
Replace openjdk:17-jdk-slim to eclipse-temurin:17-jdk-jammy

### DIFF
--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
@@ -7,4 +7,5 @@ public interface ContainerConstants {
   String DAPR_PLACEMENT_IMAGE_TAG = DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
   String DAPR_SCHEDULER_IMAGE_TAG = DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
   String TOXI_PROXY_IMAGE_TAG = "ghcr.io/shopify/toxiproxy:2.5.0";
+  String JDK_17_TEMURIN_JAMMY = "eclipse-temurin:17-jdk-jammy";
 }

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCallActivityIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCallActivityIT.java
@@ -13,6 +13,7 @@
 
 package io.dapr.it.testcontainers.workflows.multiapp;
 
+import io.dapr.it.testcontainers.ContainerConstants;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
@@ -113,7 +114,7 @@ public class WorkflowsMultiAppCallActivityIT {
 
   // TestContainers for each app
   @Container
-  private static GenericContainer<?> multiappWorker = new GenericContainer<>("openjdk:17-jdk-slim")
+  private static GenericContainer<?> multiappWorker = new GenericContainer<>(ContainerConstants.JDK_17_TEMURIN_JAMMY)
       .withCopyFileToContainer(MountableFile.forHostPath("target"), "/app")
       .withWorkingDirectory("/app")
       .withCommand("java", "-cp", "test-classes:classes:dependency/*:*",
@@ -127,7 +128,7 @@ public class WorkflowsMultiAppCallActivityIT {
       .withLogConsumer(outputFrame -> System.out.println("MultiAppWorker: " + outputFrame.getUtf8String()));
 
   @Container
-  private final static GenericContainer<?> app2Worker = new GenericContainer<>("openjdk:17-jdk-slim")
+  private final static GenericContainer<?> app2Worker = new GenericContainer<>(ContainerConstants.JDK_17_TEMURIN_JAMMY)
       .withCopyFileToContainer(MountableFile.forHostPath("target"), "/app")
       .withWorkingDirectory("/app")
       .withCommand("java", "-cp", "test-classes:classes:dependency/*:*",
@@ -141,7 +142,7 @@ public class WorkflowsMultiAppCallActivityIT {
       .withLogConsumer(outputFrame -> System.out.println("App2Worker: " + outputFrame.getUtf8String()));
 
   @Container
-  private final static GenericContainer<?> app3Worker = new GenericContainer<>("openjdk:17-jdk-slim")
+  private final static GenericContainer<?> app3Worker = new GenericContainer<>(ContainerConstants.JDK_17_TEMURIN_JAMMY)
       .withCopyFileToContainer(MountableFile.forHostPath("target"), "/app")
       .withWorkingDirectory("/app")
       .withCommand("java", "-cp", "test-classes:classes:dependency/*:*",

--- a/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
@@ -123,7 +123,7 @@ public class DaprTestContainersConfig {
                                                 @Qualifier("workerOneDapr") DaprContainer workerOneDapr,
                                                 DaprPlacementContainer daprPlacementContainer,
                                                 DaprSchedulerContainer daprSchedulerContainer){
-    return new GenericContainer<>("openjdk:17-jdk-slim")
+    return new GenericContainer<>(DockerImages.JDK_17_TEMURIN_JAMMY)
             .withCopyFileToContainer(MountableFile.forHostPath("../worker-one/target"), "/app")
             .withWorkingDirectory("/app")
             .withCommand("java",
@@ -165,7 +165,7 @@ public class DaprTestContainersConfig {
                                                 @Qualifier("workerTwoDapr") DaprContainer workerTwoDapr,
                                                 DaprPlacementContainer daprPlacementContainer,
                                                 DaprSchedulerContainer daprSchedulerContainer){
-    return new GenericContainer<>("openjdk:17-jdk-slim")
+    return new GenericContainer<>(DockerImages.JDK_17_TEMURIN_JAMMY)
             .withCopyFileToContainer(MountableFile.forHostPath("../worker-two/target"), "/app")
             .withWorkingDirectory("/app")
             .withCommand("java",

--- a/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DockerImages.java
+++ b/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DockerImages.java
@@ -1,0 +1,6 @@
+package io.dapr.springboot.examples.orchestrator;
+
+public interface DockerImages {
+
+  String JDK_17_TEMURIN_JAMMY = "eclipse-temurin:17-jdk-jammy";
+}


### PR DESCRIPTION
# Description

Due to deprecation of openjdk images.

> This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):

See [here](https://hub.docker.com/_/openjdk).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1573 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
