### PR TITLE
Add gRPC support to Dapr testcontainer

### DIFF
--- a/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
+++ b/testcontainers-dapr/src/main/java/io/dapr/testcontainers/DaprContainer.java
@@ -75,7 +75,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
   private DaprSchedulerContainer schedulerContainer;
   private String appName;
   private Integer appPort;
-  private DaprProtocol appProtocol;
+  private DaprProtocol appProtocol = DaprProtocol.HTTP; // default from docs
   private String appHealthCheckPath;
   private Integer appHealthCheckProbeInterval = 5; //default from docs
   private Integer appHealthCheckProbeTimeout = 500; //default from docs

--- a/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprContainerTest.java
+++ b/testcontainers-dapr/src/test/java/io/dapr/testcontainers/DaprContainerTest.java
@@ -6,7 +6,6 @@ import org.testcontainers.utility.DockerImageName;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DaprContainerTest {
 
@@ -81,22 +80,18 @@ public class DaprContainerTest {
   }
 
   @Test
-  public void appPortProtocolDefaultsTest() {
+  public void appProtocolDefaultsTest() {
     try (DaprContainer daprContainer = new DaprContainer(DAPR_RUNTIME_IMAGE_TAG)
             .withAppName("dapr-app")) {
       daprContainer.configure();
-      assertNull(daprContainer.getAppPort());
-      assertNull(daprContainer.getAppProtocol());
+      assertEquals(DaprProtocol.HTTP, daprContainer.getAppProtocol());
     }
 
-    Integer port = 50003;
     DaprProtocol protocol = DaprProtocol.GRPC;
     try (DaprContainer daprContainer = new DaprContainer(DAPR_RUNTIME_IMAGE_TAG)
             .withAppName("dapr-app4")
-            .withAppPort(port)
             .withAppProtocol(protocol)) {
       daprContainer.configure();
-      assertEquals(port, daprContainer.getAppPort());
       assertEquals(protocol, daprContainer.getAppProtocol());
     }
 


### PR DESCRIPTION
# Description

Added a simple `withAppProtocol` method to the DaprContainer test container which allows the user to specify `--app-protocol` either `HTTP` or `GRPC`, allowing projects to exercise gRPC services from integration tests.

## Issue reference

This will close #1578 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

Let me know if there's documentation that should be updated, I can add that.

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
