### PR TITLE
Bring DurableTask Client to the same Maven standards.

### DIFF
--- a/durabletask-client/pom.xml
+++ b/durabletask-client/pom.xml
@@ -7,11 +7,16 @@
     <groupId>io.dapr</groupId>
     <artifactId>dapr-sdk-parent</artifactId>
     <version>1.17.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>durabletask-client</artifactId>
+  <packaging>jar</packaging>
+  <name>durabletask-client</name>
+  <description>Durable Task Client for Dapr Workflows</description>
 
   <properties>
+    <maven.deploy.skip>false</maven.deploy.skip>
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.build.directory}/proto</protobuf.input.directory>
   </properties>
@@ -67,6 +72,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -85,7 +91,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>${download-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>getDaprProto</id>
@@ -105,7 +111,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>${protobuf-maven-plugin.version}</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
@@ -124,7 +130,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -137,7 +142,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
         <configuration>
           <notimestamp>true</notimestamp>
         </configuration>


### PR DESCRIPTION
# Description

Bring DurableTask Client to the same Maven standards. The purpose of this PR is to ensure that DurableTask Client is using the same Maven standards as other modules and we don't have surprises when releasing to Maven Central.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
