### PR TITLE
Add PATCH constant to HttpExtension

### DIFF
--- a/sdk/src/main/java/io/dapr/client/domain/HttpExtension.java
+++ b/sdk/src/main/java/io/dapr/client/domain/HttpExtension.java
@@ -48,6 +48,10 @@ public final class HttpExtension {
    */
   public static final HttpExtension DELETE = new HttpExtension(DaprHttp.HttpMethods.DELETE);
   /**
+   * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#PATCH} Verb with empty queryString.
+   */
+  public static final HttpExtension PATCH = new HttpExtension(DaprHttp.HttpMethods.PATCH);
+  /**
    * Convenience HttpExtension object for the {@link DaprHttp.HttpMethods#HEAD} Verb with empty queryString.
    */
   public static final HttpExtension HEAD = new HttpExtension(DaprHttp.HttpMethods.HEAD);

--- a/sdk/src/test/java/io/dapr/client/domain/HttpExtensionTest.java
+++ b/sdk/src/test/java/io/dapr/client/domain/HttpExtensionTest.java
@@ -57,4 +57,12 @@ class HttpExtensionTest {
     Assertions.assertEquals("user+name=John+Do%C3%AB+%26+Co.", encoded);
   }
 
+  @Test
+  @DisplayName("PATCH constant should use PATCH HTTP method")
+  void patchConstantShouldUsePatchHttpMethod() {
+    Assertions.assertEquals(DaprHttp.HttpMethods.PATCH, HttpExtension.PATCH.getMethod());
+    Assertions.assertTrue(HttpExtension.PATCH.getQueryParams().isEmpty());
+    Assertions.assertTrue(HttpExtension.PATCH.getHeaders().isEmpty());
+  }
+
 }


### PR DESCRIPTION
## Summary
- Adds a `PATCH` convenience constant to `HttpExtension`, matching the existing pattern for GET, PUT, POST, DELETE, etc.
- Adds a test verifying the PATCH constant uses the correct HTTP method with empty query params and headers.

## Test plan
- [ ] Verify `HttpExtensionTest.patchConstantShouldUsePatchHttpMethod` passes
