### PR TITLE
[1.17] [Cherrypick] Renaming streaming subscription to "subscribeToTopic" (#1626)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,0 @@
-[tools]
-java = "temurin-17"
-
-[env]
-JAVA_HOME = "{{exec(command='mise where java')}}"

--- a/examples/src/main/java/io/dapr/examples/pubsub/stream/README.md
+++ b/examples/src/main/java/io/dapr/examples/pubsub/stream/README.md
@@ -56,8 +56,8 @@ public class Subscriber {
 
   public static void main(String[] args) throws Exception {
     try (var client = new DaprClientBuilder().buildPreviewClient()) {
-      // Subscribe to events - receives raw String data directly
-      client.subscribeToEvents(PUBSUB_NAME, topicName, TypeRef.STRING)
+      // Subscribe to topic - receives raw String data directly
+      client.subscribeToTopic(PUBSUB_NAME, topicName, TypeRef.STRING)
           .doOnNext(message -> {
             System.out.println("Subscriber got: " + message);
           })
@@ -79,8 +79,8 @@ public class SubscriberCloudEvent {
 
   public static void main(String[] args) throws Exception {
     try (var client = new DaprClientBuilder().buildPreviewClient()) {
-      // Subscribe to events - receives CloudEvent<String> with full metadata
-      client.subscribeToEvents(PUBSUB_NAME, topicName, new TypeRef<CloudEvent<String>>() {})
+      // Subscribe to topic - receives CloudEvent<String> with full metadata
+      client.subscribeToTopic(PUBSUB_NAME, topicName, new TypeRef<CloudEvent<String>>() {})
           .doOnNext(cloudEvent -> {
             System.out.println("Received CloudEvent:");
             System.out.println("  ID: " + cloudEvent.getId());
@@ -101,7 +101,7 @@ public class SubscriberCloudEvent {
 You can also pass metadata to the subscription, for example to enable raw payload mode:
 
 ```java
-client.subscribeToEvents(PUBSUB_NAME, topicName, TypeRef.STRING, Map.of("rawPayload", "true"))
+client.subscribeToTopic(PUBSUB_NAME, topicName, TypeRef.STRING, Map.of("rawPayload", "true"))
     .doOnNext(message -> {
       System.out.println("Subscriber got: " + message);
     })

--- a/examples/src/main/java/io/dapr/examples/pubsub/stream/Subscriber.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/stream/Subscriber.java
@@ -47,8 +47,8 @@ public class Subscriber {
     try (var client = new DaprClientBuilder().buildPreviewClient()) {
       System.out.println("Subscribing to topic: " + topicName);
 
-      // Subscribe to events - receives raw String data directly
-      client.subscribeToEvents(PUBSUB_NAME, topicName, TypeRef.STRING)
+      // Subscribe to topic - receives raw String data directly
+      client.subscribeToTopic(PUBSUB_NAME, topicName, TypeRef.STRING)
           .doOnNext(message -> {
             System.out.println("Subscriber got: " + message);
           })

--- a/examples/src/main/java/io/dapr/examples/pubsub/stream/SubscriberCloudEvent.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/stream/SubscriberCloudEvent.java
@@ -50,9 +50,9 @@ public class SubscriberCloudEvent {
     try (var client = new DaprClientBuilder().buildPreviewClient()) {
       System.out.println("Subscribing to topic: " + topicName + " (CloudEvent mode)");
 
-      // Subscribe to events - receives CloudEvent<String> with full metadata
+      // Subscribe to topic - receives CloudEvent<String> with full metadata
       // Use TypeRef<CloudEvent<String>> to get CloudEvent wrapper with metadata
-      client.subscribeToEvents(PUBSUB_NAME, topicName, new TypeRef<CloudEvent<String>>() {})
+      client.subscribeToTopic(PUBSUB_NAME, topicName, new TypeRef<CloudEvent<String>>() {})
           .doOnNext(cloudEvent -> {
             System.out.println("Received CloudEvent:");
             System.out.println("  ID: " + cloudEvent.getId());

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-17"

--- a/sdk-tests/src/test/java/io/dapr/it/pubsub/stream/PubSubStreamIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/pubsub/stream/PubSubStreamIT.java
@@ -151,8 +151,8 @@ public class PubSubStreamIT extends BaseIT {
 
       Set<String> messages = Collections.synchronizedSet(new HashSet<>());
 
-      // subscribeToEvents now returns Flux<T> directly (raw data)
-      var disposable = previewClient.subscribeToEvents(PUBSUB_NAME, TOPIC_NAME_FLUX, TypeRef.STRING)
+      // subscribeToTopic returns Flux<T> directly (raw data)
+      var disposable = previewClient.subscribeToTopic(PUBSUB_NAME, TOPIC_NAME_FLUX, TypeRef.STRING)
           .doOnNext(rawMessage -> {
             // rawMessage is String directly
             if (rawMessage.contains(runId)) {
@@ -196,7 +196,7 @@ public class PubSubStreamIT extends BaseIT {
       Set<String> messageIds = Collections.synchronizedSet(new HashSet<>());
 
       // Use TypeRef<CloudEvent<String>> to receive full CloudEvent with metadata
-      var disposable = previewClient.subscribeToEvents(PUBSUB_NAME, TOPIC_NAME_CLOUDEVENT, new TypeRef<CloudEvent<String>>(){})
+      var disposable = previewClient.subscribeToTopic(PUBSUB_NAME, TOPIC_NAME_CLOUDEVENT, new TypeRef<CloudEvent<String>>(){})
           .doOnNext(cloudEvent -> {
             if (cloudEvent.getData() != null && cloudEvent.getData().contains(runId)) {
               messageIds.add(cloudEvent.getId());
@@ -241,8 +241,8 @@ public class PubSubStreamIT extends BaseIT {
       Set<String> messages = Collections.synchronizedSet(new HashSet<>());
       Map<String, String> metadata = Map.of("rawPayload", "true");
 
-      // Use subscribeToEvents with rawPayload metadata
-      var disposable = previewClient.subscribeToEvents(PUBSUB_NAME, TOPIC_NAME_RAWPAYLOAD, TypeRef.STRING, metadata)
+      // Use subscribeToTopic with rawPayload metadata
+      var disposable = previewClient.subscribeToTopic(PUBSUB_NAME, TOPIC_NAME_RAWPAYLOAD, TypeRef.STRING, metadata)
           .doOnNext(rawMessage -> {
             if (rawMessage.contains(runId)) {
               messages.add(rawMessage);

--- a/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
@@ -504,16 +504,34 @@ public class DaprClientImpl extends AbstractDaprClient {
   /**
    * {@inheritDoc}
    */
+  @Deprecated
   @Override
   public <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type) {
-    return subscribeToEvents(pubsubName, topic, type, null);
+    return subscribeToTopic(pubsubName, topic, type);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Deprecated
+  @Override
+  public <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata) {
+    return subscribeToTopic(pubsubName, topic, type, metadata);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata) {
+  public <T> Flux<T> subscribeToTopic(String pubsubName, String topic, TypeRef<T> type) {
+    return subscribeToTopic(pubsubName, topic, type, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Flux<T> subscribeToTopic(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata) {
     DaprPubsubProtos.SubscribeTopicEventsRequestInitialAlpha1.Builder initialRequestBuilder =
         DaprPubsubProtos.SubscribeTopicEventsRequestInitialAlpha1.newBuilder()
             .setTopic(topic)

--- a/sdk/src/main/java/io/dapr/client/DaprPreviewClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprPreviewClient.java
@@ -286,11 +286,38 @@ public interface DaprPreviewClient extends AutoCloseable {
    * @param type Type for object deserialization.
    * @param <T> Type of object deserialization.
    * @return An active subscription.
-   * @deprecated Use {@link #subscribeToEvents(String, String, TypeRef)} instead for a more reactive approach.
+   * @deprecated Use {@link #subscribeToTopic(String, String, TypeRef)} instead for a more reactive approach.
    */
   @Deprecated
   <T> Subscription subscribeToEvents(
       String pubsubName, String topic, SubscriptionListener<T> listener, TypeRef<T> type);
+
+  /**
+   * Subscribe to pubsub events via streaming using Project Reactor Flux.
+   *
+   * @param pubsubName Name of the pubsub component.
+   * @param topic Name of the topic to subscribe to.
+   * @param type Type for object deserialization.
+   * @param <T> Type of the event payload.
+   * @return A Flux of deserialized event payloads.
+   * @deprecated Use {@link #subscribeToTopic(String, String, TypeRef)} instead.
+   */
+  @Deprecated
+  <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type);
+
+  /**
+   * Subscribe to pubsub events via streaming using Project Reactor Flux with metadata support.
+   *
+   * @param pubsubName Name of the pubsub component.
+   * @param topic Name of the topic to subscribe to.
+   * @param type Type for object deserialization.
+   * @param metadata Subscription metadata (e.g., {"rawPayload": "true"}).
+   * @param <T> Type of the event payload.
+   * @return A Flux of deserialized event payloads.
+   * @deprecated Use {@link #subscribeToTopic(String, String, TypeRef, Map)} instead.
+   */
+  @Deprecated
+  <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata);
 
   /**
    * Subscribe to pubsub events via streaming using Project Reactor Flux.
@@ -307,12 +334,12 @@ public interface DaprPreviewClient extends AutoCloseable {
    * @return A Flux of deserialized event payloads.
    * @param <T> Type of the event payload.
    */
-  <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type);
+  <T> Flux<T> subscribeToTopic(String pubsubName, String topic, TypeRef<T> type);
 
   /**
    * Subscribe to pubsub events via streaming using Project Reactor Flux with metadata support.
    *
-   * <p>If metadata is null or empty, this method delegates to {@link #subscribeToEvents(String, String, TypeRef)}.
+   * <p>If metadata is null or empty, this method delegates to {@link #subscribeToTopic(String, String, TypeRef)}.
    * Use metadata {@code {"rawPayload": "true"}} for raw payload subscriptions where Dapr
    * delivers messages without CloudEvent wrapping.
    *
@@ -323,7 +350,7 @@ public interface DaprPreviewClient extends AutoCloseable {
    * @return A Flux of deserialized event payloads.
    * @param <T> Type of the event payload.
    */
-  <T> Flux<T> subscribeToEvents(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata);
+  <T> Flux<T> subscribeToTopic(String pubsubName, String topic, TypeRef<T> type, Map<String, String> metadata);
 
   /*
    * Converse with an LLM.

--- a/sdk/src/test/java/io/dapr/client/DaprPreviewClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprPreviewClientGrpcTest.java
@@ -663,8 +663,8 @@ public class DaprPreviewClientGrpcTest {
     final AtomicInteger eventCount = new AtomicInteger(0);
     final Semaphore gotAll = new Semaphore(0);
 
-    // subscribeToEvents now returns Flux<T> directly (raw data)
-    var disposable = previewClient.subscribeToEvents(pubsubName, topicName, TypeRef.STRING)
+    // subscribeToTopic returns Flux<T> directly (raw data)
+    var disposable = previewClient.subscribeToTopic(pubsubName, topicName, TypeRef.STRING)
             .doOnNext(rawData -> {
               // rawData is String directly, not CloudEvent
               assertEquals(data, rawData);
@@ -751,7 +751,180 @@ public class DaprPreviewClientGrpcTest {
     final Semaphore gotAll = new Semaphore(0);
     Map<String, String> metadata = Map.of("rawPayload", "true");
 
-    // Use subscribeToEvents with rawPayload metadata
+    // Use subscribeToTopic with rawPayload metadata
+    var disposable = previewClient.subscribeToTopic(pubsubName, topicName, TypeRef.STRING, metadata)
+            .doOnNext(rawData -> {
+              assertEquals(data, rawData);
+              assertTrue(rawData instanceof String);
+
+              int count = eventCount.incrementAndGet();
+
+              if (count >= numEvents) {
+                gotAll.release();
+              }
+            })
+            .subscribe();
+
+    gotAll.acquire();
+    disposable.dispose();
+
+    assertEquals(numEvents, eventCount.get());
+
+    // Verify metadata was passed to gRPC request
+    assertNotNull(capturedMetadata.get());
+    assertEquals("true", capturedMetadata.get().get("rawPayload"));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void deprecatedSubscribeToEventsFluxTest() throws Exception {
+    var numEvents = 10;
+    var pubsubName = "pubsubName";
+    var topicName = "topicName";
+    var data = "my message";
+    var started = new Semaphore(0);
+
+    doAnswer((Answer<StreamObserver<DaprPubsubProtos.SubscribeTopicEventsRequestAlpha1>>) invocation -> {
+      StreamObserver<DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1> observer =
+          (StreamObserver<DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1>) invocation.getArguments()[0];
+
+      var emitterThread = new Thread(() -> {
+        try {
+          started.acquire();
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+
+        observer.onNext(DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1.getDefaultInstance());
+
+        for (int i = 0; i < numEvents; i++) {
+          DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1 response =
+              DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1.newBuilder()
+                  .setEventMessage(DaprAppCallbackProtos.TopicEventRequest.newBuilder()
+                      .setId(Integer.toString(i))
+                      .setPubsubName(pubsubName)
+                      .setTopic(topicName)
+                      .setData(ByteString.copyFromUtf8("\"" + data + "\""))
+                      .setDataContentType("application/json")
+                      .build())
+                  .build();
+          observer.onNext(response);
+        }
+
+        observer.onCompleted();
+      });
+
+      emitterThread.start();
+
+      return new StreamObserver<>() {
+        @Override
+        public void onNext(DaprPubsubProtos.SubscribeTopicEventsRequestAlpha1 subscribeTopicEventsRequestAlpha1) {
+          started.release();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+          // No-op
+        }
+
+        @Override
+        public void onCompleted() {
+          // No-op
+        }
+      };
+    }).when(daprStub).subscribeTopicEventsAlpha1(any(StreamObserver.class));
+
+    final AtomicInteger eventCount = new AtomicInteger(0);
+    final Semaphore gotAll = new Semaphore(0);
+
+    // Test deprecated subscribeToEvents method (delegates to subscribeToTopic)
+    var disposable = previewClient.subscribeToEvents(pubsubName, topicName, TypeRef.STRING)
+            .doOnNext(rawData -> {
+              assertEquals(data, rawData);
+              assertTrue(rawData instanceof String);
+
+              int count = eventCount.incrementAndGet();
+
+              if (count >= numEvents) {
+                gotAll.release();
+              }
+            })
+            .subscribe();
+
+    gotAll.acquire();
+    disposable.dispose();
+
+    assertEquals(numEvents, eventCount.get());
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void deprecatedSubscribeToEventsWithMetadataTest() throws Exception {
+    var numEvents = 10;
+    var pubsubName = "pubsubName";
+    var topicName = "topicName";
+    var data = "my message";
+    var started = new Semaphore(0);
+    var capturedMetadata = new AtomicReference<java.util.Map<String, String>>();
+
+    doAnswer((Answer<StreamObserver<DaprPubsubProtos.SubscribeTopicEventsRequestAlpha1>>) invocation -> {
+      StreamObserver<DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1> observer =
+          (StreamObserver<DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1>) invocation.getArguments()[0];
+
+      var emitterThread = new Thread(() -> {
+        try {
+          started.acquire();
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+
+        observer.onNext(DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1.getDefaultInstance());
+
+        for (int i = 0; i < numEvents; i++) {
+          DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1 response =
+              DaprPubsubProtos.SubscribeTopicEventsResponseAlpha1.newBuilder()
+                  .setEventMessage(DaprAppCallbackProtos.TopicEventRequest.newBuilder()
+                      .setId(Integer.toString(i))
+                      .setPubsubName(pubsubName)
+                      .setTopic(topicName)
+                      .setData(ByteString.copyFromUtf8("\"" + data + "\""))
+                      .setDataContentType("application/json")
+                      .build())
+                  .build();
+          observer.onNext(response);
+        }
+
+        observer.onCompleted();
+      });
+
+      emitterThread.start();
+
+      return new StreamObserver<>() {
+        @Override
+        public void onNext(DaprPubsubProtos.SubscribeTopicEventsRequestAlpha1 request) {
+          if (request.hasInitialRequest()) {
+            capturedMetadata.set(request.getInitialRequest().getMetadataMap());
+          }
+          started.release();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+          // No-op
+        }
+
+        @Override
+        public void onCompleted() {
+          // No-op
+        }
+      };
+    }).when(daprStub).subscribeTopicEventsAlpha1(any(StreamObserver.class));
+
+    final AtomicInteger eventCount = new AtomicInteger(0);
+    final Semaphore gotAll = new Semaphore(0);
+    Map<String, String> metadata = Map.of("rawPayload", "true");
+
+    // Test deprecated subscribeToEvents method with metadata (delegates to subscribeToTopic)
     var disposable = previewClient.subscribeToEvents(pubsubName, topicName, TypeRef.STRING, metadata)
             .doOnNext(rawData -> {
               assertEquals(data, rawData);


### PR DESCRIPTION
* Renaming streaming subscription to "subscribeToTopic".



* Bring back subscribeToEvents for backward compatibility.



* Fix rebase conflicts



* Add tests for deprecated events methods.



---------

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
