### PR TITLE
docs: fix broken links

### DIFF
--- a/spring-boot-4-examples/workflows/multi-app/README.md
+++ b/spring-boot-4-examples/workflows/multi-app/README.md
@@ -40,7 +40,7 @@ You can create new workflow instances of the `CustomerWorkflow` by calling the `
 curl -X POST localhost:8080/customers -H 'Content-Type: application/json' -d '{ "customerName": "salaboy" }'
 ```
 
-The workflow definition [`CustomerWorkflow`](orchstrator/src/main/java/io/dapr/springboot/examples/orchestrator/CustomerWorkflow.java) that you can find inside the `orchestrator` app, 
+The workflow definition [`CustomerWorkflow`](orchestrator/src/main/java/io/dapr/springboot4/examples/orchestrator/CustomerWorkflow.java) that you can find inside the `orchestrator` app, 
 performs the following orchestration when a new workflow instance is created:
 
 - Call the `RegisterCustomerActivity` activity which can be found inside the `worker-one` application.  
@@ -83,9 +83,9 @@ performs the following orchestration when a new workflow instance is created:
 Testing becomes a complex task when you are dealing with multiple Spring Boot applications. For testing this workflow, 
 we rely on [Testcontainers](https://testcontainers.com) to create the entire setup which enable us to run the workflow end to end.
 
-You can find the end-to-end test in the [`OrchestratorAppIT.java`](orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/OrchestratorAppIT.java) class inside the `orchestrator` application. 
+You can find the end-to-end test in the [`OrchestratorAppIT.java`](orchestrator/src/test/java/io/dapr/springboot4/examples/orchestrator/OrchestratorAppIT.java) class inside the `orchestrator` application. 
 This test interact with the application REST endpoints to validate their correct execution. 
 
-But the magic behind the test can be located in the [`DaprTestContainersConfig.class`](orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java) which defines the configuration for 
+But the magic behind the test can be located in the [`DaprTestContainersConfig.class`](orchestrator/src/test/java/io/dapr/springboot4/examples/orchestrator/DaprTestContainersConfig.java) which defines the configuration for 
 all the Dapr containers and the `worker-one` and `worker-two` applications. Check this class to gain a deeper understand how to configure 
 multiple Dapr-enabled applications. 

--- a/spring-boot-4-examples/workflows/patterns/README.md
+++ b/spring-boot-4-examples/workflows/patterns/README.md
@@ -34,7 +34,7 @@ timeout_seconds: 180
 
 <!-- END_STEP -->
 
-By running the `spring-boot:test-run` goal, the application is loaded using the [test configurations](src/test/java/io/dapr/springboot/examples/wfp/DaprTestContainersConfig.java) 
+By running the `spring-boot:test-run` goal, the application is loaded using the [test configurations](src/test/java/io/dapr/springboot4/examples/wfp/DaprTestContainersConfig.java) 
 configured using [Testcontainers](https://testcontainers.com) to boostrap the [Dapr](https://dapr.io) sidecar and control plane.
 
 Once the application is running you can trigger the different patterns by sending the following requests: 
@@ -509,4 +509,4 @@ i.d.s.e.w.s.PerformTaskActivity          : Completing activity...
 ## Testing workflow executions
 
 Workflow execution can be tested using Testcontainers and you can find all the tests for the patterns covered in this 
-application [here](test/java/io/dapr/springboot/examples/wfp/TestWorkflowPatternsApplication.java).
+application [here](src/test/java/io/dapr/springboot4/examples/wfp/TestWorkflowPatternsApplication.java).

--- a/spring-boot-examples/workflows/multi-app/README.md
+++ b/spring-boot-examples/workflows/multi-app/README.md
@@ -40,7 +40,7 @@ You can create new workflow instances of the `CustomerWorkflow` by calling the `
 curl -X POST localhost:8080/customers -H 'Content-Type: application/json' -d '{ "customerName": "salaboy" }'
 ```
 
-The workflow definition [`CustomerWorkflow`](orchstrator/src/main/java/io/dapr/springboot/examples/orchestrator/CustomerWorkflow.java) that you can find inside the `orchestrator` app, 
+The workflow definition [`CustomerWorkflow`](orchestrator/src/main/java/io/dapr/springboot/examples/orchestrator/CustomerWorkflow.java) that you can find inside the `orchestrator` app, 
 performs the following orchestration when a new workflow instance is created:
 
 - Call the `RegisterCustomerActivity` activity which can be found inside the `worker-one` application.  

--- a/spring-boot-examples/workflows/patterns/README.md
+++ b/spring-boot-examples/workflows/patterns/README.md
@@ -509,4 +509,4 @@ i.d.s.e.w.s.PerformTaskActivity          : Completing activity...
 ## Testing workflow executions
 
 Workflow execution can be tested using Testcontainers and you can find all the tests for the patterns covered in this 
-application [here](test/java/io/dapr/springboot/examples/wfp/TestWorkflowPatternsApplication.java).
+application [here](src/test/java/io/dapr/springboot/examples/wfp/TestWorkflowPatternsApplication.java).


### PR DESCRIPTION
# Description
README.md files in [spring-boot-examples/](https://github.com/dapr/java-sdk/tree/master/spring-boot-examples) and [spring-boot-4-examples/](https://github.com/dapr/java-sdk/tree/master/spring-boot-4-examples) has broken links to files. Fixed url's for all the **README.md** files in these folders

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1551 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
