### PR TITLE
Fixing dependency to sb3 autoconfigure

### DIFF
--- a/dapr-spring/dapr-spring-boot-tests/pom.xml
+++ b/dapr-spring/dapr-spring-boot-tests/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
-      <artifactId>dapr-spring-boot-autoconfigure</artifactId>
+      <artifactId>dapr-spring-boot-properties</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
# Description

Old sb3 dependencies creeping up to SB4 artifacts. This removes the dependency from autoconfigure

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
