### PR TITLE
fix: pin netty version in sdk pom for consumer CVE resolution

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -129,6 +129,42 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
     </dependency>
+    <!-- TODO: Remove explicit netty overrides once a dapr-sdk-bom is published.
+         Parent pom dependencyManagement does not propagate to consumers, so
+         grpc-netty's transitive netty resolves to an older vulnerable version.
+         These entries ensure consumers get the patched netty version.
+         See CVE-2026-33870 (HTTP Request Smuggling). -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>${netty.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Parent pom dependencyManagement does not propagate to consumers. grpc-netty's transitive netty was resolving to 4.1.130 for anyone depending on dapr-sdk from Maven Central, leaving them exposed to CVE-2026-33870 (HTTP Request Smuggling).

Add explicit netty dependencies in sdk/pom.xml so the pinned version (4.1.132.Final) is published in the module pom and overrides the transitive versions for consumers.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
