### PR TITLE
feat: upgrade Testcontainers from 1.21.4 to 2.0.5 and migrate Junit4 to JUnit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ hs_err_pid*
 
 # macOS
 .DS_Store
+
+# Claude Code / OMC
+.omc/
+.omx/

--- a/dapr-spring/dapr-spring-boot-4-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-4-autoconfigure/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/dapr-spring/dapr-spring-boot-properties/pom.xml
+++ b/dapr-spring/dapr-spring-boot-properties/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter-test/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter-test/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter-test/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter-test/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/dapr-spring/dapr-spring-boot-tests/pom.xml
+++ b/dapr-spring/dapr-spring-boot-tests/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <surefire.version>3.2.2</surefire.version>
     <junit-bom.version>5.11.4</junit-bom.version>
     <snakeyaml.version>2.0</snakeyaml.version>
-    <testcontainers.version>1.21.4</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <springboot.version>3.5.12</springboot.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <assertj.version>3.27.7</assertj.version>
@@ -70,10 +70,9 @@
     <system-rules.version>1.19.0</system-rules.version>
     <system-stubs.version>2.1.1</system-stubs.version>
     <mockito-inline.version>4.2.0</mockito-inline.version>
-    <junit-vintage-engine.version>5.7.0</junit-vintage-engine.version>
     <junit-platform-console.version>1.7.0</junit-platform-console.version>
     <reactor.version>3.5.12</reactor.version>
-    <testcontainers-redis.version>2.2.2</testcontainers-redis.version>
+    <testcontainers-redis.version>2.2.4</testcontainers-redis.version>
     <slf4j.version>2.0.9</slf4j.version>
     <mockito.version>3.11.2</mockito.version>
     <opentelemetry-bom.version>2.1.0</opentelemetry-bom.version>
@@ -188,33 +187,33 @@
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
+        <artifactId>testcontainers-junit-jupiter</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>kafka</artifactId>
+        <artifactId>testcontainers-kafka</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>postgresql</artifactId>
+        <artifactId>testcontainers-postgresql</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>rabbitmq</artifactId>
+        <artifactId>testcontainers-rabbitmq</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>toxiproxy</artifactId>
+        <artifactId>testcontainers-toxiproxy</artifactId>
         <version>${testcontainers.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>mysql</artifactId>
+        <artifactId>testcontainers-mysql</artifactId>
         <version>${testcontainers.version}</version>
         <scope>test</scope>
       </dependency>
@@ -400,11 +399,23 @@
         <groupId>com.redis</groupId>
         <artifactId>testcontainers-redis</artifactId>
         <version>${testcontainers-redis.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.github.microcks</groupId>
         <artifactId>microcks-testcontainers</artifactId>
         <version>${microcks.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -141,7 +141,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dapr</groupId>
@@ -174,12 +174,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mysql</artifactId>
+      <artifactId>testcontainers-mysql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -209,7 +209,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>toxiproxy</artifactId>
+      <artifactId>testcontainers-toxiproxy</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk-tests/src/test/java/io/dapr/it/resiliency/SdkResiliencyIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/resiliency/SdkResiliencyIT.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;

--- a/sdk-tests/src/test/java/io/dapr/it/spring/data/CustomMySQLContainer.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/data/CustomMySQLContainer.java
@@ -1,9 +1,9 @@
 package io.dapr.it.spring.data;
 
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class CustomMySQLContainer<SELF extends MySQLContainer<SELF>> extends MySQLContainer<SELF> {
+public class CustomMySQLContainer extends MySQLContainer {
 
   public CustomMySQLContainer(String dockerImageName) {
     super(DockerImageName.parse(dockerImageName));

--- a/sdk-tests/src/test/java/io/dapr/it/spring/data/DaprKeyValueRepositoryIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/data/DaprKeyValueRepositoryIT.java
@@ -25,7 +25,7 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -58,7 +58,7 @@ public class DaprKeyValueRepositoryIT {
   private static final Network DAPR_NETWORK = Network.newNetwork();
 
   @Container
-  private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine")
+  private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:16-alpine")
       .withNetworkAliases("postgres-repository")
       .withDatabaseName("dapr_db_repository")
       .withUsername("postgres")

--- a/sdk-tests/src/test/java/io/dapr/it/spring/data/MySQLDaprKeyValueTemplateIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/data/MySQLDaprKeyValueTemplateIT.java
@@ -28,7 +28,7 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -71,7 +71,7 @@ public class MySQLDaprKeyValueTemplateIT {
       .withStartupTimeout(Duration.of(60, ChronoUnit.SECONDS));
 
   @Container
-  private static final MySQLContainer<?> MY_SQL_CONTAINER = new CustomMySQLContainer<>("mysql:5.7.34")
+  private static final MySQLContainer MY_SQL_CONTAINER = new CustomMySQLContainer("mysql:5.7.34")
       .withNetworkAliases("mysql")
       .withDatabaseName("dapr_db")
       .withUsername("mysql")

--- a/sdk-tests/src/test/java/io/dapr/it/spring/data/PostgreSQLDaprKeyValueTemplateIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/spring/data/PostgreSQLDaprKeyValueTemplateIT.java
@@ -28,7 +28,7 @@ import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -62,7 +62,7 @@ public class PostgreSQLDaprKeyValueTemplateIT {
   private static final Network DAPR_NETWORK = Network.newNetwork();
 
   @Container
-  private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine")
+  private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:16-alpine")
       .withNetworkAliases("postgres")
       .withDatabaseName("dapr_db")
       .withUsername("postgres")

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/jobs/DaprJobsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/jobs/DaprJobsIT.java
@@ -45,7 +45,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Random;
 
 import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/DaprWorkflowsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/DaprWorkflowsIT.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/version/full/FullVersioningWorkflowsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/version/full/FullVersioningWorkflowsIT.java
@@ -37,7 +37,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -55,7 +55,7 @@ import static io.dapr.it.spring.data.DaprSpringDataConstants.STATE_STORE_NAME;
 import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -81,7 +81,7 @@ public class FullVersioningWorkflowsIT {
   private static final Map<String, String> STATE_STORE_PROPERTIES = createStateStoreProperties();
 
   @Container
-  private static final MySQLContainer<?> MY_SQL_CONTAINER = new CustomMySQLContainer<>("mysql:5.7.34")
+  private static final MySQLContainer MY_SQL_CONTAINER = new CustomMySQLContainer("mysql:5.7.34")
       .withNetworkAliases("mysql")
       .withDatabaseName("dapr_db")
       .withUsername("mysql")

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/version/patch/PatchVersioningWorkflowsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/version/patch/PatchVersioningWorkflowsIT.java
@@ -33,7 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -76,7 +76,7 @@ public class PatchVersioningWorkflowsIT {
   private static final Map<String, String> STATE_STORE_PROPERTIES = createStateStoreProperties();
 
   @Container
-  private static final MySQLContainer<?> MY_SQL_CONTAINER = new CustomMySQLContainer<>("mysql:5.7.34")
+  private static final MySQLContainer MY_SQL_CONTAINER = new CustomMySQLContainer("mysql:5.7.34")
       .withNetworkAliases("mysql")
       .withDatabaseName("dapr_db")
       .withUsername("mysql")

--- a/sdk-workflows/pom.xml
+++ b/sdk-workflows/pom.xml
@@ -38,11 +38,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>durabletask-client</artifactId>
       <version>${project.parent.version}</version>

--- a/sdk-workflows/src/test/java/io/dapr/workflows/WorkflowTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/WorkflowTest.java
@@ -1,6 +1,6 @@
 package io.dapr.workflows;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WorkflowTest {
 

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityClassWrapperTest.java
@@ -3,7 +3,7 @@ package io.dapr.workflows.runtime;
 import io.dapr.durabletask.TaskActivityContext;
 import io.dapr.workflows.WorkflowActivity;
 import io.dapr.workflows.WorkflowActivityContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapperTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowActivityInstanceWrapperTest.java
@@ -3,7 +3,7 @@ package io.dapr.workflows.runtime;
 import io.dapr.durabletask.TaskActivityContext;
 import io.dapr.workflows.WorkflowActivity;
 import io.dapr.workflows.WorkflowActivityContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/WorkflowRuntimeBuilderTest.java
@@ -20,7 +20,7 @@ import io.dapr.workflows.Workflow;
 import io.dapr.workflows.WorkflowActivity;
 import io.dapr.workflows.WorkflowActivityContext;
 import io.dapr.workflows.WorkflowStub;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -50,10 +50,10 @@ public class WorkflowRuntimeBuilderTest {
     assertDoesNotThrow(() -> b.registerWorkflow("NameWithClass", TestWorkflow.class));
 //    assertDoesNotThrow(() -> b.registerWorkflow(new TestWorkflowWithNameAndVersionIsLatest()));
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> b.registerWorkflow("", new TestWorkflow(), null, null));
-    Assert.assertThrows(IllegalArgumentException.class, () -> b.registerWorkflow("", TestWorkflow.class, null, null));
-    Assert.assertThrows(IllegalArgumentException.class, () -> b.registerActivity("", new TestActivity()));
-    Assert.assertThrows(IllegalArgumentException.class, () -> b.registerActivity("", TestActivity.class));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> b.registerWorkflow("", new TestWorkflow(), null, null));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> b.registerWorkflow("", TestWorkflow.class, null, null));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> b.registerActivity("", new TestActivity()));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> b.registerActivity("", TestActivity.class));
   }
 
   public static class TestActivity implements WorkflowActivity {

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -59,7 +59,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -2596,7 +2595,7 @@ public class DaprClientGrpcTest {
 
     // Verify the second call has overwrite set to true
     DaprJobsProtos.ScheduleJobRequest secondActualRequest = captor.getAllValues().get(1);
-    Assert.assertTrue(secondActualRequest.getOverwrite());
+    Assertions.assertTrue(secondActualRequest.getOverwrite());
     assertEquals("testJob", secondActualRequest.getJob().getName());
   }
 
@@ -2729,8 +2728,8 @@ public class DaprClientGrpcTest {
     assertNull(response.getRepeats());
     assertNull(response.getTtl());
     assertEquals(job.getDueTime(), datetime);
-    Assert.assertTrue(job.hasFailurePolicy());
-    Assert.assertTrue(job.getFailurePolicy().hasDrop());
+    Assertions.assertTrue(job.hasFailurePolicy());
+    Assertions.assertTrue(job.getFailurePolicy().hasDrop());
   }
 
   @Test
@@ -2764,8 +2763,8 @@ public class DaprClientGrpcTest {
     assertNull(response.getRepeats());
     assertNull(response.getTtl());
     assertEquals(job.getDueTime(), datetime);
-    Assert.assertTrue(job.hasFailurePolicy());
-    Assert.assertTrue(job.getFailurePolicy().hasConstant());
+    Assertions.assertTrue(job.hasFailurePolicy());
+    Assertions.assertTrue(job.getFailurePolicy().hasConstant());
     assertEquals(2, job.getFailurePolicy().getConstant().getMaxRetries());
   }
 
@@ -2801,8 +2800,8 @@ public class DaprClientGrpcTest {
     assertNull(response.getRepeats());
     assertNull(response.getTtl());
     assertEquals(job.getDueTime(), datetime);
-    Assert.assertTrue(job.hasFailurePolicy());
-    Assert.assertTrue(job.getFailurePolicy().hasConstant());
+    Assertions.assertTrue(job.hasFailurePolicy());
+    Assertions.assertTrue(job.getFailurePolicy().hasConstant());
     assertEquals(5, job.getFailurePolicy().getConstant().getInterval().getNanos());
   }
 
@@ -2839,8 +2838,8 @@ public class DaprClientGrpcTest {
     assertNull(response.getRepeats());
     assertNull(response.getTtl());
     assertEquals(job.getDueTime(), datetime);
-    Assert.assertTrue(job.hasFailurePolicy());
-    Assert.assertTrue(job.getFailurePolicy().hasConstant());
+    Assertions.assertTrue(job.hasFailurePolicy());
+    Assertions.assertTrue(job.getFailurePolicy().hasConstant());
     assertEquals(10, job.getFailurePolicy().getConstant().getMaxRetries());
     assertEquals(5, job.getFailurePolicy().getConstant().getInterval().getNanos());
   }

--- a/sdk/src/test/java/io/dapr/client/DaprPreviewClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprPreviewClientGrpcTest.java
@@ -92,7 +92,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.dapr.utils.TestUtils.assertThrowsDaprException;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
+++ b/sdk/src/test/java/io/dapr/utils/NetworkUtilsTest.java
@@ -17,7 +17,6 @@ import io.dapr.config.Properties;
 import io.dapr.exceptions.DaprException;
 import io.dapr.utils.NetworkUtils.GrpcEndpointSettings;
 import io.grpc.ManagedChannel;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -329,7 +328,7 @@ public class NetworkUtilsTest {
     try {
       var properties = new Properties(Map.of(Properties.GRPC_ENDPOINT.getName(), grpcEndpointEnvValue));
       NetworkUtils.GrpcEndpointSettings.parse(properties);
-      Assert.fail();
+      Assertions.fail();
     } catch (IllegalArgumentException e) {
       // Expected
     }

--- a/spring-boot-4-examples/consumer-app/pom.xml
+++ b/spring-boot-4-examples/consumer-app/pom.xml
@@ -33,22 +33,22 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-boot-4-examples/consumer-app/src/test/java/io/dapr/springboot4/examples/consumer/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/consumer-app/src/test/java/io/dapr/springboot4/examples/consumer/DaprTestContainersConfig.java
@@ -16,15 +16,13 @@ package io.dapr.springboot4.examples.consumer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
@@ -41,11 +39,6 @@ public class DaprTestContainersConfig {
     boolean reuse = env.getProperty("reuse", Boolean.class, false);
     if (reuse) {
       Network defaultDaprNetwork = new Network() {
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
-        }
-
         @Override
         public String getId() {
           return "dapr-network";

--- a/spring-boot-4-examples/producer-app/pom.xml
+++ b/spring-boot-4-examples/producer-app/pom.xml
@@ -39,12 +39,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/spring-boot-4-examples/producer-app/src/test/java/io/dapr/springboot4/examples/producer/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/producer-app/src/test/java/io/dapr/springboot4/examples/producer/DaprTestContainersConfig.java
@@ -16,16 +16,14 @@ package io.dapr.springboot4.examples.producer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.Subscription;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
@@ -50,11 +48,6 @@ public class DaprTestContainersConfig {
     boolean reuse = env.getProperty("reuse", Boolean.class, false);
     if (reuse) {
       Network defaultDaprNetwork = new Network() {
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
-        }
-
         @Override
         public String getId() {
           return "dapr-network";
@@ -92,8 +85,8 @@ public class DaprTestContainersConfig {
   }
 
   @Bean
-  public PostgreSQLContainer<?> postgreSQLContainer(Network daprNetwork) {
-    return new PostgreSQLContainer<>("postgres:16-alpine")
+  public PostgreSQLContainer postgreSQLContainer(Network daprNetwork) {
+    return new PostgreSQLContainer("postgres:16-alpine")
             .withNetworkAliases("postgres")
             .withDatabaseName("dapr_db_repository")
             .withUsername("postgres")
@@ -105,7 +98,7 @@ public class DaprTestContainersConfig {
 
   @Bean
   @ServiceConnection
-  public DaprContainer daprContainer(Network daprNetwork, PostgreSQLContainer<?> postgreSQLContainer, RabbitMQContainer rabbitMQContainer) {
+  public DaprContainer daprContainer(Network daprNetwork, PostgreSQLContainer postgreSQLContainer, RabbitMQContainer rabbitMQContainer) {
 
     Map<String, String> rabbitMqProperties = new HashMap<>();
     rabbitMqProperties.put("connectionString", "amqp://guest:guest@rabbitmq:5672");

--- a/spring-boot-4-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot4/examples/orchestrator/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot4/examples/orchestrator/DaprTestContainersConfig.java
@@ -15,8 +15,6 @@ package io.dapr.springboot4.examples.orchestrator;
 
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.*;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -52,11 +50,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-4-examples/workflows/multi-app/worker-one/src/test/java/io/dapr/springboot4/examples/workerone/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/workflows/multi-app/worker-one/src/test/java/io/dapr/springboot4/examples/workerone/DaprTestContainersConfig.java
@@ -17,8 +17,6 @@ import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -48,11 +46,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-4-examples/workflows/multi-app/worker-two/src/test/java/io/dapr/springboot4/examples/workertwo/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/workflows/multi-app/worker-two/src/test/java/io/dapr/springboot4/examples/workertwo/DaprTestContainersConfig.java
@@ -16,8 +16,6 @@ package io.dapr.springboot4.examples.workertwo;
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +45,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-4-examples/workflows/patterns/pom.xml
+++ b/spring-boot-4-examples/workflows/patterns/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-postgresql</artifactId>
-      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/spring-boot-4-examples/workflows/patterns/src/test/java/io/dapr/springboot4/examples/wfp/DaprTestContainersConfig.java
+++ b/spring-boot-4-examples/workflows/patterns/src/test/java/io/dapr/springboot4/examples/wfp/DaprTestContainersConfig.java
@@ -18,8 +18,6 @@ import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.WorkflowDashboardContainer;
 import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -125,11 +123,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-4-sdk-tests/pom.xml
+++ b/spring-boot-4-sdk-tests/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>

--- a/spring-boot-4-sdk-tests/src/test/java/io/dapr/it/springboot4/testcontainers/jobs/DaprJobsIT.java
+++ b/spring-boot-4-sdk-tests/src/test/java/io/dapr/it/springboot4/testcontainers/jobs/DaprJobsIT.java
@@ -45,7 +45,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Random;
 
 import static io.dapr.it.springboot4.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,

--- a/spring-boot-4-sdk-tests/src/test/java/io/dapr/it/springboot4/testcontainers/workflows/DaprWorkflowsIT.java
+++ b/spring-boot-4-sdk-tests/src/test/java/io/dapr/it/springboot4/testcontainers/workflows/DaprWorkflowsIT.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static io.dapr.it.springboot4.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/spring-boot-examples/consumer-app/pom.xml
+++ b/spring-boot-examples/consumer-app/pom.xml
@@ -33,22 +33,22 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-boot-examples/consumer-app/src/test/java/io/dapr/springboot/examples/consumer/DaprTestContainersConfig.java
+++ b/spring-boot-examples/consumer-app/src/test/java/io/dapr/springboot/examples/consumer/DaprTestContainersConfig.java
@@ -16,15 +16,13 @@ package io.dapr.springboot.examples.consumer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
@@ -49,11 +47,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/producer-app/pom.xml
+++ b/spring-boot-examples/producer-app/pom.xml
@@ -39,12 +39,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-boot-examples/producer-app/src/test/java/io/dapr/springboot/examples/producer/DaprTestContainersConfig.java
+++ b/spring-boot-examples/producer-app/src/test/java/io/dapr/springboot/examples/producer/DaprTestContainersConfig.java
@@ -16,16 +16,14 @@ package io.dapr.springboot.examples.producer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.Subscription;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
@@ -59,11 +57,6 @@ public class DaprTestContainersConfig {
         public void close() {
 
         }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
-        }
       };
 
       List<com.github.dockerjava.api.model.Network> networks = DockerClientFactory.instance().client().listNetworksCmd()
@@ -92,8 +85,8 @@ public class DaprTestContainersConfig {
   }
 
   @Bean
-  public PostgreSQLContainer<?> postgreSQLContainer(Network daprNetwork) {
-    return new PostgreSQLContainer<>("postgres:16-alpine")
+  public PostgreSQLContainer postgreSQLContainer(Network daprNetwork) {
+    return new PostgreSQLContainer("postgres:16-alpine")
             .withNetworkAliases("postgres")
             .withDatabaseName("dapr_db_repository")
             .withUsername("postgres")
@@ -105,7 +98,7 @@ public class DaprTestContainersConfig {
 
   @Bean
   @ServiceConnection
-  public DaprContainer daprContainer(Network daprNetwork, PostgreSQLContainer<?> postgreSQLContainer, RabbitMQContainer rabbitMQContainer) {
+  public DaprContainer daprContainer(Network daprNetwork, PostgreSQLContainer postgreSQLContainer, RabbitMQContainer rabbitMQContainer) {
 
     Map<String, String> rabbitMqProperties = new HashMap<>();
     rabbitMqProperties.put("connectionString", "amqp://guest:guest@rabbitmq:5672");

--- a/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/multi-app/orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
@@ -15,8 +15,6 @@ package io.dapr.springboot.examples.orchestrator;
 
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.*;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -52,11 +50,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/multi-app/worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/multi-app/worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
@@ -17,8 +17,6 @@ import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -48,11 +46,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/multi-app/worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/multi-app/worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
@@ -16,8 +16,6 @@ package io.dapr.springboot.examples.workertwo;
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +45,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/patterns/pom.xml
+++ b/spring-boot-examples/workflows/patterns/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-postgresql</artifactId>
-      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/spring-boot-examples/workflows/patterns/src/test/java/io/dapr/springboot/examples/wfp/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/patterns/src/test/java/io/dapr/springboot/examples/wfp/DaprTestContainersConfig.java
@@ -18,8 +18,6 @@ import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.WorkflowDashboardContainer;
 import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -125,11 +123,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/versioning/full-version-worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/versioning/full-version-worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
@@ -17,8 +17,6 @@ import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -48,11 +46,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/versioning/full-version-worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/versioning/full-version-worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
@@ -16,8 +16,6 @@ package io.dapr.springboot.examples.workertwo;
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +45,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/versioning/patch-version-worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/versioning/patch-version-worker-one/src/test/java/io/dapr/springboot/examples/workerone/DaprTestContainersConfig.java
@@ -16,8 +16,6 @@ package io.dapr.springboot.examples.workerone;
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +45,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/versioning/patch-version-worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/versioning/patch-version-worker-two/src/test/java/io/dapr/springboot/examples/workertwo/DaprTestContainersConfig.java
@@ -16,8 +16,6 @@ package io.dapr.springboot.examples.workertwo;
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +45,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 

--- a/spring-boot-examples/workflows/versioning/version-orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
+++ b/spring-boot-examples/workflows/versioning/version-orchestrator/src/test/java/io/dapr/springboot/examples/orchestrator/DaprTestContainersConfig.java
@@ -15,8 +15,6 @@ package io.dapr.springboot.examples.orchestrator;
 
 import com.redis.testcontainers.RedisContainer;
 import io.dapr.testcontainers.*;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -52,11 +50,6 @@ public class DaprTestContainersConfig {
         @Override
         public void close() {
 
-        }
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-          return null;
         }
       };
 


### PR DESCRIPTION
# Description

Upgrade Testcontainers to v2.0.5 which removes the transitive JUnit 4 dependency and modernizes the test infrastructure. This includes renaming all module artifact IDs with the testcontainers- prefix, migrating container class imports to their new packages, converting remaining JUnit 4 test annotations and assertions to JUnit 5, removing junit-vintage-engine, and ensuring third-party TC dependencies (testcontainers-redis 2.2.4, microcks-testcontainers 0.3.1) are compatible via TC 1.x exclusions.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
