### PR TITLE
feat: add DaprClient.invokeHttpClient(appId) factory

### DIFF
--- a/dapr-spring/dapr-spring-boot-observation/src/main/java/io/dapr/spring/observation/client/ObservationDaprClient.java
+++ b/dapr-spring/dapr-spring-boot-observation/src/main/java/io/dapr/spring/observation/client/ObservationDaprClient.java
@@ -14,6 +14,7 @@ limitations under the License.
 package io.dapr.spring.observation.client;
 
 import io.dapr.client.DaprClient;
+import io.dapr.client.DaprInvokeHttpClient;
 import io.dapr.client.domain.BulkPublishRequest;
 import io.dapr.client.domain.BulkPublishResponse;
 import io.dapr.client.domain.ConfigurationItem;
@@ -332,6 +333,11 @@ public class ObservationDaprClient implements DaprClient {
   @Deprecated
   public <T> Mono<T> invokeMethod(InvokeMethodRequest invokeMethodRequest, TypeRef<T> type) {
     return delegate.invokeMethod(invokeMethodRequest, type);
+  }
+
+  @Override
+  public DaprInvokeHttpClient invokeHttpClient(String appId) {
+    return delegate.invokeHttpClient(appId);
   }
 
   // -------------------------------------------------------------------------

--- a/dapr-spring/dapr-spring-boot-observation/src/test/java/io/dapr/spring/observation/client/ObservationDaprClientTest.java
+++ b/dapr-spring/dapr-spring-boot-observation/src/test/java/io/dapr/spring/observation/client/ObservationDaprClientTest.java
@@ -14,13 +14,10 @@ limitations under the License.
 package io.dapr.spring.observation.client;
 
 import io.dapr.client.DaprClient;
-import io.dapr.client.domain.DeleteStateRequest;
-import io.dapr.client.domain.GetSecretRequest;
-import io.dapr.client.domain.GetStateRequest;
+import io.dapr.client.DaprInvokeHttpClient;
 import io.dapr.client.domain.InvokeBindingRequest;
 import io.dapr.client.domain.PublishEventRequest;
 import io.dapr.client.domain.ScheduleJobRequest;
-import io.dapr.client.domain.State;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +30,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -376,6 +372,20 @@ class ObservationDaprClientTest {
         io.dapr.client.domain.HttpExtension.NONE, String.class).block();
 
     // Registry must be empty — no spans for deprecated methods
+    TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation();
+  }
+
+  @Test
+  @DisplayName("invokeHttpClient delegates without creating a span")
+  void invokeHttpClientDelegatesWithoutSpan() {
+    DaprInvokeHttpClient stub = org.mockito.Mockito.mock(DaprInvokeHttpClient.class);
+    when(delegate.invokeHttpClient("orderprocessor")).thenReturn(stub);
+
+    DaprInvokeHttpClient result = client.invokeHttpClient("orderprocessor");
+
+    assertThat(result).isSameAs(stub);
+    verify(delegate).invokeHttpClient("orderprocessor");
+    // Synchronous factory — no Mono/Flux to observe, so no span is expected.
     TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation();
   }
 }

--- a/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
@@ -13,9 +13,12 @@ limitations under the License.
 
 package io.dapr.examples.invoke.http;
 
-import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.domain.HttpExtension;
+import io.dapr.config.Properties;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 /**
  * 1. Build and install jars:
@@ -24,6 +27,15 @@ import io.dapr.client.domain.HttpExtension;
  * 3. Send messages to the server:
  * dapr run -- java -jar target/dapr-java-sdk-examples-exec.jar \
  *   io.dapr.examples.invoke.http.InvokeClient 'message one' 'message two'
+ *
+ * <p>This example demonstrates calling another Dapr-enabled application using a
+ * native HTTP client. Two equivalent URL forms are supported by the Dapr sidecar:
+ * <ol>
+ *   <li>Sending the request to the sidecar's base URL with a {@code dapr-app-id}
+ *       header that identifies the target app.</li>
+ *   <li>Sending the request to the sidecar's {@code /v1.0/invoke/&lt;app-id&gt;/method/&lt;method&gt;}
+ *       path, with no extra header.</li>
+ * </ol>
  */
 public class InvokeClient {
 
@@ -33,21 +45,46 @@ public class InvokeClient {
   private static final String SERVICE_APP_ID = "invokedemo";
 
   /**
+   * Method on the target service to invoke.
+   */
+  private static final String METHOD = "say";
+
+  /**
    * Starts the invoke client.
    *
    * @param args Messages to be sent as request for the invoke API.
    */
   public static void main(String[] args) throws Exception {
-    try (DaprClient client = (new DaprClientBuilder()).build()) {
-      for (String message : args) {
-        byte[] response = client.invokeMethod(SERVICE_APP_ID, "say", message, HttpExtension.POST, null,
-            byte[].class).block();
-        System.out.println(new String(response));
-      }
+    int port = Properties.HTTP_PORT.get();
+    String sidecarBase = "http://localhost:" + port;
 
-      // This is an example, so for simplicity we are just exiting here.
-      // Normally a dapr app would be a web service and not exit main.
-      System.out.println("Done");
+    HttpClient httpClient = HttpClient.newHttpClient();
+
+    for (String message : args) {
+      // Form 1: dapr-app-id header against the sidecar's base URL.
+      HttpRequest headerRequest = HttpRequest.newBuilder()
+          .uri(URI.create(sidecarBase + "/" + METHOD))
+          .header("Content-Type", "application/json")
+          .header("dapr-app-id", SERVICE_APP_ID)
+          .POST(HttpRequest.BodyPublishers.ofString(message))
+          .build();
+      HttpResponse<byte[]> headerResponse =
+          httpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
+      System.out.println(new String(headerResponse.body()));
+
+      // Form 2: sidecar invoke path.
+      HttpRequest pathRequest = HttpRequest.newBuilder()
+          .uri(URI.create(sidecarBase + "/v1.0/invoke/" + SERVICE_APP_ID + "/method/" + METHOD))
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(message))
+          .build();
+      HttpResponse<byte[]> pathResponse =
+          httpClient.send(pathRequest, HttpResponse.BodyHandlers.ofByteArray());
+      System.out.println(new String(pathResponse.body()));
     }
+
+    // This is an example, so for simplicity we are just exiting here.
+    // Normally a dapr app would be a web service and not exit main.
+    System.out.println("Done");
   }
 }

--- a/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/InvokeClient.java
@@ -13,6 +13,9 @@ limitations under the License.
 
 package io.dapr.examples.invoke.http;
 
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+import io.dapr.client.DaprInvokeHttpClient;
 import io.dapr.config.Properties;
 
 import java.net.URI;
@@ -28,13 +31,14 @@ import java.net.http.HttpResponse;
  * dapr run -- java -jar target/dapr-java-sdk-examples-exec.jar \
  *   io.dapr.examples.invoke.http.InvokeClient 'message one' 'message two'
  *
- * <p>This example demonstrates calling another Dapr-enabled application using a
- * native HTTP client. Two equivalent URL forms are supported by the Dapr sidecar:
+ * <p>This example demonstrates calling another Dapr-enabled application over HTTP.
+ * Two equivalent approaches are shown:
  * <ol>
- *   <li>Sending the request to the sidecar's base URL with a {@code dapr-app-id}
- *       header that identifies the target app.</li>
- *   <li>Sending the request to the sidecar's {@code /v1.0/invoke/&lt;app-id&gt;/method/&lt;method&gt;}
- *       path, with no extra header.</li>
+ *   <li>{@link DaprClient#invokeHttpClient(String)} — an SDK-provided {@link java.net.http.HttpClient}
+ *       wrapper pre-bound to the sidecar's {@code /v1.0/invoke/&lt;app-id&gt;/method/} prefix,
+ *       with the {@code dapr-api-token} header attached when configured.</li>
+ *   <li>A raw {@link java.net.http.HttpClient} sending the request to the sidecar's base URL
+ *       with a {@code dapr-app-id} header identifying the target app — no SDK helper required.</li>
  * </ol>
  */
 public class InvokeClient {
@@ -55,32 +59,34 @@ public class InvokeClient {
    * @param args Messages to be sent as request for the invoke API.
    */
   public static void main(String[] args) throws Exception {
-    int port = Properties.HTTP_PORT.get();
-    String sidecarBase = "http://localhost:" + port;
+    try (DaprClient daprClient = new DaprClientBuilder().build()) {
+      DaprInvokeHttpClient invoker = daprClient.invokeHttpClient(SERVICE_APP_ID);
 
-    HttpClient httpClient = HttpClient.newHttpClient();
+      int port = Properties.HTTP_PORT.get();
+      String sidecarBase = "http://localhost:" + port;
+      HttpClient rawHttpClient = HttpClient.newHttpClient();
 
-    for (String message : args) {
-      // Form 1: dapr-app-id header against the sidecar's base URL.
-      HttpRequest headerRequest = HttpRequest.newBuilder()
-          .uri(URI.create(sidecarBase + "/" + METHOD))
-          .header("Content-Type", "application/json")
-          .header("dapr-app-id", SERVICE_APP_ID)
-          .POST(HttpRequest.BodyPublishers.ofString(message))
-          .build();
-      HttpResponse<byte[]> headerResponse =
-          httpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
-      System.out.println(new String(headerResponse.body()));
+      for (String message : args) {
+        // Form 1: SDK helper — paths resolve against /v1.0/invoke/<app-id>/method/.
+        HttpRequest sdkRequest = invoker.newRequestBuilder(METHOD)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(message))
+            .build();
+        HttpResponse<byte[]> sdkResponse =
+            invoker.send(sdkRequest, HttpResponse.BodyHandlers.ofByteArray());
+        System.out.println(new String(sdkResponse.body()));
 
-      // Form 2: sidecar invoke path.
-      HttpRequest pathRequest = HttpRequest.newBuilder()
-          .uri(URI.create(sidecarBase + "/v1.0/invoke/" + SERVICE_APP_ID + "/method/" + METHOD))
-          .header("Content-Type", "application/json")
-          .POST(HttpRequest.BodyPublishers.ofString(message))
-          .build();
-      HttpResponse<byte[]> pathResponse =
-          httpClient.send(pathRequest, HttpResponse.BodyHandlers.ofByteArray());
-      System.out.println(new String(pathResponse.body()));
+        // Form 2: raw HttpClient + dapr-app-id header against the sidecar's base URL.
+        HttpRequest headerRequest = HttpRequest.newBuilder()
+            .uri(URI.create(sidecarBase + "/" + METHOD))
+            .header("Content-Type", "application/json")
+            .header("dapr-app-id", SERVICE_APP_ID)
+            .POST(HttpRequest.BodyPublishers.ofString(message))
+            .build();
+        HttpResponse<byte[]> headerResponse =
+            rawHttpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
+        System.out.println(new String(headerResponse.body()));
+      }
     }
 
     // This is an example, so for simplicity we are just exiting here.

--- a/examples/src/main/java/io/dapr/examples/invoke/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/README.md
@@ -17,6 +17,15 @@ Two equivalent approaches are demonstrated:
 1. `DaprClient.invokeHttpClient(appId)` — an SDK-provided wrapper that returns a pre-configured `HttpClient` bound to the sidecar's `/v1.0/invoke/<app-id>/method/` prefix, with the `dapr-api-token` header attached when configured.
 2. A raw `java.net.http.HttpClient` sending the request to the sidecar's base URL with a `dapr-app-id` header identifying the target app — no SDK helper required.
 
+> **Migrating from `DaprClient.invokeMethod`:** the deprecated `invokeMethod` APIs serialized request bodies through the configured `DaprObjectSerializer` (JSON by default), so a `String` payload was sent as a JSON string literal — e.g. `"hello"` instead of `hello`. `invokeHttpClient` does **not** serialize bodies: callers supply raw `BodyPublisher`s exactly as with any `java.net.http.HttpClient`. To preserve the previous JSON encoding, use `DaprBodyPublishers.json(Object)`:
+>
+> ```java
+> HttpRequest request = invoker.newRequestBuilder("orders")
+>     .header("Content-Type", "application/json")
+>     .POST(DaprBodyPublishers.json(order))
+>     .build();
+> ```
+
 ## Pre-requisites
 
 * [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
@@ -109,8 +118,8 @@ Use the following command to execute the demo service example:
 <!-- STEP
 name: Run demo service
 expected_stdout_lines: 
-  - 'Server: "message one"'
-  - 'Server: "message two"'
+  - 'Server: message one'
+  - 'Server: message two'
 background: true
 sleep: 5
 -->

--- a/examples/src/main/java/io/dapr/examples/invoke/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/README.md
@@ -10,7 +10,12 @@ Visit [this](https://docs.dapr.io/developing-applications/building-blocks/servic
  
 ## Remote invocation using a native HTTP client
 
-This sample uses a native Java `HttpClient` to invoke a method on another Dapr-enabled application via the Dapr sidecar. The previous SDK-provided `DaprClient.invokeMethod` wrappers are deprecated; calling the sidecar directly is the recommended approach.
+This sample invokes a method on another Dapr-enabled application via the Dapr sidecar using `java.net.http.HttpClient`. The previous SDK-provided `DaprClient.invokeMethod` wrappers are deprecated; calling the sidecar directly is the recommended approach.
+
+Two equivalent approaches are demonstrated:
+
+1. `DaprClient.invokeHttpClient(appId)` — an SDK-provided wrapper that returns a pre-configured `HttpClient` bound to the sidecar's `/v1.0/invoke/<app-id>/method/` prefix, with the `dapr-api-token` header attached when configured.
+2. A raw `java.net.http.HttpClient` sending the request to the sidecar's base URL with a `dapr-app-id` header identifying the target app — no SDK helper required.
 
 ## Pre-requisites
 
@@ -121,10 +126,10 @@ Once running, the ExposerService is now ready to be invoked by Dapr.
 
 ### Running the InvokeClient sample
 
-The Invoke client sample uses a native Java `HttpClient` to call the remote method through the Dapr sidecar. The Dapr sidecar accepts two equivalent URL forms for service invocation; this sample demonstrates both for each message:
+The Invoke client sample calls the remote method through the Dapr sidecar using two equivalent approaches:
 
-1. Sending the request to the sidecar's base URL with a `dapr-app-id` header identifying the target app.
-2. Sending the request to the sidecar's `/v1.0/invoke/<app-id>/method/<method>` path.
+1. `DaprClient.invokeHttpClient(appId)` — an SDK-provided wrapper around `java.net.http.HttpClient` pre-bound to `/v1.0/invoke/<app-id>/method/`.
+2. A raw `java.net.http.HttpClient` against the sidecar's base URL with a `dapr-app-id` header.
 
 In `InvokeClient.java` file, you will find the `InvokeClient` class and the `main` method. See the code snippet below:
 
@@ -135,32 +140,34 @@ public class InvokeClient {
   private static final String METHOD = "say";
 
   public static void main(String[] args) throws Exception {
-    int port = Properties.HTTP_PORT.get();
-    String sidecarBase = "http://localhost:" + port;
+    try (DaprClient daprClient = new DaprClientBuilder().build()) {
+      DaprInvokeHttpClient invoker = daprClient.invokeHttpClient(SERVICE_APP_ID);
 
-    HttpClient httpClient = HttpClient.newHttpClient();
+      int port = Properties.HTTP_PORT.get();
+      String sidecarBase = "http://localhost:" + port;
+      HttpClient rawHttpClient = HttpClient.newHttpClient();
 
-    for (String message : args) {
-      // Form 1: dapr-app-id header against the sidecar's base URL.
-      HttpRequest headerRequest = HttpRequest.newBuilder()
-          .uri(URI.create(sidecarBase + "/" + METHOD))
-          .header("Content-Type", "application/json")
-          .header("dapr-app-id", SERVICE_APP_ID)
-          .POST(HttpRequest.BodyPublishers.ofString(message))
-          .build();
-      HttpResponse<byte[]> headerResponse =
-          httpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
-      System.out.println(new String(headerResponse.body()));
+      for (String message : args) {
+        // Form 1: SDK helper — paths resolve against /v1.0/invoke/<app-id>/method/.
+        HttpRequest sdkRequest = invoker.newRequestBuilder(METHOD)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(message))
+            .build();
+        HttpResponse<byte[]> sdkResponse =
+            invoker.send(sdkRequest, HttpResponse.BodyHandlers.ofByteArray());
+        System.out.println(new String(sdkResponse.body()));
 
-      // Form 2: sidecar invoke path.
-      HttpRequest pathRequest = HttpRequest.newBuilder()
-          .uri(URI.create(sidecarBase + "/v1.0/invoke/" + SERVICE_APP_ID + "/method/" + METHOD))
-          .header("Content-Type", "application/json")
-          .POST(HttpRequest.BodyPublishers.ofString(message))
-          .build();
-      HttpResponse<byte[]> pathResponse =
-          httpClient.send(pathRequest, HttpResponse.BodyHandlers.ofByteArray());
-      System.out.println(new String(pathResponse.body()));
+        // Form 2: raw HttpClient + dapr-app-id header against the sidecar's base URL.
+        HttpRequest headerRequest = HttpRequest.newBuilder()
+            .uri(URI.create(sidecarBase + "/" + METHOD))
+            .header("Content-Type", "application/json")
+            .header("dapr-app-id", SERVICE_APP_ID)
+            .POST(HttpRequest.BodyPublishers.ofString(message))
+            .build();
+        HttpResponse<byte[]> headerResponse =
+            rawHttpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
+        System.out.println(new String(headerResponse.body()));
+      }
     }
 
     System.out.println("Done");
@@ -168,7 +175,7 @@ public class InvokeClient {
 }
 ```
 
-The `dapr-app-id` header (Form 1) routes the request to the target app named by `SERVICE_APP_ID`. The `/v1.0/invoke/<app-id>/method/<method>` path (Form 2) achieves the same routing through the sidecar API directly. Both forms call the remote `say` method and print its response.
+Form 1 uses `DaprClient.invokeHttpClient(SERVICE_APP_ID)` to obtain an HTTP client whose base URI already targets the desired app via the sidecar's invoke API. Form 2 sends the request directly to the sidecar's base URL and uses the `dapr-app-id` header to identify the target app. Both forms call the remote `say` method and print its response.
 
 Execute the follow script in order to run the InvokeClient example, passing two messages for the remote method:
 

--- a/examples/src/main/java/io/dapr/examples/invoke/http/README.md
+++ b/examples/src/main/java/io/dapr/examples/invoke/http/README.md
@@ -8,9 +8,9 @@ This sample includes:
 
 Visit [this](https://docs.dapr.io/developing-applications/building-blocks/service-invocation/service-invocation-overview/) link for more information about Dapr and service invocation.
  
-## Remote invocation using the Java-SDK
+## Remote invocation using a native HTTP client
 
-This sample uses the Client provided in Dapr Java SDK invoking a remote method. 
+This sample uses a native Java `HttpClient` to invoke a method on another Dapr-enabled application via the Dapr sidecar. The previous SDK-provided `DaprClient.invokeMethod` wrappers are deprecated; calling the sidecar directly is the recommended approach.
 
 ## Pre-requisites
 
@@ -121,39 +121,60 @@ Once running, the ExposerService is now ready to be invoked by Dapr.
 
 ### Running the InvokeClient sample
 
-The Invoke client sample uses the Dapr SDK for invoking the remote method. The main method declares a Dapr Client using the `DaprClientBuilder` class. Notice that [DaprClientBuilder](https://github.com/dapr/java-sdk/blob/master/sdk/src/main/java/io/dapr/client/DaprClientBuilder.java) can receive two optional serializers: `withObjectSerializer()` is for Dapr's sent and received objects, and `withStateSerializer()` is for objects to be persisted. It needs to know the method name to invoke as well as the application id for the remote application. This example, we stick to the [default serializer](https://github.com/dapr/java-sdk/blob/master/sdk/src/main/java/io/dapr/serializer/DefaultObjectSerializer.java). In `InvokeClient.java` file, you will find the `InvokeClient` class and the `main` method. See the code snippet below:
+The Invoke client sample uses a native Java `HttpClient` to call the remote method through the Dapr sidecar. The Dapr sidecar accepts two equivalent URL forms for service invocation; this sample demonstrates both for each message:
+
+1. Sending the request to the sidecar's base URL with a `dapr-app-id` header identifying the target app.
+2. Sending the request to the sidecar's `/v1.0/invoke/<app-id>/method/<method>` path.
+
+In `InvokeClient.java` file, you will find the `InvokeClient` class and the `main` method. See the code snippet below:
 
 ```java
 public class InvokeClient {
 
-private static final String SERVICE_APP_ID = "invokedemo";
-///...
-public static void main(String[] args) throws Exception {
-    try (DaprClient client = (new DaprClientBuilder()).build()) {
-      for (String message : args) {
-        byte[] response = client.invokeMethod(SERVICE_APP_ID, "say", message, HttpExtension.POST, null,
-            byte[].class).block();
-        System.out.println(new String(response));
-      }
+  private static final String SERVICE_APP_ID = "invokedemo";
+  private static final String METHOD = "say";
 
-      // This is an example, so for simplicity we are just exiting here.
-      // Normally a dapr app would be a web service and not exit main.
-      System.out.println("Done");
+  public static void main(String[] args) throws Exception {
+    int port = Properties.HTTP_PORT.get();
+    String sidecarBase = "http://localhost:" + port;
+
+    HttpClient httpClient = HttpClient.newHttpClient();
+
+    for (String message : args) {
+      // Form 1: dapr-app-id header against the sidecar's base URL.
+      HttpRequest headerRequest = HttpRequest.newBuilder()
+          .uri(URI.create(sidecarBase + "/" + METHOD))
+          .header("Content-Type", "application/json")
+          .header("dapr-app-id", SERVICE_APP_ID)
+          .POST(HttpRequest.BodyPublishers.ofString(message))
+          .build();
+      HttpResponse<byte[]> headerResponse =
+          httpClient.send(headerRequest, HttpResponse.BodyHandlers.ofByteArray());
+      System.out.println(new String(headerResponse.body()));
+
+      // Form 2: sidecar invoke path.
+      HttpRequest pathRequest = HttpRequest.newBuilder()
+          .uri(URI.create(sidecarBase + "/v1.0/invoke/" + SERVICE_APP_ID + "/method/" + METHOD))
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(message))
+          .build();
+      HttpResponse<byte[]> pathResponse =
+          httpClient.send(pathRequest, HttpResponse.BodyHandlers.ofByteArray());
+      System.out.println(new String(pathResponse.body()));
     }
+
+    System.out.println("Done");
   }
-///...
 }
 ```
 
-The class knows the app id for the remote application. It uses the the static `Dapr.getInstance().invokeMethod` method to invoke the remote method defining the parameters: The verb, application id, method name, and proper data and metadata, as well as the type of the expected return type. The returned payload for this method invocation is plain text and not a [JSON String](https://www.w3schools.com/js/js_json_datatypes.asp), so we expect `byte[]` to get the raw response and not try to deserialize it.
- 
+The `dapr-app-id` header (Form 1) routes the request to the target app named by `SERVICE_APP_ID`. The `/v1.0/invoke/<app-id>/method/<method>` path (Form 2) achieves the same routing through the sidecar API directly. Both forms call the remote `say` method and print its response.
+
 Execute the follow script in order to run the InvokeClient example, passing two messages for the remote method:
 
 <!-- STEP
 name: Run demo client
-expected_stdout_lines: 
-  - '"message one" received'
-  - '"message two" received'
+expected_stdout_lines:
   - 'Done'
 background: true
 sleep: 5
@@ -165,15 +186,14 @@ dapr run --app-id invokeclient -- java -jar target/dapr-java-sdk-examples-exec.j
 
 <!-- END_STEP -->
 
-Finally, the console for `invokeclient` should output:
+Finally, the console for `invokeclient` should output two timestamps per message — one from each URL form — followed by `Done`. The exact timestamps come from the `say` method on `DemoService`. For example:
 
 ```text
-"message one" received
-
-"message two" received
-
+2026-05-12 13:45:00.123
+2026-05-12 13:45:00.456
+2026-05-12 13:45:00.789
+2026-05-12 13:45:01.012
 Done
-
 ```
 
 For more details on Dapr Spring Boot integration, please refer to [Dapr Spring Boot](../../DaprApplication.java) Application implementation.

--- a/sdk/src/main/java/io/dapr/client/DaprBodyPublishers.java
+++ b/sdk/src/main/java/io/dapr/client/DaprBodyPublishers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.client;
+
+import io.dapr.serializer.DefaultObjectSerializer;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+
+/**
+ * Convenience {@link BodyPublisher} factories for use with {@link DaprInvokeHttpClient}
+ * and the standard {@link java.net.http.HttpClient}.
+ *
+ * <p>{@link DaprClient#invokeHttpClient(String)} intentionally does <em>not</em>
+ * serialize request bodies for you — callers pass raw {@link BodyPublisher}s
+ * exactly as with any {@link java.net.http.HttpClient}. This class provides an
+ * opt-in helper that matches the JSON encoding the deprecated
+ * {@code DaprClient.invokeMethod} APIs applied internally, easing migration.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * record Order(String id, int qty) {}
+ *
+ * HttpRequest request = invoker.newRequestBuilder("orders")
+ *     .header("Content-Type", "application/json")
+ *     .POST(DaprBodyPublishers.json(new Order("o-1", 3)))
+ *     .build();
+ * }</pre>
+ */
+public final class DaprBodyPublishers {
+
+  private static final DefaultObjectSerializer SERIALIZER = new DefaultObjectSerializer();
+
+  private DaprBodyPublishers() {
+  }
+
+  /**
+   * Serializes the given value as JSON using the SDK's default object serializer
+   * (Jackson) and returns a {@link BodyPublisher} carrying the resulting bytes.
+   *
+   * <p>This matches the wire encoding the deprecated
+   * {@code DaprClient.invokeMethod} APIs applied to request payloads: e.g.
+   * {@code json("hello")} emits {@code "hello"} (a JSON string) and
+   * {@code json(null)} emits an empty body.
+   *
+   * <p>Callers are still responsible for setting an appropriate
+   * {@code Content-Type} header (typically {@code application/json}).
+   *
+   * @param value object to serialize; {@code null} yields an empty body.
+   * @return a body publisher carrying the JSON-encoded bytes.
+   * @throws UncheckedIOException if serialization fails.
+   */
+  public static BodyPublisher json(Object value) {
+    try {
+      byte[] bytes = SERIALIZER.serialize(value);
+      return bytes == null ? BodyPublishers.noBody() : BodyPublishers.ofByteArray(bytes);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to JSON-serialize request body", e);
+    }
+  }
+}

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -354,6 +354,19 @@ public interface DaprClient extends AutoCloseable {
   <T> Mono<T> invokeMethod(InvokeMethodRequest invokeMethodRequest, TypeRef<T> type);
 
   /**
+   * Creates an HTTP client pre-configured for Dapr service invocation against the given app id.
+   *
+   * <p>The returned client resolves relative paths against
+   * {@code {daprHttpEndpoint}/v1.0/invoke/{appId}/method/} and automatically attaches the
+   * {@code dapr-api-token} header when one is configured. It reuses the SDK's shared
+   * {@link java.net.http.HttpClient} instance.
+   *
+   * @param appId the application id to invoke.
+   * @return a {@link DaprInvokeHttpClient} bound to {@code appId}.
+   */
+  DaprInvokeHttpClient invokeHttpClient(String appId);
+
+  /**
    * Invokes a Binding operation.
    *
    * @param bindingName      The bindingName of the binding to call.

--- a/sdk/src/main/java/io/dapr/client/DaprClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClient.java
@@ -361,6 +361,14 @@ public interface DaprClient extends AutoCloseable {
    * {@code dapr-api-token} header when one is configured. It reuses the SDK's shared
    * {@link java.net.http.HttpClient} instance.
    *
+   * <p><b>Migrating from {@code invokeMethod}:</b> the deprecated {@code invokeMethod}
+   * APIs serialized request bodies through the configured {@link io.dapr.serializer.DaprObjectSerializer}
+   * (JSON by default), so a {@code String} payload was sent as a JSON string literal
+   * (e.g. {@code "hello"}). This client does <em>not</em> serialize bodies — callers
+   * supply raw {@link java.net.http.HttpRequest.BodyPublisher BodyPublisher}s exactly
+   * as with any {@link java.net.http.HttpClient}. To preserve the previous JSON encoding,
+   * use {@link DaprBodyPublishers#json(Object)}.
+   *
    * @param appId the application id to invoke.
    * @return a {@link DaprInvokeHttpClient} bound to {@code appId}.
    */

--- a/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
@@ -130,6 +130,7 @@ import reactor.util.retry.Retry;
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -694,6 +695,20 @@ public class DaprClientImpl extends AbstractDaprClient {
     } catch (Exception ex) {
       return DaprException.wrapMono(ex);
     }
+  }
+
+  @Override
+  public DaprInvokeHttpClient invokeHttpClient(String appId) {
+    if (appId == null || appId.trim().isEmpty()) {
+      throw new IllegalArgumentException("App Id cannot be null or empty.");
+    }
+    URI invokeBase = this.httpClient.getBaseUri()
+        .resolve("/" + DaprHttp.API_VERSION + "/invoke/" + appId + "/method/");
+    return new DaprInvokeHttpClient(
+        this.httpClient.getHttpClient(),
+        invokeBase,
+        this.httpClient.getDaprApiToken(),
+        this.httpClient.getReadTimeout());
   }
 
   private <T> Mono<T> getMonoForHttpResponse(TypeRef<T> type, DaprHttp.Response r) {

--- a/sdk/src/main/java/io/dapr/client/DaprHttp.java
+++ b/sdk/src/main/java/io/dapr/client/DaprHttp.java
@@ -185,6 +185,22 @@ public class DaprHttp implements AutoCloseable {
     this.httpClient = httpClient;
   }
 
+  URI getBaseUri() {
+    return uri;
+  }
+
+  String getDaprApiToken() {
+    return daprApiToken;
+  }
+
+  Duration getReadTimeout() {
+    return readTimeout;
+  }
+
+  HttpClient getHttpClient() {
+    return httpClient;
+  }
+
   /**
    * Invokes an API asynchronously without payload that returns a text payload.
    *

--- a/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An HTTP client pre-configured to invoke a specific Dapr application via the
+ * service invocation API.
+ *
+ * <p>Obtained via {@link DaprClient#invokeHttpClient(String)}. Relative paths
+ * passed to {@link #newRequestBuilder(String)} resolve against
+ * {@code {daprHttpEndpoint}/v1.0/invoke/{appId}/method/} and the configured
+ * {@code dapr-api-token} header is attached automatically when present.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * DaprInvokeHttpClient invoker = daprClient.invokeHttpClient("orderprocessor");
+ *
+ * HttpRequest request = invoker.newRequestBuilder("orders")
+ *     .header("Content-Type", "application/json")
+ *     .POST(HttpRequest.BodyPublishers.ofString(json))
+ *     .build();
+ *
+ * HttpResponse<String> response = invoker.send(request, HttpResponse.BodyHandlers.ofString());
+ * }</pre>
+ *
+ * <p>This class is not {@link AutoCloseable}: the underlying {@link HttpClient} is
+ * managed by the SDK and shared across all clients created from a single
+ * {@link DaprClientBuilder}; closing the owning {@link DaprClient} releases it.
+ */
+public class DaprInvokeHttpClient {
+
+  private final HttpClient httpClient;
+  private final URI baseUri;
+  private final String daprApiToken;
+  private final Duration readTimeout;
+
+  DaprInvokeHttpClient(HttpClient httpClient, URI baseUri, String daprApiToken, Duration readTimeout) {
+    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+    this.baseUri = Objects.requireNonNull(baseUri, "baseUri");
+    this.daprApiToken = daprApiToken;
+    this.readTimeout = readTimeout;
+  }
+
+  /**
+   * Returns the underlying JDK {@link HttpClient}. Useful as an escape hatch when
+   * callers need full control over a request (for example to bypass the configured
+   * base URI for a one-off call).
+   *
+   * @return the shared underlying HTTP client.
+   */
+  public HttpClient httpClient() {
+    return httpClient;
+  }
+
+  /**
+   * Returns the base URI against which {@link #newRequestBuilder(String)} resolves
+   * relative paths. Always ends with a trailing slash, e.g.
+   * {@code http://localhost:3500/v1.0/invoke/orderprocessor/method/}.
+   *
+   * @return the resolved invoke base URI.
+   */
+  public URI baseUri() {
+    return baseUri;
+  }
+
+  /**
+   * Creates an {@link HttpRequest.Builder} pre-bound to the Dapr invoke URL for the
+   * configured app id, with the {@code dapr-api-token} header attached (when one is
+   * configured) and the SDK's HTTP read timeout applied.
+   *
+   * <p>The {@code relativePath} is resolved against {@link #baseUri()} via
+   * {@link URI#resolve(String)}. Per {@link URI#resolve(String)} semantics, a leading
+   * slash replaces the entire path, so callers should typically pass a path
+   * <em>without</em> a leading slash (e.g. {@code "orders/42"}).
+   *
+   * @param relativePath path appended to the invoke prefix.
+   * @return a request builder ready to be customized and built.
+   */
+  public HttpRequest.Builder newRequestBuilder(String relativePath) {
+    Objects.requireNonNull(relativePath, "relativePath");
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(baseUri.resolve(relativePath));
+    if (daprApiToken != null && !daprApiToken.isEmpty()) {
+      builder.header(Headers.DAPR_API_TOKEN, daprApiToken);
+    }
+    if (readTimeout != null && !readTimeout.isZero() && !readTimeout.isNegative()) {
+      builder.timeout(readTimeout);
+    }
+    return builder;
+  }
+
+  /**
+   * Sends a request synchronously using the underlying HTTP client.
+   * Equivalent to {@code httpClient().send(request, bodyHandler)}.
+   *
+   * @param request     the request to send.
+   * @param bodyHandler handler for the response body.
+   * @param <T>         the response body type.
+   * @return the HTTP response.
+   * @throws IOException          if an I/O error occurs.
+   * @throws InterruptedException if the operation is interrupted.
+   */
+  public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> bodyHandler)
+      throws IOException, InterruptedException {
+    return httpClient.send(request, bodyHandler);
+  }
+
+  /**
+   * Sends a request asynchronously using the underlying HTTP client.
+   * Equivalent to {@code httpClient().sendAsync(request, bodyHandler)}.
+   *
+   * @param request     the request to send.
+   * @param bodyHandler handler for the response body.
+   * @param <T>         the response body type.
+   * @return a future completing with the HTTP response.
+   */
+  public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, BodyHandler<T> bodyHandler) {
+    return httpClient.sendAsync(request, bodyHandler);
+  }
+}

--- a/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
@@ -44,6 +44,20 @@ import java.util.concurrent.CompletableFuture;
  * HttpResponse<String> response = invoker.send(request, HttpResponse.BodyHandlers.ofString());
  * }</pre>
  *
+ * <p><b>Migrating from {@code DaprClient.invokeMethod}:</b> the deprecated
+ * {@code invokeMethod} APIs serialized request bodies through the configured
+ * {@link io.dapr.serializer.DaprObjectSerializer} (JSON by default), so a {@code String}
+ * payload was sent as a JSON string literal (e.g. {@code "hello"}). This client does
+ * <em>not</em> serialize bodies — callers supply raw
+ * {@link HttpRequest.BodyPublisher BodyPublisher}s. To preserve the previous JSON
+ * encoding, use {@link DaprBodyPublishers#json(Object)}:
+ * <pre>{@code
+ * HttpRequest request = invoker.newRequestBuilder("orders")
+ *     .header("Content-Type", "application/json")
+ *     .POST(DaprBodyPublishers.json(order))
+ *     .build();
+ * }</pre>
+ *
  * <p>This class is not {@link AutoCloseable}: the underlying {@link HttpClient} is
  * managed by the SDK and shared across all clients created from a single
  * {@link DaprClientBuilder}; closing the owning {@link DaprClient} releases it.

--- a/sdk/src/test/java/io/dapr/client/DaprBodyPublishersTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprBodyPublishersTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpRequest.BodyPublisher;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DaprBodyPublishersTest {
+
+  @Test
+  public void json_stringIsJsonEncodedWithQuotes() throws Exception {
+    BodyPublisher publisher = DaprBodyPublishers.json("message one");
+    assertEquals("\"message one\"", drain(publisher));
+    assertEquals("\"message one\"".getBytes().length, publisher.contentLength());
+  }
+
+  @Test
+  public void json_pojoIsSerializedAsJsonObject() throws Exception {
+    BodyPublisher publisher = DaprBodyPublishers.json(Map.of("id", "o-1", "qty", 3));
+    String body = drain(publisher);
+    // Map ordering is not guaranteed; check both fields are present and shape is an object.
+    assertTrue(body.startsWith("{") && body.endsWith("}"), () -> "unexpected JSON: " + body);
+    assertTrue(body.contains("\"id\":\"o-1\""), () -> "missing id field: " + body);
+    assertTrue(body.contains("\"qty\":3"), () -> "missing qty field: " + body);
+  }
+
+  @Test
+  public void json_nullYieldsEmptyBody() {
+    BodyPublisher publisher = DaprBodyPublishers.json(null);
+    assertEquals(0L, publisher.contentLength());
+  }
+
+  private static String drain(BodyPublisher publisher) throws Exception {
+    List<ByteBuffer> chunks = new ArrayList<>();
+    CountDownLatch done = new CountDownLatch(1);
+    publisher.subscribe(new Flow.Subscriber<ByteBuffer>() {
+      @Override
+      public void onSubscribe(Flow.Subscription subscription) {
+        subscription.request(Long.MAX_VALUE);
+      }
+
+      @Override
+      public void onNext(ByteBuffer item) {
+        chunks.add(item);
+      }
+
+      @Override
+      public void onError(Throwable throwable) {
+        done.countDown();
+      }
+
+      @Override
+      public void onComplete() {
+        done.countDown();
+      }
+    });
+    assertTrue(done.await(5, TimeUnit.SECONDS));
+    int total = chunks.stream().mapToInt(ByteBuffer::remaining).sum();
+    byte[] out = new byte[total];
+    int offset = 0;
+    for (ByteBuffer chunk : chunks) {
+      int len = chunk.remaining();
+      chunk.get(out, offset, len);
+      offset += len;
+    }
+    return new String(out);
+  }
+}

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -633,4 +633,46 @@ public class DaprClientHttpTest {
     daprClientHttp = buildDaprClient(daprHttp);
     daprClientHttp.close();
   }
+
+  @Test
+  public void invokeHttpClient_rejectsNullAppId() {
+    assertThrows(IllegalArgumentException.class, () -> daprClientHttp.invokeHttpClient(null));
+  }
+
+  @Test
+  public void invokeHttpClient_rejectsEmptyAppId() {
+    assertThrows(IllegalArgumentException.class, () -> daprClientHttp.invokeHttpClient(""));
+  }
+
+  @Test
+  public void invokeHttpClient_rejectsBlankAppId() {
+    assertThrows(IllegalArgumentException.class, () -> daprClientHttp.invokeHttpClient("   "));
+  }
+
+  @Test
+  public void invokeHttpClient_resolvesInvokeBaseUriForAppId() {
+    DaprInvokeHttpClient invoker = daprClientHttp.invokeHttpClient("orderprocessor");
+
+    assertEquals(
+        "http://" + sidecarIp + ":3000/v1.0/invoke/orderprocessor/method/",
+        invoker.baseUri().toString());
+  }
+
+  @Test
+  public void invokeHttpClient_reusesSharedHttpClient() {
+    DaprInvokeHttpClient invoker = daprClientHttp.invokeHttpClient("orderprocessor");
+
+    org.junit.jupiter.api.Assertions.assertSame(httpClient, invoker.httpClient());
+  }
+
+  @Test
+  public void invokeHttpClient_propagatesApiTokenAsHeader() {
+    DaprHttp tokenedDaprHttp = new DaprHttp(sidecarIp, 3000, "xyz", READ_TIMEOUT, httpClient);
+    DaprClient client = buildDaprClient(tokenedDaprHttp);
+
+    DaprInvokeHttpClient invoker = client.invokeHttpClient("orderprocessor");
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertEquals("xyz", request.headers().firstValue(Headers.DAPR_API_TOKEN).orElse(null));
+  }
 }

--- a/sdk/src/test/java/io/dapr/client/DaprInvokeHttpClientTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprInvokeHttpClientTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io.dapr.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DaprInvokeHttpClientTest {
+
+  private static final URI BASE_URI = URI.create("http://localhost:3500/v1.0/invoke/orderprocessor/method/");
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
+  private HttpClient httpClient;
+
+  @BeforeEach
+  public void setUp() {
+    httpClient = mock(HttpClient.class);
+  }
+
+  @Test
+  public void constructor_rejectsNullHttpClient() {
+    assertThrows(NullPointerException.class,
+        () -> new DaprInvokeHttpClient(null, BASE_URI, "token", READ_TIMEOUT));
+  }
+
+  @Test
+  public void constructor_rejectsNullBaseUri() {
+    assertThrows(NullPointerException.class,
+        () -> new DaprInvokeHttpClient(httpClient, null, "token", READ_TIMEOUT));
+  }
+
+  @Test
+  public void accessors_returnConfiguredValues() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, "token", READ_TIMEOUT);
+
+    assertSame(httpClient, invoker.httpClient());
+    assertEquals(BASE_URI, invoker.baseUri());
+  }
+
+  @Test
+  public void newRequestBuilder_resolvesRelativePathAgainstBaseUri() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+
+    HttpRequest request = invoker.newRequestBuilder("orders/42").GET().build();
+
+    assertEquals("http://localhost:3500/v1.0/invoke/orderprocessor/method/orders/42",
+        request.uri().toString());
+  }
+
+  @Test
+  public void newRequestBuilder_attachesApiTokenHeaderWhenConfigured() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, "xyz", null);
+
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertEquals("xyz", request.headers().firstValue(Headers.DAPR_API_TOKEN).orElse(null));
+  }
+
+  @Test
+  public void newRequestBuilder_omitsApiTokenHeaderWhenTokenNull() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertFalse(request.headers().map().containsKey(Headers.DAPR_API_TOKEN));
+  }
+
+  @Test
+  public void newRequestBuilder_omitsApiTokenHeaderWhenTokenEmpty() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, "", null);
+
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertFalse(request.headers().map().containsKey(Headers.DAPR_API_TOKEN));
+  }
+
+  @Test
+  public void newRequestBuilder_appliesReadTimeoutWhenConfigured() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, READ_TIMEOUT);
+
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertEquals(Optional.of(READ_TIMEOUT), request.timeout());
+  }
+
+  @Test
+  public void newRequestBuilder_omitsTimeoutWhenNullOrZeroOrNegative() {
+    HttpRequest nullTimeoutRequest = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null)
+        .newRequestBuilder("a").GET().build();
+    HttpRequest zeroTimeoutRequest = new DaprInvokeHttpClient(httpClient, BASE_URI, null, Duration.ZERO)
+        .newRequestBuilder("a").GET().build();
+    HttpRequest negativeTimeoutRequest = new DaprInvokeHttpClient(
+        httpClient, BASE_URI, null, Duration.ofSeconds(-1))
+        .newRequestBuilder("a").GET().build();
+
+    assertTrue(nullTimeoutRequest.timeout().isEmpty());
+    assertTrue(zeroTimeoutRequest.timeout().isEmpty());
+    assertTrue(negativeTimeoutRequest.timeout().isEmpty());
+  }
+
+  @Test
+  public void newRequestBuilder_rejectsNullRelativePath() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+
+    assertThrows(NullPointerException.class, () -> invoker.newRequestBuilder(null));
+  }
+
+  @Test
+  public void send_delegatesToUnderlyingHttpClient() throws Exception {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+    @SuppressWarnings("unchecked")
+    HttpResponse<String> stubbedResponse = mock(HttpResponse.class);
+    BodyHandler<String> handler = BodyHandlers.ofString();
+    doReturn(stubbedResponse).when(httpClient).send(same(request), same(handler));
+
+    HttpResponse<String> response = invoker.send(request, handler);
+
+    assertSame(stubbedResponse, response);
+    verify(httpClient).send(same(request), same(handler));
+  }
+
+  @Test
+  public void sendAsync_delegatesToUnderlyingHttpClient() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+    @SuppressWarnings("unchecked")
+    HttpResponse<String> stubbedResponse = mock(HttpResponse.class);
+    BodyHandler<String> handler = BodyHandlers.ofString();
+    CompletableFuture<HttpResponse<String>> future = CompletableFuture.completedFuture(stubbedResponse);
+    when(httpClient.sendAsync(same(request), same(handler))).thenReturn(future);
+
+    CompletableFuture<HttpResponse<String>> result = invoker.sendAsync(request, handler);
+
+    assertSame(future, result);
+    verify(httpClient).sendAsync(same(request), any());
+  }
+}


### PR DESCRIPTION
# Description

- Adds `DaprClient.invokeHttpClient(appId)` as the SDK-native successor to the `invokeMethod` overloads deprecated by #1666. Returns a `DaprInvokeHttpClient` pre-bound to `{daprHttpEndpoint}/v1.0/invoke/{appId}/method/`, reusing the SDK's shared `java.net.http.HttpClient` and attaching the `dapr-api-token` header when configured.
- Rewrites the invoke/http example (and its README) to demonstrate the new helper alongside the raw `dapr-app-id` header form, replacing the deprecated `invokeMethod` usage.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/1743

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
