### PR TITLE
fix(release): install dapr-sdk-bom locally before bumping dapr-spring-bom

### DIFF
--- a/.github/scripts/update_sdk_version.sh
+++ b/.github/scripts/update_sdk_version.sh
@@ -15,6 +15,8 @@ mvn versions:set-property -Dproperty=dapr.sdk.version -DnewVersion=$DAPR_JAVA_SD
 # BOMs are standalone (no parent), so versions:set skips them — update explicitly.
 mvn versions:set -DnewVersion=$DAPR_JAVA_SDK_VERSION -f sdk-bom/pom.xml
 mvn versions:set-property -Dproperty=dapr.sdk.version -DnewVersion=$DAPR_JAVA_SDK_VERSION -f sdk-bom/pom.xml
+# Install dapr-sdk-bom locally so dapr-spring-bom's import can resolve when loaded with -f (no reactor).
+mvn install -N -DskipTests -f sdk-bom/pom.xml
 mvn versions:set -DnewVersion=$DAPR_JAVA_SDK_VERSION -f dapr-spring/dapr-spring-bom/pom.xml
 mvn versions:set-property -Dproperty=dapr.sdk.version -DnewVersion=$DAPR_JAVA_SDK_VERSION -f dapr-spring/dapr-spring-bom/pom.xml
 mvn versions:set-property -Dproperty=dapr.sdk.alpha.version -DnewVersion=$DAPR_JAVA_SDK_ALPHA_VERSION -f sdk-tests/pom.xml


### PR DESCRIPTION


The release script bumps the dapr.sdk.version property in all reactor POMs (including dapr-spring-bom) before bumping the standalone BOMs. The later 'mvn versions:set -f dapr-spring/dapr-spring-bom/pom.xml' runs in single-POM mode (no reactor) and tries to resolve the import dapr-sdk-bom at the new version, which is not yet installed.

Install sdk-bom into the local repo between the two BOM updates so the import resolves.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
