### PR TITLE
feat: attach SDK User-Agent

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprBodyPublishers.java
+++ b/sdk/src/main/java/io/dapr/client/DaprBodyPublishers.java
@@ -59,6 +59,18 @@ public final class DaprBodyPublishers {
    * <p>Callers are still responsible for setting an appropriate
    * {@code Content-Type} header (typically {@code application/json}).
    *
+   * <p>This helper is a convenience for the default-serializer case. It does
+   * <em>not</em> honor a custom {@link io.dapr.serializer.DaprObjectSerializer}
+   * configured on the {@link DaprClientBuilder}. Callers with a custom serializer
+   * should serialize the value themselves and wrap the resulting bytes:
+   * <pre>{@code
+   * byte[] bytes = mySerializer.serialize(value);
+   * BodyPublisher body = HttpRequest.BodyPublishers.ofByteArray(bytes);
+   * }</pre>
+   * The only behavior this helper adds over a direct {@code ofByteArray} call is
+   * choosing a length-known {@link BodyPublisher} so the JDK emits
+   * {@code Content-Length} rather than {@code Transfer-Encoding: chunked}.
+   *
    * @param value object to serialize; {@code null} yields an empty body.
    * @return a body publisher carrying the JSON-encoded bytes.
    * @throws UncheckedIOException if serialization fails.

--- a/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
+++ b/sdk/src/main/java/io/dapr/client/DaprInvokeHttpClient.java
@@ -13,6 +13,8 @@ limitations under the License.
 
 package io.dapr.client;
 
+import io.dapr.utils.Version;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -100,8 +102,9 @@ public class DaprInvokeHttpClient {
 
   /**
    * Creates an {@link HttpRequest.Builder} pre-bound to the Dapr invoke URL for the
-   * configured app id, with the {@code dapr-api-token} header attached (when one is
-   * configured) and the SDK's HTTP read timeout applied.
+   * configured app id, with the SDK {@code User-Agent} header attached, the
+   * {@code dapr-api-token} header attached (when one is configured) and the SDK's
+   * HTTP read timeout applied.
    *
    * <p>The {@code relativePath} is resolved against {@link #baseUri()} via
    * {@link URI#resolve(String)}. Per {@link URI#resolve(String)} semantics, a leading
@@ -113,7 +116,9 @@ public class DaprInvokeHttpClient {
    */
   public HttpRequest.Builder newRequestBuilder(String relativePath) {
     Objects.requireNonNull(relativePath, "relativePath");
-    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(baseUri.resolve(relativePath));
+    HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(baseUri.resolve(relativePath))
+        .header(Headers.DAPR_USER_AGENT, Version.getSdkVersion());
     if (daprApiToken != null && !daprApiToken.isEmpty()) {
       builder.header(Headers.DAPR_API_TOKEN, daprApiToken);
     }

--- a/sdk/src/test/java/io/dapr/client/DaprInvokeHttpClientTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprInvokeHttpClientTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 
 package io.dapr.client;
 
+import io.dapr.utils.Version;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -78,6 +79,16 @@ public class DaprInvokeHttpClientTest {
 
     assertEquals("http://localhost:3500/v1.0/invoke/orderprocessor/method/orders/42",
         request.uri().toString());
+  }
+
+  @Test
+  public void newRequestBuilder_attachesSdkUserAgentHeader() {
+    DaprInvokeHttpClient invoker = new DaprInvokeHttpClient(httpClient, BASE_URI, null, null);
+
+    HttpRequest request = invoker.newRequestBuilder("orders").GET().build();
+
+    assertEquals(Version.getSdkVersion(),
+        request.headers().firstValue(Headers.DAPR_USER_AGENT).orElse(null));
   }
 
   @Test


### PR DESCRIPTION
# Description

newRequestBuilder now sets the User-Agent header to the SDK version, matching what the deprecated invokeMethod path emitted via DaprHttp. This is the only default the SDK can supply that callers cannot, and it is useful for runtime side triage. Other implicit invokeMethod behaviors (Content-Type default, request-id, error mapping, trace propagation) are intentionally left to the caller, since exposing the native HttpClient is the point of the migration.

Also document on DaprBodyPublishers.json that the helper uses the SDK's default object serializer and is not a wrapper around a configured custom DaprObjectSerializer. Its only contribution over a plain ofByteArray call is guaranteeing a length-known BodyPublisher, which keeps the JDK on Content-Length framing and sidesteps the Transfer-Encoding: chunked race reported under load.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
