### PR TITLE
fix: remove usage of reserved per-action router fields

### DIFF
--- a/durabletask-client/src/main/java/io/dapr/durabletask/TaskOrchestrationExecutor.java
+++ b/durabletask-client/src/main/java/io/dapr/durabletask/TaskOrchestrationExecutor.java
@@ -424,18 +424,6 @@ public final class TaskOrchestrationExecutor {
         scheduleTaskBuilder.setInput(StringValue.of(serializedInput));
       }
 
-      // Add router information for cross-app routing
-      if (hasSourceAppId() && hasTargetAppId(options)) {
-        String targetAppId = options.getAppID();
-        scheduleTaskBuilder.setRouter(Orchestration.TaskRouter.newBuilder()
-            .setSourceAppID(this.appId)
-            .setTargetAppID(targetAppId)
-            .build());
-        this.logger.fine(() -> String.format(
-            "cross app routing detected: source=%s, target=%s",
-            this.appId, targetAppId));
-      }
-
       // Set history propagation scope if specified
       if (options != null && options.hasHistoryPropagationScope()) {
         scheduleTaskBuilder.setHistoryPropagationScope(
@@ -449,10 +437,14 @@ public final class TaskOrchestrationExecutor {
             .setId(id)
             .setScheduleTask(scheduleTaskBuilder);
         if (hasSourceAppId() && hasTargetAppId(options)) {
+          String targetAppId = options.getAppID();
           actionBuilder.setRouter(Orchestration.TaskRouter.newBuilder()
               .setSourceAppID(this.appId)
-              .setTargetAppID(options.getAppID())
+              .setTargetAppID(targetAppId)
               .build());
+          this.logger.fine(() -> String.format(
+              "cross app routing detected: source=%s, target=%s",
+              this.appId, targetAppId));
         }
         this.pendingActions.put(id, actionBuilder.build());
 
@@ -597,22 +589,6 @@ public final class TaskOrchestrationExecutor {
       }
       createSubOrchestrationActionBuilder.setInstanceId(instanceId);
 
-      // Add router information for cross-app routing of sub-orchestrations
-      if (hasSourceAppId()) {
-        Orchestration.TaskRouter.Builder routerBuilder = Orchestration.TaskRouter.newBuilder()
-            .setSourceAppID(this.appId);
-
-        // Add target app ID if specified in options
-        if (hasTargetAppId(options)) {
-          routerBuilder.setTargetAppID(options.getAppID());
-          this.logger.fine(() -> String.format(
-              "cross app sub-orchestration routing detected: source=%s, target=%s",
-              this.appId, options.getAppID()));
-        }
-
-        createSubOrchestrationActionBuilder.setRouter(routerBuilder.build());
-      }
-
       // Set history propagation scope if specified
       if (options != null && options.hasHistoryPropagationScope()) {
         createSubOrchestrationActionBuilder.setHistoryPropagationScope(
@@ -632,6 +608,9 @@ public final class TaskOrchestrationExecutor {
               .setSourceAppID(this.appId);
           if (hasTargetAppId(options)) {
             actionRouterBuilder.setTargetAppID(options.getAppID());
+            this.logger.fine(() -> String.format(
+                "cross app sub-orchestration routing detected: source=%s, target=%s",
+                this.appId, options.getAppID()));
           }
           actionBuilder.setRouter(actionRouterBuilder.build());
         }

--- a/durabletask-client/src/test/java/io/dapr/durabletask/HistoryPropagationIntegrationTest.java
+++ b/durabletask-client/src/test/java/io/dapr/durabletask/HistoryPropagationIntegrationTest.java
@@ -527,10 +527,6 @@ class HistoryPropagationIntegrationTest {
     OrchestratorActions.CreateChildWorkflowAction createChild = action.getCreateChildWorkflow();
 
     // Verify BOTH cross-app routing and history propagation are set
-    assertTrue(createChild.hasRouter());
-    assertEquals(sourceAppId, createChild.getRouter().getSourceAppID());
-    assertEquals(targetAppId, createChild.getRouter().getTargetAppID());
-
     assertTrue(createChild.hasHistoryPropagationScope());
     assertEquals(Orchestration.HistoryPropagationScope.HISTORY_PROPAGATION_SCOPE_LINEAGE,
         createChild.getHistoryPropagationScope());

--- a/durabletask-client/src/test/java/io/dapr/durabletask/SubOrchestrationCrossAppTest.java
+++ b/durabletask-client/src/test/java/io/dapr/durabletask/SubOrchestrationCrossAppTest.java
@@ -151,16 +151,11 @@ class SubOrchestrationCrossAppTest {
     OrchestratorActions.WorkflowAction action = actions.get(0);
     assertTrue(action.hasCreateChildWorkflow());
 
-    // Verify the CreateSubOrchestrationAction has the router
     OrchestratorActions.CreateChildWorkflowAction createSub = action.getCreateChildWorkflow();
     assertEquals(subOrchestratorName, createSub.getName());
     assertEquals("child-instance-1", createSub.getInstanceId());
-    assertTrue(createSub.hasRouter());
-    assertEquals(sourceAppId, createSub.getRouter().getSourceAppID());
-    assertTrue(createSub.getRouter().hasTargetAppID());
-    assertEquals(targetAppId, createSub.getRouter().getTargetAppID());
 
-    // Verify the OrchestratorAction also has the router
+    // Verify the OrchestratorAction has the router
     assertTrue(action.hasRouter());
     assertEquals(sourceAppId, action.getRouter().getSourceAppID());
     assertTrue(action.getRouter().hasTargetAppID());
@@ -198,13 +193,7 @@ class SubOrchestrationCrossAppTest {
     OrchestratorActions.WorkflowAction action = actions.get(0);
     assertTrue(action.hasCreateChildWorkflow());
 
-    // Router should have source only, no target
-    OrchestratorActions.CreateChildWorkflowAction createSub = action.getCreateChildWorkflow();
-    assertTrue(createSub.hasRouter());
-    assertEquals(sourceAppId, createSub.getRouter().getSourceAppID());
-    assertFalse(createSub.getRouter().hasTargetAppID());
-
-    // OrchestratorAction router should also have source only
+    // OrchestratorAction router should have source only, no target
     assertTrue(action.hasRouter());
     assertEquals(sourceAppId, action.getRouter().getSourceAppID());
     assertFalse(action.getRouter().hasTargetAppID());
@@ -239,8 +228,6 @@ class SubOrchestrationCrossAppTest {
     assertTrue(action.hasCreateChildWorkflow());
 
     // No router should be set when appId is null
-    OrchestratorActions.CreateChildWorkflowAction createSub = action.getCreateChildWorkflow();
-    assertFalse(createSub.hasRouter());
     assertFalse(action.hasRouter());
   }
 
@@ -489,11 +476,6 @@ class SubOrchestrationCrossAppTest {
     assertEquals(subOrchestratorName, createSub.getName());
     assertEquals("child-id-1", createSub.getInstanceId());
 
-    // Verify cross-app router on the sub-orchestration action
-    assertTrue(createSub.hasRouter());
-    assertEquals(sourceAppId, createSub.getRouter().getSourceAppID());
-    assertEquals(targetAppId, createSub.getRouter().getTargetAppID());
-
     // Verify cross-app router on the OrchestratorAction envelope
     assertTrue(subAction.hasRouter());
     assertEquals(sourceAppId, subAction.getRouter().getSourceAppID());
@@ -527,7 +509,6 @@ class SubOrchestrationCrossAppTest {
     assertTrue(action.hasCreateChildWorkflow());
 
     // No router should be set when appId is empty
-    assertFalse(action.getCreateChildWorkflow().hasRouter());
     assertFalse(action.hasRouter());
   }
 
@@ -569,9 +550,8 @@ class SubOrchestrationCrossAppTest {
     OrchestratorActions.WorkflowAction action = actions.get(0);
     assertTrue(action.hasCreateChildWorkflow());
 
-    OrchestratorActions.CreateChildWorkflowAction createSub = action.getCreateChildWorkflow();
-    assertTrue(createSub.hasRouter());
-    assertEquals(sourceAppId, createSub.getRouter().getSourceAppID());
-    assertEquals(targetAppId, createSub.getRouter().getTargetAppID());
+    assertTrue(action.hasRouter());
+    assertEquals(sourceAppId, action.getRouter().getSourceAppID());
+    assertEquals(targetAppId, action.getRouter().getTargetAppID());
   }
 }


### PR DESCRIPTION
dapr/durabletask-protobuf#51 reserved the unused router fields on ScheduleTaskAction (4) and CreateChildWorkflowAction (5), which broke compilation since protos are downloaded from main at build time.

The runtime only reads the enclosing WorkflowAction.router, which was always set alongside the inner ones, so dropping the inner setters and their test assertions has no behavior change.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
