### PR TITLE
fix: bump dependencies for CVE fixes on release-1.17

### DIFF
--- a/dapr-spring/dapr-spring-6-data/pom.xml
+++ b/dapr-spring/dapr-spring-6-data/pom.xml
@@ -17,13 +17,22 @@
   <packaging>jar</packaging>
 
   <properties>
-    <springboot4.version>4.0.5</springboot4.version>
+    <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+    <springboot4.version>4.0.6</springboot4.version>
     <!-- Override JUnit version to align with Spring Boot 4.x -->
     <junit-bom.version>6.0.2</junit-bom.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- Override Jackson 2.x for CVE-2026-54512..54518 (must precede SB BOM) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/dapr-spring/dapr-spring-boot-4-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-4-autoconfigure/pom.xml
@@ -16,18 +16,35 @@
   <packaging>jar</packaging>
 
   <properties>
-    <springboot4.version>4.0.5</springboot4.version>
+    <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+    <springboot4.version>4.0.6</springboot4.version>
     <!-- Override JUnit version to align with Spring Boot 4.0.x -->
     <junit-bom.version>6.0.2</junit-bom.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Override Jackson 3.x for CVE SNYK-JAVA-TOOLSJACKSONCORE-15907550 (must precede SB BOM) -->
+      <!-- Override Jackson 3.x for CVE SNYK-JAVA-TOOLSJACKSONCORE-15907550 and CVE-2026-54512..54518 (must precede SB BOM) -->
       <dependency>
         <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override Jackson 2.x for CVE-2026-54512..54518 (must precede SB BOM) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override OTel for CVE-2026-45292 (must precede SB BOM) -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter-test/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter-test/pom.xml
@@ -16,12 +16,29 @@
     <packaging>jar</packaging>
 
     <properties>
-      <springboot4.version>4.0.5</springboot4.version>
+      <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+      <springboot4.version>4.0.6</springboot4.version>
       <!-- Override JUnit version to align with Spring Boot 4.x -->
       <junit-bom.version>6.0.2</junit-bom.version>
     </properties>
     <dependencyManagement>
       <dependencies>
+        <!-- Override Jackson 2.x for CVE-2026-54512..54518 (must precede SB BOM) -->
+        <dependency>
+          <groupId>com.fasterxml.jackson</groupId>
+          <artifactId>jackson-bom</artifactId>
+          <version>${jackson.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+        <!-- Override OTel for CVE-2026-45292 (must precede SB BOM) -->
+        <dependency>
+          <groupId>io.opentelemetry</groupId>
+          <artifactId>opentelemetry-bom</artifactId>
+          <version>${opentelemetry.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
         <dependency>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-dependencies</artifactId>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-4-starter/pom.xml
@@ -16,13 +16,30 @@
   <packaging>jar</packaging>
 
   <properties>
-    <springboot4.version>4.0.5</springboot4.version>
+    <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+    <springboot4.version>4.0.6</springboot4.version>
     <!-- Override JUnit version to align with Spring Boot 4.x -->
     <junit-bom.version>6.0.2</junit-bom.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- Override Jackson 2.x for CVE-2026-54512..54518 (must precede SB BOM) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override OTel for CVE-2026-45292 (must precede SB BOM) -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <jackson.version>2.21.2</jackson.version>
+    <jackson.version>2.21.5</jackson.version>
     <gpg.skip>true</gpg.skip>
     <spotbugs.fail>true</spotbugs.fail>
     <spotbugs.exclude.filter.file>${maven.multiModuleProjectDirectory}/spotbugs-exclude.xml</spotbugs.exclude.filter.file>
@@ -57,7 +57,10 @@
     <springboot.version>3.4.13</springboot.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <assertj.version>3.27.7</assertj.version>
-    <opentelemetry.version>1.41.0</opentelemetry.version>
+    <!-- Must be >= 1.62.0 for CVE-2026-45292 -->
+    <opentelemetry.version>1.62.0</opentelemetry.version>
+    <!-- Must be >= 6.2.18 for CVE-2026-22735, CVE-2026-22737, CVE-2026-22741, CVE-2026-22745 -->
+    <spring-framework.version>6.2.18</spring-framework.version>
     <wiremock.version>3.9.1</wiremock.version>
     <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
@@ -81,14 +84,14 @@
     <opentelemetry-bom.version>2.1.0</opentelemetry-bom.version>
     <kotlin.version>2.1.0</kotlin.version>
     <rest-assured.version>5.5.1</rest-assured.version>
-    <!-- TODO: Remove netty-bom override once gRPC ships with Netty >= 4.1.132 (CVE-2026-33871, CVE-2026-33870) -->
-    <netty.version>4.1.132.Final</netty.version>
-    <!-- TODO: Remove logback override once Spring Boot 3.4.x ships with logback >= 1.5.25 -->
-    <logback.version>1.5.25</logback.version>
+    <!-- TODO: Remove netty-bom override once gRPC ships with Netty >= 4.1.135 (CVE-2026-33871, CVE-2026-33870 and later fixes) -->
+    <netty.version>4.1.135.Final</netty.version>
+    <!-- TODO: Remove logback override once Spring Boot 3.4.x ships with logback >= 1.5.35 -->
+    <logback.version>1.5.35</logback.version>
     <!-- TODO: Remove commons-compress override once testcontainers ships with >= 1.26.0 -->
     <commons-compress.version>1.26.0</commons-compress.version>
-    <!-- TODO: Remove tomcat override once Spring Boot 3.4.x ships with tomcat >= 10.1.52 -->
-    <tomcat.version>10.1.52</tomcat.version>
+    <!-- TODO: Remove tomcat override once Spring Boot 3.4.x ships with tomcat >= 10.1.55 -->
+    <tomcat.version>10.1.55</tomcat.version>
   </properties>
 
   <distributionManagement>
@@ -133,6 +136,22 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Imported before spring-boot-dependencies so this version wins for OTel artifacts -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- TODO: Remove spring-framework override once Spring Boot ships with spring-framework >= 6.2.18 (CVE-2026-22735, CVE-2026-22737, CVE-2026-22741, CVE-2026-22745) -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring-framework.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -158,13 +177,6 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-bom</artifactId>
         <version>${protobuf.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spring-boot-4-examples/pom.xml
+++ b/spring-boot-4-examples/pom.xml
@@ -15,7 +15,8 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <springboot4.version>4.0.5</springboot4.version>
+    <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+    <springboot4.version>4.0.6</springboot4.version>
     <!-- Override JUnit version to align with Spring Boot 4.x -->
     <junit-bom.version>6.0.2</junit-bom.version>
   </properties>
@@ -28,11 +29,11 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Override Jackson 3.x for CVE SNYK-JAVA-TOOLSJACKSONCORE-15907550 (must precede SB BOM) -->
+      <!-- Override Jackson 3.x for CVE SNYK-JAVA-TOOLSJACKSONCORE-15907550 and CVE-2026-54512..54518 (must precede SB BOM) -->
       <dependency>
         <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spring-boot-4-sdk-tests/pom.xml
+++ b/spring-boot-4-sdk-tests/pom.xml
@@ -19,7 +19,8 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
     <protobuf.input.directory>${project.basedir}/proto</protobuf.input.directory>
-    <springboot4.version>4.0.5</springboot4.version>
+    <!-- Must be >= 4.0.6 for CVE-2026-40973 -->
+    <springboot4.version>4.0.6</springboot4.version>
     <!-- Override JUnit version to align with Spring Boot 4.x -->
     <junit-bom.version>6.0.2</junit-bom.version>
     <!-- The JaCoCo plugin was expecting coverage for this module, but since it's a test module


### PR DESCRIPTION
Mirror the 1.18 CVE fixes (#1788) and address FOSSA findings:

- netty 4.1.132 -> 4.1.135.Final (CVE-2026-41417, CVE-2026-42578, CVE-2026-42580..42587, CVE-2026-44249, CVE-2026-45416, CVE-2026-47244, CVE-2026-48043, CVE-2026-50010, CVE-2026-50020, CVE-2026-50560)
- jackson 2.21.2 -> 2.21.5 and Jackson 3 BOM 3.1.1 -> 3.1.4 (CVE-2026-54512..54518)
- opentelemetry 1.41.0 -> 1.62.0 (CVE-2026-45292), imported before the Spring Boot BOM so the override wins
- logback 1.5.25 -> 1.5.35 (CVE-2026-9828, CVE-2026-10532)
- tomcat 10.1.52 -> 10.1.55 (CVE-2026-25854, CVE-2026-29129, CVE-2026-32990, CVE-2026-34483, CVE-2026-41284, CVE-2026-41293, CVE-2026-42498, CVE-2026-43512..43515)
- spring-framework-bom 6.2.18 override (CVE-2026-22735, CVE-2026-22737, CVE-2026-22741, CVE-2026-22745)
- Spring Boot 4 modules 4.0.5 -> 4.0.6 (CVE-2026-40973)
- Jackson 2.x/OTel BOM imports added ahead of the local Spring Boot 4 BOMs so module resolution does not downgrade the fixed versions

CVE-2026-40973 remains on spring-boot 3.4.13: no fix exists on the OSS-EOL 3.4.x line; accepted and ignored in FOSSA.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
