### PR TITLE
fix: pin Netty to the gRPC-supported version in Spring modules

### DIFF
--- a/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
+++ b/dapr-spring/dapr-spring-boot-autoconfigure/pom.xml
@@ -31,6 +31,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter/pom.xml
+++ b/dapr-spring/dapr-spring-boot-starters/dapr-spring-boot-starter/pom.xml
@@ -23,6 +23,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/dapr-spring/dapr-spring-data/pom.xml
+++ b/dapr-spring/dapr-spring-data/pom.xml
@@ -24,6 +24,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -35,6 +35,15 @@
     <dependencies>
       <!-- Import the Spring Boot 4 BOM so JUnit (jupiter + platform) resolves consistently to 6.x,
            matching the spring-boot-sdk-tests module and the Spring Boot 4 starter pulled in here. -->
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/spring-boot-examples/pom.xml
+++ b/spring-boot-examples/pom.xml
@@ -36,6 +36,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/spring-boot-sdk-tests/pom.xml
+++ b/spring-boot-sdk-tests/pom.xml
@@ -29,6 +29,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Pin Netty to the gRPC-supported 4.1.x line (root netty.version); MUST precede the Spring Boot
+           BOM, which manages Netty 4.2.x - unsupported by the non-shaded grpc-netty this SDK uses. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Description

The Spring Boot 4 migration (#1772) has the Dapr Spring modules import the Spring Boot 4 BOM, which manages **Netty 4.2.x**. The SDK uses the non-shaded `grpc-netty` (1.79.0), and per gRPC's [compatibility matrix](https://github.com/grpc/grpc-java/blob/master/SECURITY.md) gRPC 1.79 targets **Netty 4.1.x** — no gRPC release supports Netty 4.2.x. Inside these modules `grpc-netty` is a `compile`-scope transitive (via `dapr-sdk`), so it was resolving onto an unsupported Netty line.

The concrete impact is on the SDK's **own** reactor: it was building and — more importantly — running its Spring integration tests and examples against a Netty version gRPC does not support (`sdk-tests` / `spring-boot-sdk-tests` exercise real gRPC over a Testcontainers `daprd`). In other words, "CI green" was validating gRPC on Netty 4.2.x, an untested combination that can fail with `NoSuchMethodError` / `NoClassDefFoundError`.

**Scope note:** downstream apps that import `dapr-spring-bom` are already protected — it pins Netty `4.1.132` transitively via `dapr-sdk-bom`. This change does not alter that; it aligns the SDK's own builds, tests, and examples with the same supported Netty version the core modules already use. The root `pom.xml` pins `netty-bom` `4.1.132`, but the Spring modules override it by importing the Spring Boot BOM in their own `dependencyManagement`, so the pin never reached them.

Switching to `grpc-netty-shaded` is not an option — it was deliberately removed in #1543 because shaded Netty breaks native compilation (Quarkus / Spring Native), prevents patching Netty CVEs, and increases memory usage.

## Fix

Import `netty-bom` (`${netty.version}` = `4.1.132`) **before** `spring-boot-dependencies` in the gRPC-reachable Spring modules, so Maven's first-declared-wins rule keeps Netty on the gRPC-supported 4.1.x line:

- `dapr-spring-boot-autoconfigure`
- `dapr-spring-data`
- `dapr-spring-boot-starter`
- `sdk-tests`
- `spring-boot-examples`
- `spring-boot-sdk-tests`

`dapr-spring-boot-starter-test` pulls no Netty transitively, so it is intentionally left unpinned.

## Verification

Resolved `io.netty:netty-common` via `dependency:tree` in each affected module — all now resolve **`4.1.132.Final`** (previously `4.2.12.Final`), matching the version already used by the core SDK.

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation (inline comment explaining the pin)
