### PR TITLE
Fix publish event content type handling

### DIFF
--- a/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
+++ b/sdk/src/main/java/io/dapr/client/DaprClientImpl.java
@@ -352,18 +352,20 @@ public class DaprClientImpl extends AbstractDaprClient {
       String pubsubName = request.getPubsubName();
       String topic = request.getTopic();
       Object data = request.getData();
+      String contentType = getPublishEventContentType(data, request.getContentType());
+      boolean useContentTypeConverter = objectSerializer instanceof DefaultObjectSerializer
+          && (DefaultContentTypeConverter.isBinaryContentType(contentType)
+          || DefaultContentTypeConverter.isStringContentType(contentType)
+          || DefaultContentTypeConverter.isJsonContentType(contentType)
+          || DefaultContentTypeConverter.isCloudEventContentType(contentType));
+      byte[] serializedEvent = useContentTypeConverter
+          ? DefaultContentTypeConverter.convertEventToBytesForGrpc(data, contentType)
+          : objectSerializer.serialize(data);
       DaprPubsubProtos.PublishEventRequest.Builder envelopeBuilder = DaprPubsubProtos.PublishEventRequest.newBuilder()
           .setTopic(topic)
           .setPubsubName(pubsubName)
-          .setData(ByteString.copyFrom(objectSerializer.serialize(data)));
-
-      // Content-type can be overwritten on a per-request basis.
-      // It allows CloudEvents to be handled differently, for example.
-      String contentType = request.getContentType();
-      if (contentType == null || contentType.isEmpty()) {
-        contentType = objectSerializer.getContentType();
-      }
-      envelopeBuilder.setDataContentType(contentType);
+          .setData(ByteString.copyFrom(serializedEvent))
+          .setDataContentType(contentType);
 
       Map<String, String> metadata = request.getMetadata();
       if (metadata != null) {
@@ -379,6 +381,20 @@ public class DaprClientImpl extends AbstractDaprClient {
     } catch (Exception ex) {
       return DaprException.wrapMono(ex);
     }
+  }
+
+  private String getPublishEventContentType(Object data, String contentType) {
+    if (!Strings.isNullOrEmpty(contentType) || !(objectSerializer instanceof DefaultObjectSerializer)) {
+      return Strings.isNullOrEmpty(contentType) ? objectSerializer.getContentType() : contentType;
+    }
+
+    if (data instanceof byte[]) {
+      return "application/octet-stream";
+    }
+    if (data instanceof String || data instanceof Boolean || data instanceof Number) {
+      return "text/plain";
+    }
+    return objectSerializer.getContentType();
   }
 
   /**

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -266,6 +266,17 @@ public class DaprClientGrpcTest {
   }
 
   @Test
+  public void publishEventBooleanInfersTextPlainContentTypeTest() {
+    mockPublishEventSuccess();
+
+    client.publishEvent("pubsubname", "topic", true).block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("text/plain", request.getDataContentType());
+    assertEquals("true", request.getData().toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
   public void publishEventByteArrayInfersOctetStreamContentTypeTest() {
     byte[] event = new byte[] {1, 2, 3};
     mockPublishEventSuccess();
@@ -289,6 +300,19 @@ public class DaprClientGrpcTest {
     DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
     assertEquals("image/png", request.getDataContentType());
     assertArrayEquals(event, request.getData().toByteArray());
+  }
+
+  @Test
+  public void publishEventCloudEventContentTypeUsesDefaultConverterTest() {
+    mockPublishEventSuccess();
+
+    client.publishEvent(
+        new PublishEventRequest("pubsubname", "topic", "hello")
+            .setContentType("application/cloudevents+json")).block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("application/cloudevents+json", request.getDataContentType());
+    assertEquals("\"hello\"", request.getData().toString(StandardCharsets.UTF_8));
   }
 
   private void mockPublishEventSuccess() {

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTest.java
@@ -231,27 +231,80 @@ public class DaprClientGrpcTest {
 
   @Test
   public void publishEventContentTypeOverrideTest() {
-    doAnswer((Answer<Void>) invocation -> {
-      StreamObserver<Empty> observer = (StreamObserver<Empty>) invocation.getArguments()[1];
-      observer.onNext(Empty.getDefaultInstance());
-      observer.onCompleted();
-      return null;
-    }).when(daprStub).publishEvent(ArgumentMatchers.argThat(publishEventRequest -> {
-      if (!"text/plain".equals(publishEventRequest.getDataContentType())) {
-        return false;
-      }
-
-      if (!"\"hello\"".equals(new String(publishEventRequest.getData().toByteArray()))) {
-        return false;
-      }
-      return true;
-    }), any());
-
+    mockPublishEventSuccess();
 
     Mono<Void> result = client.publishEvent(
         new PublishEventRequest("pubsubname", "topic", "hello")
             .setContentType("text/plain"));
     result.block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("text/plain", request.getDataContentType());
+    assertEquals("hello", request.getData().toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void publishEventStringInfersTextPlainContentTypeTest() {
+    mockPublishEventSuccess();
+
+    client.publishEvent("pubsubname", "topic", "hello").block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("text/plain", request.getDataContentType());
+    assertEquals("hello", request.getData().toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void publishEventNumberInfersTextPlainContentTypeTest() {
+    mockPublishEventSuccess();
+
+    client.publishEvent("pubsubname", "topic", 42).block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("text/plain", request.getDataContentType());
+    assertEquals("42", request.getData().toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void publishEventByteArrayInfersOctetStreamContentTypeTest() {
+    byte[] event = new byte[] {1, 2, 3};
+    mockPublishEventSuccess();
+
+    client.publishEvent("pubsubname", "topic", event).block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("application/octet-stream", request.getDataContentType());
+    assertArrayEquals(event, request.getData().toByteArray());
+  }
+
+  @Test
+  public void publishEventByteArrayPreservesCustomContentTypeTest() {
+    byte[] event = new byte[] {1, 2, 3};
+    mockPublishEventSuccess();
+
+    client.publishEvent(
+        new PublishEventRequest("pubsubname", "topic", event)
+            .setContentType("image/png")).block();
+
+    DaprPubsubProtos.PublishEventRequest request = capturePublishEventRequest();
+    assertEquals("image/png", request.getDataContentType());
+    assertArrayEquals(event, request.getData().toByteArray());
+  }
+
+  private void mockPublishEventSuccess() {
+    doAnswer((Answer<Void>) invocation -> {
+      StreamObserver<Empty> observer = (StreamObserver<Empty>) invocation.getArguments()[1];
+      observer.onNext(Empty.getDefaultInstance());
+      observer.onCompleted();
+      return null;
+    }).when(daprStub).publishEvent(any(), any());
+  }
+
+  private DaprPubsubProtos.PublishEventRequest capturePublishEventRequest() {
+    ArgumentCaptor<DaprPubsubProtos.PublishEventRequest> captor =
+        ArgumentCaptor.forClass(DaprPubsubProtos.PublishEventRequest.class);
+    verify(daprStub).publishEvent(captor.capture(), any());
+    return captor.getValue();
   }
 
   @Test


### PR DESCRIPTION
Fixes #779

## Summary

- infer `text/plain` for String, Number, and Boolean payloads when no content type is supplied
- infer `application/octet-stream` for byte arrays and keep their raw bytes on the gRPC path
- respect explicit content types while reusing the existing default content-type converter for recognized MIME types
- preserve custom serializers and custom MIME types

## Reproduction

Before the fix, four focused regression tests were run three times. All four failed consistently: an explicit `text/plain` String was JSON-quoted, and implicit String, Number, and byte-array payloads were all labeled `application/json`.

After the fix, those cases pass, along with coverage for POJO serialization and preservation of a custom `image/png` byte-array payload.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -pl sdk clean test`
- 556 tests passed; 0 failures, 0 errors, 0 skipped
- Checkstyle: 0 violations
- SpotBugs and JaCoCo completed successfully

No screenshot is needed because the regression tests assert the exact content type and wire-level protobuf payload bytes.
