### PR TITLE
Workflow: cross-app client operations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,41 @@ jobs:
         name: surefire-report-spring-boot-sdk-tests-jdk${{ matrix.java }}-sb${{ matrix.spring-boot-version }}
         path: spring-boot-sdk-tests/target/surefire-reports
 
+  # Tests tagged dapr-head cover runtime features that no dapr release carries yet, so they run
+  # against daprd built from dapr/dapr master rather than the release image the default suite pins.
+  # Kept out of the build job so a change in that moving image cannot fail unrelated pull requests.
+  build-dapr-head:
+    name: "Integration tests against dapr master"
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true
+    env:
+      JDK_VER: 17
+    steps:
+    - uses: actions/checkout@v7
+    - name: Check Docker version
+      run: docker version
+    - name: Set up OpenJDK ${{ env.JDK_VER }}
+      uses: actions/setup-java@v6
+      with:
+        distribution: 'temurin'
+        java-version: ${{ env.JDK_VER }}
+    - name: Clean up and install sdk
+      run: ./mvnw clean install -B -q -DskipTests
+    - name: Integration tests against dapr master
+      id: dapr_head_tests
+      uses: nick-fields/retry@v4
+      with:
+        max_attempts: 2
+        timeout_minutes: 20
+        retry_wait_seconds: 15
+        command: ./mvnw -B -pl sdk-tests -Pintegration-tests,dapr-head dependency:copy-dependencies verify
+    - name: Upload failsafe test report on failure
+      if: ${{ failure() && steps.dapr_head_tests.conclusion == 'failure' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: failsafe-report-dapr-head-jdk${{ env.JDK_VER }}
+        path: sdk-tests/target/failsafe-reports
 
   publish:
     runs-on: ubuntu-latest

--- a/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskClient.java
+++ b/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskClient.java
@@ -127,7 +127,29 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param eventName    the case-insensitive name of the event
    * @param eventPayload the serializable data payload to include with the event
    */
-  public abstract void raiseEvent(String instanceId, String eventName, @Nullable Object eventPayload);
+  public void raiseEvent(String instanceId, String eventName, @Nullable Object eventPayload) {
+    this.raiseEvent(instanceId, eventName, eventPayload, null);
+  }
+
+  /**
+   * Sends an event notification message with a payload to a waiting orchestration instance owned by another app.
+   *
+   * <p>See {@link #raiseEvent(String, String, Object)} for the event delivery semantics.</p>
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the event is raised on the local app instead.</p>
+   *
+   * @param instanceId   the ID of the orchestration instance that will handle the event
+   * @param eventName    the case-insensitive name of the event
+   * @param eventPayload the serializable data payload to include with the event
+   * @param appID        the ID of the app that owns the target orchestration instance, used for cross-app
+   *                     routing. May be null to target the local app.
+   */
+  public abstract void raiseEvent(
+      String instanceId,
+      String eventName,
+      @Nullable Object eventPayload,
+      @Nullable String appID);
 
   /**
    * Fetches orchestration instance metadata from the configured durable store.
@@ -140,7 +162,30 @@ public abstract class DurableTaskClient implements AutoCloseable {
    *     {@link OrchestrationMetadata#isInstanceFound()} to check if an instance is found.
    */
   @Nullable
-  public abstract OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs);
+  public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs) {
+    return this.getInstanceMetadata(instanceId, getInputsAndOutputs, null);
+  }
+
+  /**
+   * Fetches orchestration instance metadata from the durable store of another app.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the metadata is fetched from the local app instead.</p>
+   *
+   * @param instanceId          the unique ID of the orchestration instance to fetch
+   * @param getInputsAndOutputs <code>true</code> to fetch the orchestration instance's inputs, outputs, and custom
+   *                            status, or <code>false</code> to omit them
+   * @param appID               the ID of the app that owns the target orchestration instance, used for cross-app
+   *                            routing. May be null to target the local app.
+   * @return a metadata record that describes the orchestration instance and its execution status, or
+   *     a default instance if no such instance is found. Please refer to method
+   *     {@link OrchestrationMetadata#isInstanceFound()} to check if an instance is found.
+   */
+  @Nullable
+  public abstract OrchestrationMetadata getInstanceMetadata(
+      String instanceId,
+      boolean getInputsAndOutputs,
+      @Nullable String appID);
 
   /**
    * Waits for an orchestration to start running and returns an {@link OrchestrationMetadata} object that contains
@@ -181,10 +226,36 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
    */
   @Nullable
+  public OrchestrationMetadata waitForInstanceStart(
+      String instanceId,
+      Duration timeout,
+      boolean getInputsAndOutputs) throws TimeoutException {
+    return this.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs, null);
+  }
+
+  /**
+   * Waits for an orchestration instance owned by another app to start running.
+   *
+   * <p>See {@link #waitForInstanceStart(String, Duration, boolean)} for the wait semantics.</p>
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the wait applies to the local app instead.</p>
+   *
+   * @param instanceId          the unique ID of the orchestration instance to wait for
+   * @param timeout             the amount of time to wait for the orchestration instance to start
+   * @param getInputsAndOutputs <code>true</code> to fetch the orchestration instance's inputs, outputs, and custom
+   *                            status, or <code>false</code> to omit them
+   * @param appID               the ID of the app that owns the target orchestration instance, used for cross-app
+   *                            routing. May be null to target the local app.
+   * @return the orchestration instance metadata or <code>null</code> if no such instance is found
+   * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
+   */
+  @Nullable
   public abstract OrchestrationMetadata waitForInstanceStart(
       String instanceId,
       Duration timeout,
-      boolean getInputsAndOutputs) throws TimeoutException;
+      boolean getInputsAndOutputs,
+      @Nullable String appID) throws TimeoutException;
 
   /**
    * Waits for an orchestration to complete and returns an {@link OrchestrationMetadata} object that contains
@@ -208,10 +279,36 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not completed within the specified amount of time
    */
   @Nullable
+  public OrchestrationMetadata waitForInstanceCompletion(
+      String instanceId,
+      Duration timeout,
+      boolean getInputsAndOutputs) throws TimeoutException {
+    return this.waitForInstanceCompletion(instanceId, timeout, getInputsAndOutputs, null);
+  }
+
+  /**
+   * Waits for an orchestration instance owned by another app to complete.
+   *
+   * <p>See {@link #waitForInstanceCompletion(String, Duration, boolean)} for the wait semantics.</p>
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the wait applies to the local app instead.</p>
+   *
+   * @param instanceId          the unique ID of the orchestration instance to wait for
+   * @param timeout             the amount of time to wait for the orchestration instance to complete
+   * @param getInputsAndOutputs <code>true</code> to fetch the orchestration instance's inputs, outputs, and custom
+   *                            status, or <code>false</code> to omit them
+   * @param appID               the ID of the app that owns the target orchestration instance, used for cross-app
+   *                            routing. May be null to target the local app.
+   * @return the orchestration instance metadata or <code>null</code> if no such instance is found
+   * @throws TimeoutException when the orchestration instance is not completed within the specified amount of time
+   */
+  @Nullable
   public abstract OrchestrationMetadata waitForInstanceCompletion(
       String instanceId,
       Duration timeout,
-      boolean getInputsAndOutputs) throws TimeoutException;
+      boolean getInputsAndOutputs,
+      @Nullable String appID) throws TimeoutException;
 
   /**
    * Terminates a running orchestration instance and updates its runtime status to <code>Terminated</code>.
@@ -234,7 +331,25 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param output     the optional output to set for the terminated orchestration instance.
    *                   This value must be serializable.
    */
-  public abstract void terminate(String instanceId, @Nullable Object output);
+  public void terminate(String instanceId, @Nullable Object output) {
+    this.terminate(instanceId, output, null);
+  }
+
+  /**
+   * Terminates a running orchestration instance owned by another app.
+   *
+   * <p>See {@link #terminate(String, Object)} for the termination semantics.</p>
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the instance is terminated on the local app instead.</p>
+   *
+   * @param instanceId the unique ID of the orchestration instance to terminate
+   * @param output     the optional output to set for the terminated orchestration instance.
+   *                   This value must be serializable.
+   * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
+   *                   routing. May be null to target the local app.
+   */
+  public abstract void terminate(String instanceId, @Nullable Object output, @Nullable String appID);
 
   /**
    * Purges orchestration instance metadata from the durable store.
@@ -252,7 +367,24 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the unique ID of the orchestration instance to purge
    * @return the result of the purge operation, including the number of purged orchestration instances (0 or 1)
    */
-  public abstract PurgeResult purgeInstance(String instanceId);
+  public PurgeResult purgeInstance(String instanceId) {
+    return this.purgeInstance(instanceId, null);
+  }
+
+  /**
+   * Purges orchestration instance metadata from the durable store of another app.
+   *
+   * <p>See {@link #purgeInstance(String)} for the purge semantics.</p>
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the instance is purged from the local app instead.</p>
+   *
+   * @param instanceId the unique ID of the orchestration instance to purge
+   * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
+   *                   routing. May be null to target the local app.
+   * @return the result of the purge operation, including the number of purged orchestration instances (0 or 1)
+   */
+  public abstract PurgeResult purgeInstance(String instanceId, @Nullable String appID);
 
   /**
    * Purges orchestration instance metadata from the durable store using a filter that determines which instances to
@@ -283,7 +415,28 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @return the ID of the scheduled orchestration instance, which is either <code>instanceId</code> or randomly
    *     generated depending on the value of <code>restartWithNewInstanceId</code>
    */
-  public abstract String restartInstance(String instanceId, boolean restartWithNewInstanceId);
+  public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {
+    return this.restartInstance(instanceId, restartWithNewInstanceId, null);
+  }
+
+  /**
+   * Restarts an existing orchestration instance owned by another app with the original input.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the instance is restarted on the local app instead.</p>
+   *
+   * @param instanceId               the ID of the previously run orchestration instance to restart.
+   * @param restartWithNewInstanceId <code>true</code> to restart the orchestration instance with a new instance ID
+   *                                 <code>false</code> to restart the orchestration instance with same instance ID
+   * @param appID                    the ID of the app that owns the target orchestration instance, used for
+   *                                 cross-app routing. May be null to target the local app.
+   * @return the ID of the scheduled orchestration instance, which is either <code>instanceId</code> or randomly
+   *     generated depending on the value of <code>restartWithNewInstanceId</code>
+   */
+  public abstract String restartInstance(
+      String instanceId,
+      boolean restartWithNewInstanceId,
+      @Nullable String appID);
 
   /**
    * Suspends a running orchestration instance.
@@ -300,7 +453,22 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the ID of the orchestration instance to suspend
    * @param reason     the reason for suspending the orchestration instance
    */
-  public abstract void suspendInstance(String instanceId, @Nullable String reason);
+  public void suspendInstance(String instanceId, @Nullable String reason) {
+    this.suspendInstance(instanceId, reason, null);
+  }
+
+  /**
+   * Suspends a running orchestration instance owned by another app.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the instance is suspended on the local app instead.</p>
+   *
+   * @param instanceId the ID of the orchestration instance to suspend
+   * @param reason     the reason for suspending the orchestration instance
+   * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
+   *                   routing. May be null to target the local app.
+   */
+  public abstract void suspendInstance(String instanceId, @Nullable String reason, @Nullable String appID);
 
   /**
    * Resumes a running orchestration instance.
@@ -317,5 +485,20 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the ID of the orchestration instance to resume
    * @param reason     the reason for resuming the orchestration instance
    */
-  public abstract void resumeInstance(String instanceId, @Nullable String reason);
+  public void resumeInstance(String instanceId, @Nullable String reason) {
+    this.resumeInstance(instanceId, reason, null);
+  }
+
+  /**
+   * Resumes a running orchestration instance owned by another app.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the instance is resumed on the local app instead.</p>
+   *
+   * @param instanceId the ID of the orchestration instance to resume
+   * @param reason     the reason for resuming the orchestration instance
+   * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
+   *                   routing. May be null to target the local app.
+   */
+  public abstract void resumeInstance(String instanceId, @Nullable String reason, @Nullable String appID);
 }

--- a/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskClient.java
+++ b/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskClient.java
@@ -127,9 +127,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param eventName    the case-insensitive name of the event
    * @param eventPayload the serializable data payload to include with the event
    */
-  public void raiseEvent(String instanceId, String eventName, @Nullable Object eventPayload) {
-    this.raiseEvent(instanceId, eventName, eventPayload, null);
-  }
+  public abstract void raiseEvent(String instanceId, String eventName, @Nullable Object eventPayload);
 
   /**
    * Sends an event notification message with a payload to a waiting orchestration instance owned by another app.
@@ -145,11 +143,14 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param appID        the ID of the app that owns the target orchestration instance, used for cross-app
    *                     routing. May be null to target the local app.
    */
-  public abstract void raiseEvent(
+  public void raiseEvent(
       String instanceId,
       String eventName,
       @Nullable Object eventPayload,
-      @Nullable String appID);
+      @Nullable String appID) {
+    requireLocalRouting(appID);
+    this.raiseEvent(instanceId, eventName, eventPayload);
+  }
 
   /**
    * Fetches orchestration instance metadata from the configured durable store.
@@ -162,9 +163,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    *     {@link OrchestrationMetadata#isInstanceFound()} to check if an instance is found.
    */
   @Nullable
-  public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs) {
-    return this.getInstanceMetadata(instanceId, getInputsAndOutputs, null);
-  }
+  public abstract OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs);
 
   /**
    * Fetches orchestration instance metadata from the durable store of another app.
@@ -182,10 +181,13 @@ public abstract class DurableTaskClient implements AutoCloseable {
    *     {@link OrchestrationMetadata#isInstanceFound()} to check if an instance is found.
    */
   @Nullable
-  public abstract OrchestrationMetadata getInstanceMetadata(
+  public OrchestrationMetadata getInstanceMetadata(
       String instanceId,
       boolean getInputsAndOutputs,
-      @Nullable String appID);
+      @Nullable String appID) {
+    requireLocalRouting(appID);
+    return this.getInstanceMetadata(instanceId, getInputsAndOutputs);
+  }
 
   /**
    * Waits for an orchestration to start running and returns an {@link OrchestrationMetadata} object that contains
@@ -226,12 +228,10 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
    */
   @Nullable
-  public OrchestrationMetadata waitForInstanceStart(
+  public abstract OrchestrationMetadata waitForInstanceStart(
       String instanceId,
       Duration timeout,
-      boolean getInputsAndOutputs) throws TimeoutException {
-    return this.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs, null);
-  }
+      boolean getInputsAndOutputs) throws TimeoutException;
 
   /**
    * Waits for an orchestration instance owned by another app to start running.
@@ -251,11 +251,14 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not started within the specified amount of time
    */
   @Nullable
-  public abstract OrchestrationMetadata waitForInstanceStart(
+  public OrchestrationMetadata waitForInstanceStart(
       String instanceId,
       Duration timeout,
       boolean getInputsAndOutputs,
-      @Nullable String appID) throws TimeoutException;
+      @Nullable String appID) throws TimeoutException {
+    requireLocalRouting(appID);
+    return this.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs);
+  }
 
   /**
    * Waits for an orchestration to complete and returns an {@link OrchestrationMetadata} object that contains
@@ -279,12 +282,10 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not completed within the specified amount of time
    */
   @Nullable
-  public OrchestrationMetadata waitForInstanceCompletion(
+  public abstract OrchestrationMetadata waitForInstanceCompletion(
       String instanceId,
       Duration timeout,
-      boolean getInputsAndOutputs) throws TimeoutException {
-    return this.waitForInstanceCompletion(instanceId, timeout, getInputsAndOutputs, null);
-  }
+      boolean getInputsAndOutputs) throws TimeoutException;
 
   /**
    * Waits for an orchestration instance owned by another app to complete.
@@ -304,11 +305,14 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @throws TimeoutException when the orchestration instance is not completed within the specified amount of time
    */
   @Nullable
-  public abstract OrchestrationMetadata waitForInstanceCompletion(
+  public OrchestrationMetadata waitForInstanceCompletion(
       String instanceId,
       Duration timeout,
       boolean getInputsAndOutputs,
-      @Nullable String appID) throws TimeoutException;
+      @Nullable String appID) throws TimeoutException {
+    requireLocalRouting(appID);
+    return this.waitForInstanceCompletion(instanceId, timeout, getInputsAndOutputs);
+  }
 
   /**
    * Terminates a running orchestration instance and updates its runtime status to <code>Terminated</code>.
@@ -331,9 +335,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param output     the optional output to set for the terminated orchestration instance.
    *                   This value must be serializable.
    */
-  public void terminate(String instanceId, @Nullable Object output) {
-    this.terminate(instanceId, output, null);
-  }
+  public abstract void terminate(String instanceId, @Nullable Object output);
 
   /**
    * Terminates a running orchestration instance owned by another app.
@@ -349,7 +351,10 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
    *                   routing. May be null to target the local app.
    */
-  public abstract void terminate(String instanceId, @Nullable Object output, @Nullable String appID);
+  public void terminate(String instanceId, @Nullable Object output, @Nullable String appID) {
+    requireLocalRouting(appID);
+    this.terminate(instanceId, output);
+  }
 
   /**
    * Purges orchestration instance metadata from the durable store.
@@ -367,9 +372,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the unique ID of the orchestration instance to purge
    * @return the result of the purge operation, including the number of purged orchestration instances (0 or 1)
    */
-  public PurgeResult purgeInstance(String instanceId) {
-    return this.purgeInstance(instanceId, null);
-  }
+  public abstract PurgeResult purgeInstance(String instanceId);
 
   /**
    * Purges orchestration instance metadata from the durable store of another app.
@@ -384,7 +387,10 @@ public abstract class DurableTaskClient implements AutoCloseable {
    *                   routing. May be null to target the local app.
    * @return the result of the purge operation, including the number of purged orchestration instances (0 or 1)
    */
-  public abstract PurgeResult purgeInstance(String instanceId, @Nullable String appID);
+  public PurgeResult purgeInstance(String instanceId, @Nullable String appID) {
+    requireLocalRouting(appID);
+    return this.purgeInstance(instanceId);
+  }
 
   /**
    * Purges orchestration instance metadata from the durable store using a filter that determines which instances to
@@ -415,9 +421,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @return the ID of the scheduled orchestration instance, which is either <code>instanceId</code> or randomly
    *     generated depending on the value of <code>restartWithNewInstanceId</code>
    */
-  public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {
-    return this.restartInstance(instanceId, restartWithNewInstanceId, null);
-  }
+  public abstract String restartInstance(String instanceId, boolean restartWithNewInstanceId);
 
   /**
    * Restarts an existing orchestration instance owned by another app with the original input.
@@ -433,10 +437,13 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @return the ID of the scheduled orchestration instance, which is either <code>instanceId</code> or randomly
    *     generated depending on the value of <code>restartWithNewInstanceId</code>
    */
-  public abstract String restartInstance(
+  public String restartInstance(
       String instanceId,
       boolean restartWithNewInstanceId,
-      @Nullable String appID);
+      @Nullable String appID) {
+    requireLocalRouting(appID);
+    return this.restartInstance(instanceId, restartWithNewInstanceId);
+  }
 
   /**
    * Suspends a running orchestration instance.
@@ -453,9 +460,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the ID of the orchestration instance to suspend
    * @param reason     the reason for suspending the orchestration instance
    */
-  public void suspendInstance(String instanceId, @Nullable String reason) {
-    this.suspendInstance(instanceId, reason, null);
-  }
+  public abstract void suspendInstance(String instanceId, @Nullable String reason);
 
   /**
    * Suspends a running orchestration instance owned by another app.
@@ -468,7 +473,10 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
    *                   routing. May be null to target the local app.
    */
-  public abstract void suspendInstance(String instanceId, @Nullable String reason, @Nullable String appID);
+  public void suspendInstance(String instanceId, @Nullable String reason, @Nullable String appID) {
+    requireLocalRouting(appID);
+    this.suspendInstance(instanceId, reason);
+  }
 
   /**
    * Resumes a running orchestration instance.
@@ -485,9 +493,7 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param instanceId the ID of the orchestration instance to resume
    * @param reason     the reason for resuming the orchestration instance
    */
-  public void resumeInstance(String instanceId, @Nullable String reason) {
-    this.resumeInstance(instanceId, reason, null);
-  }
+  public abstract void resumeInstance(String instanceId, @Nullable String reason);
 
   /**
    * Resumes a running orchestration instance owned by another app.
@@ -500,5 +506,19 @@ public abstract class DurableTaskClient implements AutoCloseable {
    * @param appID      the ID of the app that owns the target orchestration instance, used for cross-app
    *                   routing. May be null to target the local app.
    */
-  public abstract void resumeInstance(String instanceId, @Nullable String reason, @Nullable String appID);
+  public void resumeInstance(String instanceId, @Nullable String reason, @Nullable String appID) {
+    requireLocalRouting(appID);
+    this.resumeInstance(instanceId, reason);
+  }
+
+  /**
+   * Rejects a cross-app target on a client that does not implement cross-app routing. Implementations that
+   * support it override the app ID overloads, so this is only reached on ones that do not.
+   */
+  private static void requireLocalRouting(@Nullable String appID) {
+    if (appID != null && !appID.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "cross-app workflow operations are not supported by this DurableTaskClient implementation");
+    }
+  }
 }

--- a/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskGrpcClient.java
+++ b/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskGrpcClient.java
@@ -208,6 +208,10 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
       builder.setEnforceUniqueInstanceId(true);
     }
 
+    if (options.hasAppID()) {
+      builder.setRouter(buildTaskRouter(options.getAppID()));
+    }
+
     Span span = null;
     if (this.tracer != null) {
       span = this.tracer.spanBuilder("create_orchestration:" + orchestratorName)
@@ -270,8 +274,18 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     return traceContext.build();
   }
 
+  /**
+   * Builds a router that targets the given app. Only the target app ID is set by the client;
+   * the sidecar stamps the source app ID.
+   */
+  private static Orchestration.TaskRouter buildTaskRouter(String appID) {
+    return Orchestration.TaskRouter.newBuilder()
+        .setTargetAppID(appID)
+        .build();
+  }
+
   @Override
-  public void raiseEvent(String instanceId, String eventName, Object eventPayload) {
+  public void raiseEvent(String instanceId, String eventName, Object eventPayload, @Nullable String appID) {
     Helpers.throwIfArgumentNull(instanceId, "instanceId");
     Helpers.throwIfArgumentNull(eventName, "eventName");
 
@@ -283,28 +297,39 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
       builder.setInput(StringValue.of(serializedPayload));
     }
 
+    if (appID != null) {
+      builder.setRouter(buildTaskRouter(appID));
+    }
+
     OrchestratorService.RaiseEventRequest request = builder.build();
     this.sidecarClient.raiseEvent(request);
 
   }
 
   @Override
-  public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs) {
-    OrchestratorService.GetInstanceRequest request = OrchestratorService.GetInstanceRequest.newBuilder()
+  public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs,
+                                                   @Nullable String appID) {
+    OrchestratorService.GetInstanceRequest.Builder builder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
-        .setGetInputsAndOutputs(getInputsAndOutputs)
-        .build();
+        .setGetInputsAndOutputs(getInputsAndOutputs);
+    if (appID != null) {
+      builder.setRouter(buildTaskRouter(appID));
+    }
+    OrchestratorService.GetInstanceRequest request = builder.build();
     OrchestratorService.GetInstanceResponse response = this.sidecarClient.getInstance(request);
     return new OrchestrationMetadata(response, this.dataConverter, request.getGetInputsAndOutputs());
   }
 
   @Override
-  public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs)
-      throws TimeoutException {
-    OrchestratorService.GetInstanceRequest request = OrchestratorService.GetInstanceRequest.newBuilder()
+  public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs,
+                                                    @Nullable String appID) throws TimeoutException {
+    OrchestratorService.GetInstanceRequest.Builder requestBuilder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
-        .setGetInputsAndOutputs(getInputsAndOutputs)
-        .build();
+        .setGetInputsAndOutputs(getInputsAndOutputs);
+    if (appID != null) {
+      requestBuilder.setRouter(buildTaskRouter(appID));
+    }
+    OrchestratorService.GetInstanceRequest request = requestBuilder.build();
 
     if (timeout == null || timeout.isNegative() || timeout.isZero()) {
       timeout = Duration.ofMinutes(10);
@@ -328,11 +353,15 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
 
   @Override
   public OrchestrationMetadata waitForInstanceCompletion(String instanceId, Duration timeout,
-                                                         boolean getInputsAndOutputs) throws TimeoutException {
-    OrchestratorService.GetInstanceRequest request = OrchestratorService.GetInstanceRequest.newBuilder()
+                                                         boolean getInputsAndOutputs,
+                                                         @Nullable String appID) throws TimeoutException {
+    OrchestratorService.GetInstanceRequest.Builder requestBuilder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
-        .setGetInputsAndOutputs(getInputsAndOutputs)
-        .build();
+        .setGetInputsAndOutputs(getInputsAndOutputs);
+    if (appID != null) {
+      requestBuilder.setRouter(buildTaskRouter(appID));
+    }
+    OrchestratorService.GetInstanceRequest request = requestBuilder.build();
 
     if (timeout == null || timeout.isNegative() || timeout.isZero()) {
       timeout = Duration.ofMinutes(10);
@@ -355,7 +384,7 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
-  public void terminate(String instanceId, @Nullable Object output) {
+  public void terminate(String instanceId, @Nullable Object output, @Nullable String appID) {
     Helpers.throwIfArgumentNull(instanceId, "instanceId");
     String serializeOutput = this.dataConverter.serialize(output);
     this.logger.fine(() -> String.format(
@@ -367,16 +396,21 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     if (serializeOutput != null) {
       builder.setOutput(StringValue.of(serializeOutput));
     }
+    if (appID != null) {
+      builder.setRouter(buildTaskRouter(appID));
+    }
     this.sidecarClient.terminateInstance(builder.build());
   }
 
   @Override
-  public PurgeResult purgeInstance(String instanceId) {
-    OrchestratorService.PurgeInstancesRequest request = OrchestratorService.PurgeInstancesRequest.newBuilder()
-        .setInstanceId(instanceId)
-        .build();
+  public PurgeResult purgeInstance(String instanceId, @Nullable String appID) {
+    OrchestratorService.PurgeInstancesRequest.Builder builder = OrchestratorService.PurgeInstancesRequest.newBuilder()
+        .setInstanceId(instanceId);
+    if (appID != null) {
+      builder.setRouter(buildTaskRouter(appID));
+    }
 
-    OrchestratorService.PurgeInstancesResponse response = this.sidecarClient.purgeInstances(request);
+    OrchestratorService.PurgeInstancesResponse response = this.sidecarClient.purgeInstances(builder.build());
     return toPurgeResult(response);
   }
 
@@ -414,28 +448,34 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
-  public void suspendInstance(String instanceId, @Nullable String reason) {
+  public void suspendInstance(String instanceId, @Nullable String reason, @Nullable String appID) {
     OrchestratorService.SuspendRequest.Builder suspendRequestBuilder = OrchestratorService.SuspendRequest.newBuilder();
     suspendRequestBuilder.setInstanceId(instanceId);
     if (reason != null) {
       suspendRequestBuilder.setReason(StringValue.of(reason));
     }
+    if (appID != null) {
+      suspendRequestBuilder.setRouter(buildTaskRouter(appID));
+    }
     this.sidecarClient.suspendInstance(suspendRequestBuilder.build());
   }
 
   @Override
-  public void resumeInstance(String instanceId, @Nullable String reason) {
+  public void resumeInstance(String instanceId, @Nullable String reason, @Nullable String appID) {
     OrchestratorService.ResumeRequest.Builder resumeRequestBuilder = OrchestratorService.ResumeRequest.newBuilder();
     resumeRequestBuilder.setInstanceId(instanceId);
     if (reason != null) {
       resumeRequestBuilder.setReason(StringValue.of(reason));
     }
+    if (appID != null) {
+      resumeRequestBuilder.setRouter(buildTaskRouter(appID));
+    }
     this.sidecarClient.resumeInstance(resumeRequestBuilder.build());
   }
 
   @Override
-  public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {
-    OrchestrationMetadata metadata = this.getInstanceMetadata(instanceId, true);
+  public String restartInstance(String instanceId, boolean restartWithNewInstanceId, @Nullable String appID) {
+    OrchestrationMetadata metadata = this.getInstanceMetadata(instanceId, true, appID);
     if (!metadata.isInstanceFound()) {
       throw new IllegalArgumentException(new StringBuilder()
           .append("An orchestration with instanceId ")
@@ -443,13 +483,15 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
           .append(" was not found.").toString());
     }
 
-    if (restartWithNewInstanceId) {
-      return this.scheduleNewOrchestrationInstance(metadata.getName(),
-          this.dataConverter.deserialize(metadata.getSerializedInput(), Object.class));
-    } else {
-      return this.scheduleNewOrchestrationInstance(metadata.getName(),
-          this.dataConverter.deserialize(metadata.getSerializedInput(), Object.class), metadata.getInstanceId());
+    NewOrchestrationInstanceOptions options = new NewOrchestrationInstanceOptions()
+        .setInput(this.dataConverter.deserialize(metadata.getSerializedInput(), Object.class));
+    if (!restartWithNewInstanceId) {
+      options.setInstanceId(metadata.getInstanceId());
     }
+    if (appID != null) {
+      options.setAppID(appID);
+    }
+    return this.scheduleNewOrchestrationInstance(metadata.getName(), options);
   }
 
   private PurgeResult toPurgeResult(OrchestratorService.PurgeInstancesResponse response) {

--- a/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskGrpcClient.java
+++ b/durabletask-client/src/main/java/io/dapr/durabletask/DurableTaskGrpcClient.java
@@ -275,6 +275,14 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   /**
+   * An empty app ID means the local app, matching how the options carry one, so it must not become a
+   * router with an empty target.
+   */
+  private static boolean hasAppID(@Nullable String appID) {
+    return appID != null && !appID.isEmpty();
+  }
+
+  /**
    * Builds a router that targets the given app. Only the target app ID is set by the client;
    * the sidecar stamps the source app ID.
    */
@@ -282,6 +290,11 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     return Orchestration.TaskRouter.newBuilder()
         .setTargetAppID(appID)
         .build();
+  }
+
+  @Override
+  public void raiseEvent(String instanceId, String eventName, Object eventPayload) {
+    this.raiseEvent(instanceId, eventName, eventPayload, null);
   }
 
   @Override
@@ -297,7 +310,7 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
       builder.setInput(StringValue.of(serializedPayload));
     }
 
-    if (appID != null) {
+    if (hasAppID(appID)) {
       builder.setRouter(buildTaskRouter(appID));
     }
 
@@ -307,12 +320,17 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
+  public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs) {
+    return this.getInstanceMetadata(instanceId, getInputsAndOutputs, null);
+  }
+
+  @Override
   public OrchestrationMetadata getInstanceMetadata(String instanceId, boolean getInputsAndOutputs,
                                                    @Nullable String appID) {
     OrchestratorService.GetInstanceRequest.Builder builder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
         .setGetInputsAndOutputs(getInputsAndOutputs);
-    if (appID != null) {
+    if (hasAppID(appID)) {
       builder.setRouter(buildTaskRouter(appID));
     }
     OrchestratorService.GetInstanceRequest request = builder.build();
@@ -321,12 +339,18 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
+  public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs)
+      throws TimeoutException {
+    return this.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs, null);
+  }
+
+  @Override
   public OrchestrationMetadata waitForInstanceStart(String instanceId, Duration timeout, boolean getInputsAndOutputs,
                                                     @Nullable String appID) throws TimeoutException {
     OrchestratorService.GetInstanceRequest.Builder requestBuilder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
         .setGetInputsAndOutputs(getInputsAndOutputs);
-    if (appID != null) {
+    if (hasAppID(appID)) {
       requestBuilder.setRouter(buildTaskRouter(appID));
     }
     OrchestratorService.GetInstanceRequest request = requestBuilder.build();
@@ -352,13 +376,21 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
+  public OrchestrationMetadata waitForInstanceCompletion(
+      String instanceId,
+      Duration timeout,
+      boolean getInputsAndOutputs) throws TimeoutException {
+    return this.waitForInstanceCompletion(instanceId, timeout, getInputsAndOutputs, null);
+  }
+
+  @Override
   public OrchestrationMetadata waitForInstanceCompletion(String instanceId, Duration timeout,
                                                          boolean getInputsAndOutputs,
                                                          @Nullable String appID) throws TimeoutException {
     OrchestratorService.GetInstanceRequest.Builder requestBuilder = OrchestratorService.GetInstanceRequest.newBuilder()
         .setInstanceId(instanceId)
         .setGetInputsAndOutputs(getInputsAndOutputs);
-    if (appID != null) {
+    if (hasAppID(appID)) {
       requestBuilder.setRouter(buildTaskRouter(appID));
     }
     OrchestratorService.GetInstanceRequest request = requestBuilder.build();
@@ -384,6 +416,11 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
+  public void terminate(String instanceId, @Nullable Object output) {
+    this.terminate(instanceId, output, null);
+  }
+
+  @Override
   public void terminate(String instanceId, @Nullable Object output, @Nullable String appID) {
     Helpers.throwIfArgumentNull(instanceId, "instanceId");
     String serializeOutput = this.dataConverter.serialize(output);
@@ -396,17 +433,22 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     if (serializeOutput != null) {
       builder.setOutput(StringValue.of(serializeOutput));
     }
-    if (appID != null) {
+    if (hasAppID(appID)) {
       builder.setRouter(buildTaskRouter(appID));
     }
     this.sidecarClient.terminateInstance(builder.build());
   }
 
   @Override
+  public PurgeResult purgeInstance(String instanceId) {
+    return this.purgeInstance(instanceId, null);
+  }
+
+  @Override
   public PurgeResult purgeInstance(String instanceId, @Nullable String appID) {
     OrchestratorService.PurgeInstancesRequest.Builder builder = OrchestratorService.PurgeInstancesRequest.newBuilder()
         .setInstanceId(instanceId);
-    if (appID != null) {
+    if (hasAppID(appID)) {
       builder.setRouter(buildTaskRouter(appID));
     }
 
@@ -448,16 +490,26 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
   }
 
   @Override
+  public void suspendInstance(String instanceId, @Nullable String reason) {
+    this.suspendInstance(instanceId, reason, null);
+  }
+
+  @Override
   public void suspendInstance(String instanceId, @Nullable String reason, @Nullable String appID) {
     OrchestratorService.SuspendRequest.Builder suspendRequestBuilder = OrchestratorService.SuspendRequest.newBuilder();
     suspendRequestBuilder.setInstanceId(instanceId);
     if (reason != null) {
       suspendRequestBuilder.setReason(StringValue.of(reason));
     }
-    if (appID != null) {
+    if (hasAppID(appID)) {
       suspendRequestBuilder.setRouter(buildTaskRouter(appID));
     }
     this.sidecarClient.suspendInstance(suspendRequestBuilder.build());
+  }
+
+  @Override
+  public void resumeInstance(String instanceId, @Nullable String reason) {
+    this.resumeInstance(instanceId, reason, null);
   }
 
   @Override
@@ -467,10 +519,15 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     if (reason != null) {
       resumeRequestBuilder.setReason(StringValue.of(reason));
     }
-    if (appID != null) {
+    if (hasAppID(appID)) {
       resumeRequestBuilder.setRouter(buildTaskRouter(appID));
     }
     this.sidecarClient.resumeInstance(resumeRequestBuilder.build());
+  }
+
+  @Override
+  public String restartInstance(String instanceId, boolean restartWithNewInstanceId) {
+    return this.restartInstance(instanceId, restartWithNewInstanceId, null);
   }
 
   @Override
@@ -488,7 +545,7 @@ public final class DurableTaskGrpcClient extends DurableTaskClient {
     if (!restartWithNewInstanceId) {
       options.setInstanceId(metadata.getInstanceId());
     }
-    if (appID != null) {
+    if (hasAppID(appID)) {
       options.setAppID(appID);
     }
     return this.scheduleNewOrchestrationInstance(metadata.getName(), options);

--- a/durabletask-client/src/test/java/io/dapr/durabletask/DurableTaskGrpcClientRoutingTest.java
+++ b/durabletask-client/src/test/java/io/dapr/durabletask/DurableTaskGrpcClientRoutingTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.durabletask;
+
+import com.google.protobuf.StringValue;
+import io.dapr.durabletask.implementation.protobuf.Orchestration;
+import io.dapr.durabletask.implementation.protobuf.OrchestratorService;
+import io.dapr.durabletask.implementation.protobuf.TaskHubSidecarServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that client operations carry a router with the target app ID when an
+ * app ID is provided (cross-app routing), and no router otherwise. Only the
+ * target app ID is set by the client; the sidecar stamps the source app ID.
+ */
+class DurableTaskGrpcClientRoutingTest {
+
+  private static final String INSTANCE_ID = "testInstanceId";
+  private static final String APP_ID = "targetApp";
+  private static final String ORCHESTRATION_NAME = "TestOrchestration";
+
+  // Returned by the getInstance RPC so that restartInstance finds an instance to reschedule.
+  private static final OrchestratorService.GetInstanceResponse EXISTING_INSTANCE =
+      OrchestratorService.GetInstanceResponse.newBuilder()
+          .setExists(true)
+          .setWorkflowState(Orchestration.WorkflowState.newBuilder()
+              .setInstanceId(INSTANCE_ID)
+              .setName(ORCHESTRATION_NAME)
+              .setInput(StringValue.of("\"payload\"")))
+          .build();
+
+  private Server server;
+  private ManagedChannel channel;
+  private DurableTaskClient client;
+
+  private final AtomicReference<OrchestratorService.CreateInstanceRequest> createRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.RaiseEventRequest> raiseEventRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.GetInstanceRequest> getInstanceRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.TerminateRequest> terminateRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.SuspendRequest> suspendRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.ResumeRequest> resumeRequest = new AtomicReference<>();
+  private final AtomicReference<OrchestratorService.PurgeInstancesRequest> purgeRequest = new AtomicReference<>();
+
+  @BeforeEach
+  void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+    server = InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(new TaskHubSidecarServiceGrpc.TaskHubSidecarServiceImplBase() {
+          @Override
+          public void startInstance(
+              OrchestratorService.CreateInstanceRequest request,
+              StreamObserver<OrchestratorService.CreateInstanceResponse> responseObserver) {
+            createRequest.set(request);
+            responseObserver.onNext(OrchestratorService.CreateInstanceResponse.newBuilder()
+                .setInstanceId(request.getInstanceId())
+                .build());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void raiseEvent(
+              OrchestratorService.RaiseEventRequest request,
+              StreamObserver<OrchestratorService.RaiseEventResponse> responseObserver) {
+            raiseEventRequest.set(request);
+            responseObserver.onNext(OrchestratorService.RaiseEventResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void getInstance(
+              OrchestratorService.GetInstanceRequest request,
+              StreamObserver<OrchestratorService.GetInstanceResponse> responseObserver) {
+            getInstanceRequest.set(request);
+            responseObserver.onNext(EXISTING_INSTANCE);
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void waitForInstanceStart(
+              OrchestratorService.GetInstanceRequest request,
+              StreamObserver<OrchestratorService.GetInstanceResponse> responseObserver) {
+            getInstanceRequest.set(request);
+            responseObserver.onNext(OrchestratorService.GetInstanceResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void waitForInstanceCompletion(
+              OrchestratorService.GetInstanceRequest request,
+              StreamObserver<OrchestratorService.GetInstanceResponse> responseObserver) {
+            getInstanceRequest.set(request);
+            responseObserver.onNext(OrchestratorService.GetInstanceResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void terminateInstance(
+              OrchestratorService.TerminateRequest request,
+              StreamObserver<OrchestratorService.TerminateResponse> responseObserver) {
+            terminateRequest.set(request);
+            responseObserver.onNext(OrchestratorService.TerminateResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void suspendInstance(
+              OrchestratorService.SuspendRequest request,
+              StreamObserver<OrchestratorService.SuspendResponse> responseObserver) {
+            suspendRequest.set(request);
+            responseObserver.onNext(OrchestratorService.SuspendResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void resumeInstance(
+              OrchestratorService.ResumeRequest request,
+              StreamObserver<OrchestratorService.ResumeResponse> responseObserver) {
+            resumeRequest.set(request);
+            responseObserver.onNext(OrchestratorService.ResumeResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void purgeInstances(
+              OrchestratorService.PurgeInstancesRequest request,
+              StreamObserver<OrchestratorService.PurgeInstancesResponse> responseObserver) {
+            purgeRequest.set(request);
+            responseObserver.onNext(OrchestratorService.PurgeInstancesResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+        })
+        .build()
+        .start();
+    channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    client = new DurableTaskGrpcClientBuilder()
+        .grpcChannel(channel)
+        .build();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+    if (channel != null) {
+      channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+    }
+    if (server != null) {
+      server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static void assertTargetsApp(Orchestration.TaskRouter router) {
+    assertEquals(APP_ID, router.getTargetAppID());
+    // The client must not stamp the source app ID; the sidecar does.
+    assertEquals("", router.getSourceAppID());
+    assertFalse(router.hasTargetAppNamespace());
+  }
+
+  @Test
+  void scheduleWithoutAppIdDoesNotSetRouter() {
+    client.scheduleNewOrchestrationInstance("TestOrchestration", new NewOrchestrationInstanceOptions());
+
+    assertFalse(createRequest.get().hasRouter());
+  }
+
+  @Test
+  void scheduleWithAppIdSetsRouter() {
+    client.scheduleNewOrchestrationInstance("TestOrchestration",
+        new NewOrchestrationInstanceOptions().setAppID(APP_ID));
+
+    assertTrue(createRequest.get().hasRouter());
+    assertTargetsApp(createRequest.get().getRouter());
+  }
+
+  @Test
+  void raiseEventWithoutAppIdDoesNotSetRouter() {
+    client.raiseEvent(INSTANCE_ID, "testEvent", "payload");
+
+    assertFalse(raiseEventRequest.get().hasRouter());
+  }
+
+  @Test
+  void raiseEventWithAppIdSetsRouter() {
+    client.raiseEvent(INSTANCE_ID, "testEvent", "payload", APP_ID);
+
+    assertTrue(raiseEventRequest.get().hasRouter());
+    assertTargetsApp(raiseEventRequest.get().getRouter());
+  }
+
+  @Test
+  void getInstanceMetadataWithoutAppIdDoesNotSetRouter() {
+    client.getInstanceMetadata(INSTANCE_ID, true);
+
+    assertFalse(getInstanceRequest.get().hasRouter());
+  }
+
+  @Test
+  void getInstanceMetadataWithAppIdSetsRouter() {
+    client.getInstanceMetadata(INSTANCE_ID, true, APP_ID);
+
+    assertTrue(getInstanceRequest.get().hasRouter());
+    assertTargetsApp(getInstanceRequest.get().getRouter());
+  }
+
+  @Test
+  void waitForInstanceStartWithoutAppIdDoesNotSetRouter() throws Exception {
+    client.waitForInstanceStart(INSTANCE_ID, Duration.ofSeconds(5), false);
+
+    assertFalse(getInstanceRequest.get().hasRouter());
+  }
+
+  @Test
+  void waitForInstanceStartWithAppIdSetsRouter() throws Exception {
+    client.waitForInstanceStart(INSTANCE_ID, Duration.ofSeconds(5), false, APP_ID);
+
+    assertTrue(getInstanceRequest.get().hasRouter());
+    assertTargetsApp(getInstanceRequest.get().getRouter());
+  }
+
+  @Test
+  void waitForInstanceCompletionWithoutAppIdDoesNotSetRouter() throws Exception {
+    client.waitForInstanceCompletion(INSTANCE_ID, Duration.ofSeconds(5), false);
+
+    assertFalse(getInstanceRequest.get().hasRouter());
+  }
+
+  @Test
+  void waitForInstanceCompletionWithAppIdSetsRouter() throws Exception {
+    client.waitForInstanceCompletion(INSTANCE_ID, Duration.ofSeconds(5), false, APP_ID);
+
+    assertTrue(getInstanceRequest.get().hasRouter());
+    assertTargetsApp(getInstanceRequest.get().getRouter());
+  }
+
+  @Test
+  void terminateWithoutAppIdDoesNotSetRouter() {
+    client.terminate(INSTANCE_ID, null);
+
+    assertFalse(terminateRequest.get().hasRouter());
+  }
+
+  @Test
+  void terminateWithAppIdSetsRouter() {
+    client.terminate(INSTANCE_ID, null, APP_ID);
+
+    assertTrue(terminateRequest.get().hasRouter());
+    assertTargetsApp(terminateRequest.get().getRouter());
+  }
+
+  @Test
+  void suspendWithoutAppIdDoesNotSetRouter() {
+    client.suspendInstance(INSTANCE_ID, "reason");
+
+    assertFalse(suspendRequest.get().hasRouter());
+  }
+
+  @Test
+  void suspendWithAppIdSetsRouter() {
+    client.suspendInstance(INSTANCE_ID, "reason", APP_ID);
+
+    assertTrue(suspendRequest.get().hasRouter());
+    assertTargetsApp(suspendRequest.get().getRouter());
+  }
+
+  @Test
+  void resumeWithoutAppIdDoesNotSetRouter() {
+    client.resumeInstance(INSTANCE_ID, "reason");
+
+    assertFalse(resumeRequest.get().hasRouter());
+  }
+
+  @Test
+  void resumeWithAppIdSetsRouter() {
+    client.resumeInstance(INSTANCE_ID, "reason", APP_ID);
+
+    assertTrue(resumeRequest.get().hasRouter());
+    assertTargetsApp(resumeRequest.get().getRouter());
+  }
+
+  @Test
+  void purgeInstanceWithoutAppIdDoesNotSetRouter() {
+    client.purgeInstance(INSTANCE_ID);
+
+    assertFalse(purgeRequest.get().hasRouter());
+  }
+
+  @Test
+  void purgeInstanceWithAppIdSetsRouter() {
+    client.purgeInstance(INSTANCE_ID, APP_ID);
+
+    assertTrue(purgeRequest.get().hasRouter());
+    assertTargetsApp(purgeRequest.get().getRouter());
+  }
+
+  /**
+   * restartInstance reschedules the instance, so it issues two requests: the metadata lookup for the
+   * original instance and the create request for the replacement. Both must stay on the local app.
+   */
+  @Test
+  void restartInstanceWithoutAppIdDoesNotSetRouterOnEitherRequest() {
+    client.restartInstance(INSTANCE_ID, false);
+
+    assertFalse(getInstanceRequest.get().hasRouter());
+    assertFalse(createRequest.get().hasRouter());
+  }
+
+  /**
+   * Both requests issued by restartInstance must carry the router, otherwise the replacement instance
+   * would be created on the calling app instead of the app that owns the original instance.
+   */
+  @Test
+  void restartInstanceWithAppIdSetsRouterOnBothRequests() {
+    client.restartInstance(INSTANCE_ID, false, APP_ID);
+
+    assertTrue(getInstanceRequest.get().hasRouter());
+    assertTargetsApp(getInstanceRequest.get().getRouter());
+
+    assertTrue(createRequest.get().hasRouter());
+    assertTargetsApp(createRequest.get().getRouter());
+  }
+
+  @Test
+  void restartInstanceWithNewInstanceIdWithAppIdSetsRouterOnBothRequests() {
+    client.restartInstance(INSTANCE_ID, true, APP_ID);
+
+    assertTrue(getInstanceRequest.get().hasRouter());
+    assertTargetsApp(getInstanceRequest.get().getRouter());
+
+    assertTrue(createRequest.get().hasRouter());
+    assertTargetsApp(createRequest.get().getRouter());
+  }
+}

--- a/durabletask-client/src/test/java/io/dapr/durabletask/DurableTaskGrpcClientRoutingTest.java
+++ b/durabletask-client/src/test/java/io/dapr/durabletask/DurableTaskGrpcClientRoutingTest.java
@@ -357,4 +357,25 @@ class DurableTaskGrpcClientRoutingTest {
     assertTrue(createRequest.get().hasRouter());
     assertTargetsApp(createRequest.get().getRouter());
   }
+
+  @Test
+  void emptyAppIdIsTreatedAsLocalRouting() {
+    client.raiseEvent(INSTANCE_ID, "testEvent", "payload", "");
+    assertFalse(raiseEventRequest.get().hasRouter());
+
+    client.getInstanceMetadata(INSTANCE_ID, true, "");
+    assertFalse(getInstanceRequest.get().hasRouter());
+
+    client.terminate(INSTANCE_ID, null, "");
+    assertFalse(terminateRequest.get().hasRouter());
+
+    client.suspendInstance(INSTANCE_ID, null, "");
+    assertFalse(suspendRequest.get().hasRouter());
+
+    client.resumeInstance(INSTANCE_ID, null, "");
+    assertFalse(resumeRequest.get().hasRouter());
+
+    client.purgeInstance(INSTANCE_ID, "");
+    assertFalse(purgeRequest.get().hasRouter());
+  }
 }

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -314,6 +314,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${failsafe.version}</version>
+        <configuration>
+          <!--
+            Tests tagged dapr-head need a daprd built from dapr/dapr master, so they cannot run
+            against the release image the default suite pins. The dapr-head profile runs them.
+          -->
+          <excludedGroups>dapr-head</excludedGroups>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -329,6 +336,27 @@
       <properties>
         <springboot.version>${env.PRODUCT_SPRING_BOOT_VERSION}</springboot.version>
       </properties>
+    </profile>
+
+    <!--
+      Runs only the tests that require a daprd built from dapr/dapr master, covering runtime
+      features no release carries yet.
+    -->
+    <profile>
+      <id>dapr-head</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${failsafe.version}</version>
+            <configuration>
+              <groups>dapr-head</groups>
+              <excludedGroups combine.self="override"/>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
@@ -6,7 +6,11 @@ public interface ContainerConstants {
   String DAPR_RUNTIME_IMAGE_TAG = DaprContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
   // Built from dapr/dapr master. Needed by tests covering runtime features that no release
   // carries yet, where the pinned release image would silently ignore the new request fields.
+  // The whole control plane moves together so the sidecar never talks to an older placement or
+  // scheduler than it was built against.
   String DAPR_RUNTIME_EDGE_IMAGE_TAG = "daprio/daprd:edge";
+  String DAPR_PLACEMENT_EDGE_IMAGE_TAG = "daprio/placement:edge";
+  String DAPR_SCHEDULER_EDGE_IMAGE_TAG = "daprio/scheduler:edge";
   String DAPR_PLACEMENT_IMAGE_TAG = DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
   String DAPR_SCHEDULER_IMAGE_TAG = DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
   String TOXI_PROXY_IMAGE_TAG = "ghcr.io/shopify/toxiproxy:2.5.0";

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/ContainerConstants.java
@@ -4,6 +4,9 @@ import io.dapr.testcontainers.DaprContainerConstants;
 
 public interface ContainerConstants {
   String DAPR_RUNTIME_IMAGE_TAG = DaprContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
+  // Built from dapr/dapr master. Needed by tests covering runtime features that no release
+  // carries yet, where the pinned release image would silently ignore the new request fields.
+  String DAPR_RUNTIME_EDGE_IMAGE_TAG = "daprio/daprd:edge";
   String DAPR_PLACEMENT_IMAGE_TAG = DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
   String DAPR_SCHEDULER_IMAGE_TAG = DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
   String TOXI_PROXY_IMAGE_TAG = "ghcr.io/shopify/toxiproxy:2.5.0";

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/CrossAppEventWorker.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/CrossAppEventWorker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.it.testcontainers.workflows.multiapp;
+
+import io.dapr.workflows.runtime.WorkflowRuntime;
+import io.dapr.workflows.runtime.WorkflowRuntimeBuilder;
+
+/**
+ * Worker that registers {@link CrossAppEventWorkflow}. It is started for the host app only, so any
+ * instance of that workflow can only be running on the host app.
+ */
+public class CrossAppEventWorker {
+  public static void main(String[] args) throws Exception {
+    WorkflowRuntimeBuilder builder = new WorkflowRuntimeBuilder()
+        .registerWorkflow(CrossAppEventWorkflow.class);
+    try (WorkflowRuntime runtime = builder.build()) {
+      System.out.println("CrossAppEventWorker started - registered CrossAppEventWorkflow");
+      runtime.start();
+    }
+  }
+}

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/CrossAppEventWorkflow.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/CrossAppEventWorkflow.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.it.testcontainers.workflows.multiapp;
+
+import io.dapr.workflows.Workflow;
+import io.dapr.workflows.WorkflowStub;
+import org.slf4j.Logger;
+
+/**
+ * Workflow that blocks on an external event so that a remote caller can observe it running,
+ * suspend it, resume it, raise the event and terminate it.
+ *
+ * <p>The completion output carries the app ID of the app that actually ran the workflow, so a test
+ * can assert which app hosted the instance.
+ */
+public class CrossAppEventWorkflow implements Workflow {
+
+  public static final String CONTINUE_EVENT = "continue";
+
+  @Override
+  public WorkflowStub create() {
+    return ctx -> {
+      Logger logger = ctx.getLogger();
+      String input = ctx.getInput(String.class);
+      logger.info("CrossAppEventWorkflow {} started with input: {}", ctx.getInstanceId(), input);
+
+      String eventPayload = ctx.waitForExternalEvent(CONTINUE_EVENT, String.class).await();
+      logger.info("CrossAppEventWorkflow {} received event: {}", ctx.getInstanceId(), eventPayload);
+
+      ctx.complete(input + " [" + eventPayload + "] [hosted by " + System.getProperty("dapr.app.id") + "]");
+    };
+  }
+}

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.it.testcontainers.workflows.multiapp;
+
+import io.dapr.config.Properties;
+import io.dapr.it.testcontainers.ContainerConstants;
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.DaprContainer;
+import io.dapr.testcontainers.DaprLogLevel;
+import io.dapr.testcontainers.DaprPlacementContainer;
+import io.dapr.testcontainers.DaprSchedulerContainer;
+import io.dapr.workflows.client.DaprWorkflowClient;
+import io.dapr.workflows.client.NewWorkflowOptions;
+import io.dapr.workflows.client.WorkflowRuntimeStatus;
+import io.dapr.workflows.client.WorkflowState;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_EDGE_IMAGE_TAG;
+import static io.dapr.testcontainers.DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
+import static io.dapr.testcontainers.DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Cross-app workflow operations integration test.
+ *
+ * <p>Two apps share a placement and a scheduler on one Docker network:
+ * <ul>
+ *   <li>the caller app, which has no workflow worker at all</li>
+ *   <li>the host app, whose worker is the only one that registers {@link CrossAppEventWorkflow}</li>
+ * </ul>
+ *
+ * <p>A {@link DaprWorkflowClient} in the test JVM talks only to the caller app's sidecar and drives
+ * the whole lifecycle of an instance owned by the host app, using the app ID overloads. Because the
+ * workflow is registered only on the host app, an instance that actually runs proves the operations
+ * were routed there rather than handled locally.
+ */
+@Testcontainers
+@Tag("testcontainers")
+public class WorkflowsMultiAppCrossAppOperationsIT {
+
+  private static final String CALLER_APP_ID = "crossapp-caller";
+  private static final String HOST_APP_ID = "crossapp-host";
+
+  private static final Duration POLL_TIMEOUT = Duration.ofSeconds(60);
+
+  private static final Network DAPR_NETWORK = Network.newNetwork();
+
+  @Container
+  private final static DaprPlacementContainer sharedPlacementContainer = new DaprPlacementContainer(DAPR_PLACEMENT_IMAGE_TAG)
+      .withNetwork(DAPR_NETWORK)
+      .withNetworkAliases("placement")
+      .withReuse(false);
+
+  @Container
+  private final static DaprSchedulerContainer sharedSchedulerContainer = new DaprSchedulerContainer(DAPR_SCHEDULER_IMAGE_TAG)
+      .withNetwork(DAPR_NETWORK)
+      .withNetworkAliases("scheduler")
+      .withReuse(false);
+
+  // Caller app sidecar. The test JVM's workflow client connects to this one.
+  //
+  // Both sidecars run the edge image: cross-app client operations are not in any release yet, and a
+  // release daprd ignores the app ID and applies every operation to the caller's own app, which
+  // would make this test fail rather than skip. Placement and scheduler stay on the release images
+  // because the feature lives entirely in daprd.
+  @Container
+  private final static DaprContainer CALLER_SIDECAR = new DaprContainer(DAPR_RUNTIME_EDGE_IMAGE_TAG)
+      .withAppName(CALLER_APP_ID)
+      .withNetwork(DAPR_NETWORK)
+      .withNetworkAliases("caller-sidecar")
+      .withPlacementContainer(sharedPlacementContainer)
+      .withSchedulerContainer(sharedSchedulerContainer)
+      .withComponent(new Component("kvstore", "state.in-memory", "v1", Map.of("actorStateStore", "true")))
+      .withDaprLogLevel(DaprLogLevel.DEBUG)
+      .dependsOn(sharedPlacementContainer, sharedSchedulerContainer)
+      .withLogConsumer(outputFrame -> System.out.println("CALLER: " + outputFrame.getUtf8String()))
+      .withAppChannelAddress("host.testcontainers.internal");
+
+  // Host app sidecar. This is the app that owns and runs the workflow instances.
+  @Container
+  private final static DaprContainer HOST_SIDECAR = new DaprContainer(DAPR_RUNTIME_EDGE_IMAGE_TAG)
+      .withAppName(HOST_APP_ID)
+      .withNetwork(DAPR_NETWORK)
+      .withNetworkAliases("host-sidecar")
+      .withPlacementContainer(sharedPlacementContainer)
+      .withSchedulerContainer(sharedSchedulerContainer)
+      .withAppChannelAddress("caller-sidecar:3500")
+      .withDaprLogLevel(DaprLogLevel.DEBUG)
+      .dependsOn(sharedPlacementContainer, sharedSchedulerContainer, CALLER_SIDECAR)
+      .withComponent(new Component("kvstore", "state.in-memory", "v1", Map.of("actorStateStore", "true")))
+      .withLogConsumer(outputFrame -> System.out.println("HOST: " + outputFrame.getUtf8String()));
+
+  // The only worker in the test: it registers CrossAppEventWorkflow for the host app.
+  @Container
+  private final static GenericContainer<?> hostWorker = new GenericContainer<>(ContainerConstants.JDK_17_TEMURIN_JAMMY)
+      .withCopyFileToContainer(MountableFile.forHostPath("target"), "/app")
+      .withWorkingDirectory("/app")
+      .withCommand("java", "-cp", "test-classes:classes:dependency/*:*",
+          "-Ddapr.app.id=" + HOST_APP_ID,
+          "-Ddapr.grpc.endpoint=host-sidecar:50001",
+          "-Ddapr.http.endpoint=host-sidecar:3500",
+          "io.dapr.it.testcontainers.workflows.multiapp.CrossAppEventWorker")
+      .withNetwork(DAPR_NETWORK)
+      .dependsOn(HOST_SIDECAR)
+      .waitingFor(Wait.forLogMessage(".*CrossAppEventWorker started.*", 1))
+      .withLogConsumer(outputFrame -> System.out.println("HostWorker: " + outputFrame.getUtf8String()));
+
+  @Test
+  public void testCrossAppWorkflowLifecycle() throws Exception {
+    try (DaprWorkflowClient workflowClient = callerWorkflowClient()) {
+      String instanceId = workflowClient.scheduleNewWorkflow(CrossAppEventWorkflow.class,
+          new NewWorkflowOptions().setAppId(HOST_APP_ID).setInput("Hello"));
+      assertNotNull(instanceId, "Workflow instance ID should not be null");
+
+      WorkflowState started = workflowClient.waitForWorkflowStart(instanceId, POLL_TIMEOUT, false, HOST_APP_ID);
+      assertNotNull(started, "Workflow should have started on the host app");
+
+      WorkflowState state = workflowClient.getWorkflowState(instanceId, true, HOST_APP_ID);
+      assertNotNull(state, "Workflow state should be readable from the host app");
+      assertEquals(CrossAppEventWorkflow.class.getCanonicalName(), state.getName());
+      assertEquals(instanceId, state.getWorkflowId());
+
+      assertNotHostedByCaller(workflowClient, instanceId);
+
+      workflowClient.suspendWorkflow(instanceId, "pausing from the caller app", HOST_APP_ID);
+      awaitStatus(workflowClient, instanceId, WorkflowRuntimeStatus.SUSPENDED);
+
+      workflowClient.resumeWorkflow(instanceId, "resuming from the caller app", HOST_APP_ID);
+      awaitStatus(workflowClient, instanceId, WorkflowRuntimeStatus.RUNNING);
+
+      workflowClient.raiseEvent(instanceId, CrossAppEventWorkflow.CONTINUE_EVENT, "carry on", HOST_APP_ID);
+
+      WorkflowState completed = workflowClient.waitForWorkflowCompletion(instanceId, POLL_TIMEOUT, true, HOST_APP_ID);
+      assertNotNull(completed, "Workflow status should not be null");
+      assertEquals(WorkflowRuntimeStatus.COMPLETED, completed.getRuntimeStatus());
+      assertEquals("Hello [carry on] [hosted by " + HOST_APP_ID + "]", completed.readOutputAs(String.class),
+          "The workflow must have run on the host app, not on the caller app");
+
+      assertTrue(workflowClient.purgeWorkflow(instanceId, HOST_APP_ID),
+          "Purging the host app's instance from the caller app should report a purged instance");
+    }
+  }
+
+  @Test
+  public void testCrossAppTerminate() throws Exception {
+    try (DaprWorkflowClient workflowClient = callerWorkflowClient()) {
+      String instanceId = workflowClient.scheduleNewWorkflow(CrossAppEventWorkflow.class,
+          new NewWorkflowOptions().setAppId(HOST_APP_ID).setInput("Doomed"));
+      assertNotNull(instanceId, "Workflow instance ID should not be null");
+
+      workflowClient.waitForWorkflowStart(instanceId, POLL_TIMEOUT, false, HOST_APP_ID);
+      assertNotHostedByCaller(workflowClient, instanceId);
+
+      workflowClient.terminateWorkflow(instanceId, "terminated from the caller app", HOST_APP_ID);
+      awaitStatus(workflowClient, instanceId, WorkflowRuntimeStatus.TERMINATED);
+
+      assertTrue(workflowClient.purgeWorkflow(instanceId, HOST_APP_ID),
+          "Purging the terminated instance from the caller app should report a purged instance");
+    }
+  }
+
+  private static DaprWorkflowClient callerWorkflowClient() {
+    Map<String, String> propertyOverrides = Map.of(
+        "dapr.grpc.endpoint", CALLER_SIDECAR.getGrpcEndpoint(),
+        "dapr.http.endpoint", CALLER_SIDECAR.getHttpEndpoint()
+    );
+
+    return new DaprWorkflowClient(new Properties(propertyOverrides));
+  }
+
+  /**
+   * The two apps have their own state stores and their own workflow actor types, so the instance must
+   * not be visible when the same client is used without a target app ID.
+   */
+  private static void assertNotHostedByCaller(DaprWorkflowClient workflowClient, String instanceId) {
+    WorkflowState localState;
+    try {
+      localState = workflowClient.getWorkflowState(instanceId, false);
+    } catch (RuntimeException e) {
+      // A runtime that reports an unknown instance as an error is equally proof it is not local.
+      return;
+    }
+
+    if (localState != null && localState.getName() != null && !localState.getName().isEmpty()) {
+      fail("Instance " + instanceId + " should not exist on " + CALLER_APP_ID
+          + " but the caller app reported it as " + localState.getName());
+    }
+  }
+
+  private static void awaitStatus(DaprWorkflowClient workflowClient, String instanceId,
+                                  WorkflowRuntimeStatus expected) throws InterruptedException {
+    Instant deadline = Instant.now().plus(POLL_TIMEOUT);
+    WorkflowRuntimeStatus observed = null;
+
+    while (Instant.now().isBefore(deadline)) {
+      WorkflowState state = workflowClient.getWorkflowState(instanceId, false, HOST_APP_ID);
+      observed = state == null ? null : state.getRuntimeStatus();
+      if (observed == expected) {
+        return;
+      }
+      Thread.sleep(500);
+    }
+
+    fail("Timed out waiting for status " + expected + " on " + instanceId + ", last seen: " + observed);
+  }
+}

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
@@ -31,13 +31,17 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 
+import static io.dapr.it.testcontainers.ContainerConstants.DAPR_PLACEMENT_EDGE_IMAGE_TAG;
 import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_EDGE_IMAGE_TAG;
+import static io.dapr.it.testcontainers.ContainerConstants.DAPR_RUNTIME_IMAGE_TAG;
+import static io.dapr.it.testcontainers.ContainerConstants.DAPR_SCHEDULER_EDGE_IMAGE_TAG;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_PLACEMENT_IMAGE_TAG;
 import static io.dapr.testcontainers.DaprContainerConstants.DAPR_SCHEDULER_IMAGE_TAG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,26 +75,34 @@ public class WorkflowsMultiAppCrossAppOperationsIT {
 
   private static final Network DAPR_NETWORK = Network.newNetwork();
 
+  // The containers assert the image is the release one they pin, so each edge build has to be
+  // declared as a substitute for it explicitly.
+  private static final DockerImageName EDGE_DAPRD_IMAGE = DockerImageName.parse(DAPR_RUNTIME_EDGE_IMAGE_TAG)
+      .asCompatibleSubstituteFor(DAPR_RUNTIME_IMAGE_TAG);
+  private static final DockerImageName EDGE_PLACEMENT_IMAGE = DockerImageName.parse(DAPR_PLACEMENT_EDGE_IMAGE_TAG)
+      .asCompatibleSubstituteFor(DAPR_PLACEMENT_IMAGE_TAG);
+  private static final DockerImageName EDGE_SCHEDULER_IMAGE = DockerImageName.parse(DAPR_SCHEDULER_EDGE_IMAGE_TAG)
+      .asCompatibleSubstituteFor(DAPR_SCHEDULER_IMAGE_TAG);
+
   @Container
-  private final static DaprPlacementContainer sharedPlacementContainer = new DaprPlacementContainer(DAPR_PLACEMENT_IMAGE_TAG)
+  private final static DaprPlacementContainer sharedPlacementContainer = new DaprPlacementContainer(EDGE_PLACEMENT_IMAGE)
       .withNetwork(DAPR_NETWORK)
       .withNetworkAliases("placement")
       .withReuse(false);
 
   @Container
-  private final static DaprSchedulerContainer sharedSchedulerContainer = new DaprSchedulerContainer(DAPR_SCHEDULER_IMAGE_TAG)
+  private final static DaprSchedulerContainer sharedSchedulerContainer = new DaprSchedulerContainer(EDGE_SCHEDULER_IMAGE)
       .withNetwork(DAPR_NETWORK)
       .withNetworkAliases("scheduler")
       .withReuse(false);
 
   // Caller app sidecar. The test JVM's workflow client connects to this one.
   //
-  // Both sidecars run the edge image: cross-app client operations are not in any release yet, and a
+  // The stack runs the edge images: cross-app client operations are not in any release yet, and a
   // release daprd ignores the app ID and applies every operation to the caller's own app, which
-  // would make this test fail rather than skip. Placement and scheduler stay on the release images
-  // because the feature lives entirely in daprd.
+  // would make this test fail rather than skip.
   @Container
-  private final static DaprContainer CALLER_SIDECAR = new DaprContainer(DAPR_RUNTIME_EDGE_IMAGE_TAG)
+  private final static DaprContainer CALLER_SIDECAR = new DaprContainer(EDGE_DAPRD_IMAGE)
       .withAppName(CALLER_APP_ID)
       .withNetwork(DAPR_NETWORK)
       .withNetworkAliases("caller-sidecar")
@@ -104,7 +116,7 @@ public class WorkflowsMultiAppCrossAppOperationsIT {
 
   // Host app sidecar. This is the app that owns and runs the workflow instances.
   @Container
-  private final static DaprContainer HOST_SIDECAR = new DaprContainer(DAPR_RUNTIME_EDGE_IMAGE_TAG)
+  private final static DaprContainer HOST_SIDECAR = new DaprContainer(EDGE_DAPRD_IMAGE)
       .withAppName(HOST_APP_ID)
       .withNetwork(DAPR_NETWORK)
       .withNetworkAliases("host-sidecar")

--- a/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/testcontainers/workflows/multiapp/WorkflowsMultiAppCrossAppOperationsIT.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Testcontainers
 @Tag("testcontainers")
+@Tag("dapr-head")
 public class WorkflowsMultiAppCrossAppOperationsIT {
 
   private static final String CALLER_APP_ID = "crossapp-caller";

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
@@ -227,6 +227,23 @@ public class DaprWorkflowClient implements AutoCloseable {
   }
 
   /**
+   * Suspend the workflow associated with the provided instance id, owned by another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param workflowInstanceId Workflow instance id to suspend.
+   * @param reason             reason for suspending the workflow instance.
+   * @param appId              ID of the app that owns the workflow instance. May be null to target the local app.
+   */
+  public void suspendWorkflow(String workflowInstanceId, @Nullable String reason, @Nullable String appId) {
+    this.innerClient.suspendInstance(workflowInstanceId, reason, appId);
+  }
+
+  /**
    * Resume the workflow associated with the provided instance id.
    *
    * @param workflowInstanceId Workflow instance id to resume.
@@ -237,6 +254,23 @@ public class DaprWorkflowClient implements AutoCloseable {
   }
 
   /**
+   * Resume the workflow associated with the provided instance id, owned by another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param workflowInstanceId Workflow instance id to resume.
+   * @param reason             reason for resuming the workflow instance.
+   * @param appId              ID of the app that owns the workflow instance. May be null to target the local app.
+   */
+  public void resumeWorkflow(String workflowInstanceId, @Nullable String reason, @Nullable String appId) {
+    this.innerClient.resumeInstance(workflowInstanceId, reason, appId);
+  }
+
+  /**
    * Terminates the workflow associated with the provided instance id.
    *
    * @param workflowInstanceId Workflow instance id to terminate.
@@ -244,6 +278,23 @@ public class DaprWorkflowClient implements AutoCloseable {
    */
   public void terminateWorkflow(String workflowInstanceId, @Nullable Object output) {
     this.innerClient.terminate(workflowInstanceId, output);
+  }
+
+  /**
+   * Terminates the workflow associated with the provided instance id, owned by another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param workflowInstanceId Workflow instance id to terminate.
+   * @param output             the optional output to set for the terminated orchestration instance.
+   * @param appId              ID of the app that owns the workflow instance. May be null to target the local app.
+   */
+  public void terminateWorkflow(String workflowInstanceId, @Nullable Object output, @Nullable String appId) {
+    this.innerClient.terminate(workflowInstanceId, output, appId);
   }
 
   /**
@@ -274,6 +325,28 @@ public class DaprWorkflowClient implements AutoCloseable {
   @Nullable
   public WorkflowState getWorkflowState(String instanceId, boolean getInputsAndOutputs) {
     OrchestrationMetadata metadata = this.innerClient.getInstanceMetadata(instanceId, getInputsAndOutputs);
+
+    return metadata == null ? null : new DefaultWorkflowState(metadata);
+  }
+
+  /**
+   * Fetches workflow instance metadata from the durable store of another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param instanceId          the unique ID of the workflow instance to fetch
+   * @param getInputsAndOutputs <code>true</code> to fetch the workflow instance's
+   *                            inputs, outputs, and custom status, or <code>false</code> to omit them
+   * @param appId               ID of the app that owns the workflow instance. May be null to target the local app.
+   * @return a metadata record that describes the workflow instance and it execution status, or a default instance
+   */
+  @Nullable
+  public WorkflowState getWorkflowState(String instanceId, boolean getInputsAndOutputs, @Nullable String appId) {
+    OrchestrationMetadata metadata = this.innerClient.getInstanceMetadata(instanceId, getInputsAndOutputs, appId);
 
     return metadata == null ? null : new DefaultWorkflowState(metadata);
   }
@@ -329,6 +402,34 @@ public class DaprWorkflowClient implements AutoCloseable {
       throws TimeoutException {
 
     OrchestrationMetadata metadata = this.innerClient.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs);
+
+    return metadata == null ? null : new DefaultWorkflowState(metadata);
+  }
+
+  /**
+   * Waits for a workflow owned by another app to start running.
+   *
+   * <p>See {@link #waitForWorkflowStart(String, Duration, boolean)} for the wait semantics.
+   * Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param instanceId          the unique ID of the workflow instance to wait for
+   * @param timeout             the amount of time to wait for the workflow instance to start
+   * @param getInputsAndOutputs true to fetch the workflow instance's
+   *                            inputs, outputs, and custom status, or false to omit them
+   * @param appId               ID of the app that owns the workflow instance. May be null to target the local app.
+   * @return the workflow instance metadata or null if no such instance is found
+   * @throws TimeoutException when the workflow instance is not started within the specified amount of time
+   */
+  @Nullable
+  public WorkflowState waitForWorkflowStart(String instanceId, Duration timeout, boolean getInputsAndOutputs,
+                                            @Nullable String appId) throws TimeoutException {
+
+    OrchestrationMetadata metadata = this.innerClient.waitForInstanceStart(instanceId, timeout, getInputsAndOutputs,
+        appId);
 
     return metadata == null ? null : new DefaultWorkflowState(metadata);
   }
@@ -393,6 +494,33 @@ public class DaprWorkflowClient implements AutoCloseable {
   }
 
   /**
+   * Waits for a workflow owned by another app to complete.
+   *
+   * <p>See {@link #waitForWorkflowCompletion(String, Duration, boolean)} for the wait semantics.
+   * Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param instanceId          the unique ID of the workflow instance to wait for
+   * @param timeout             the amount of time to wait for the workflow instance to complete
+   * @param getInputsAndOutputs true to fetch the workflow instance's inputs, outputs, and custom
+   *                            status, or false to omit them
+   * @param appId               ID of the app that owns the workflow instance. May be null to target the local app.
+   * @return the workflow instance metadata or null if no such instance is found
+   * @throws TimeoutException when the workflow instance is not completed within the specified amount of time
+   */
+  @Nullable
+  public WorkflowState waitForWorkflowCompletion(String instanceId, Duration timeout, boolean getInputsAndOutputs,
+                                                 @Nullable String appId) throws TimeoutException {
+
+    OrchestrationMetadata metadata = this.innerClient.waitForInstanceCompletion(instanceId, timeout,
+        getInputsAndOutputs, appId);
+    return metadata == null ? null : new DefaultWorkflowState(metadata);
+  }
+
+  /**
    * Sends an event notification message to awaiting workflow instance.
    *
    * @param workflowInstanceId The ID of the workflow instance that will handle the event.
@@ -401,6 +529,24 @@ public class DaprWorkflowClient implements AutoCloseable {
    */
   public void raiseEvent(String workflowInstanceId, String eventName, Object eventPayload) {
     this.innerClient.raiseEvent(workflowInstanceId, eventName, eventPayload);
+  }
+
+  /**
+   * Sends an event notification message to a waiting workflow instance owned by another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param workflowInstanceId The ID of the workflow instance that will handle the event.
+   * @param eventName          The name of the event. Event names are case-insensitive.
+   * @param eventPayload       The serializable data payload to include with the event.
+   * @param appId              ID of the app that owns the workflow instance. May be null to target the local app.
+   */
+  public void raiseEvent(String workflowInstanceId, String eventName, Object eventPayload, @Nullable String appId) {
+    this.innerClient.raiseEvent(workflowInstanceId, eventName, eventPayload, appId);
   }
 
   /**
@@ -429,6 +575,29 @@ public class DaprWorkflowClient implements AutoCloseable {
    */
   public boolean purgeWorkflow(String workflowInstanceId) {
     PurgeResult result = this.innerClient.purgeInstance(workflowInstanceId);
+
+    if (result != null) {
+      return result.getDeletedInstanceCount() > 0;
+    }
+
+    return false;
+  }
+
+  /**
+   * Purges workflow instance state from the workflow state store of another app.
+   *
+   * <p>Permission to operate on workflows owned by another app is governed by the target app's
+   * WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the operation applies to the local app instead.
+   *
+   * @param workflowInstanceId The unique ID of the workflow instance to purge.
+   * @param appId              ID of the app that owns the workflow instance. May be null to target the local app.
+   * @return Return true if the workflow state was found and purged successfully otherwise false.
+   */
+  public boolean purgeWorkflow(String workflowInstanceId, @Nullable String appId) {
+    PurgeResult result = this.innerClient.purgeInstance(workflowInstanceId, appId);
 
     if (result != null) {
       return result.getDeletedInstanceCount() > 0;
@@ -534,6 +703,9 @@ public class DaprWorkflowClient implements AutoCloseable {
     }
 
     instanceOptions.setEnforceUniqueInstanceId(options.isEnforceUniqueInstanceId());
+    if (options.getAppId() != null) {
+      instanceOptions.setAppID(options.getAppId());
+    }
 
     return instanceOptions;
   }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
@@ -342,7 +342,8 @@ public class DaprWorkflowClient implements AutoCloseable {
    * @param getInputsAndOutputs <code>true</code> to fetch the workflow instance's
    *                            inputs, outputs, and custom status, or <code>false</code> to omit them
    * @param appId               ID of the app that owns the workflow instance. May be null to target the local app.
-   * @return a metadata record that describes the workflow instance and it execution status, or a default instance
+   * @return a metadata record that describes the workflow instance and its execution status, or null when no such
+   *     instance is found
    */
   @Nullable
   public WorkflowState getWorkflowState(String instanceId, boolean getInputsAndOutputs, @Nullable String appId) {

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/DaprWorkflowClient.java
@@ -342,8 +342,9 @@ public class DaprWorkflowClient implements AutoCloseable {
    * @param getInputsAndOutputs <code>true</code> to fetch the workflow instance's
    *                            inputs, outputs, and custom status, or <code>false</code> to omit them
    * @param appId               ID of the app that owns the workflow instance. May be null to target the local app.
-   * @return a metadata record that describes the workflow instance and its execution status, or null when no such
-   *     instance is found
+   * @return a metadata record that describes the workflow instance and its execution status, or a default instance
+   *     when no such instance is found, matching {@link #getWorkflowState(String, boolean)}. Null only when the
+   *     underlying client returns no metadata at all.
    */
   @Nullable
   public WorkflowState getWorkflowState(String instanceId, boolean getInputsAndOutputs, @Nullable String appId) {

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOptions.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOptions.java
@@ -162,7 +162,8 @@ public class NewWorkflowOptions {
   /**
    * Gets the configured app ID of the app that will run the new workflow.
    *
-   * @return the configured app ID, or null when the workflow runs on the local app.
+   * @return the configured app ID, or null when none was set. A null or empty value runs the workflow on the
+   *     local app.
    */
   public String getAppId() {
     return this.appId;

--- a/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOptions.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/client/NewWorkflowOptions.java
@@ -25,6 +25,7 @@ public class NewWorkflowOptions {
   private Object input;
   private Instant startTime;
   private boolean enforceUniqueInstanceId;
+  private String appId;
 
   /**
    * Sets the version of the workflow to start.
@@ -96,6 +97,24 @@ public class NewWorkflowOptions {
   }
 
   /**
+   * Sets the app ID of the app that will run the new workflow.
+   *
+   * <p>By default, workflows are scheduled on the app that starts them. This method can be used to
+   * schedule the workflow on a different app. The target app must allow the calling app to schedule
+   * workflows on it: permission is governed by the target app's WorkflowAccessPolicy.
+   *
+   * <p>Requires a Dapr runtime with cross-app workflow support; against an older runtime the target app ID is
+   * ignored and the workflow is scheduled on the local app instead.
+   *
+   * @param appId the ID of the app that will run the new workflow
+   * @return this {@link NewWorkflowOptions} object
+   */
+  public NewWorkflowOptions setAppId(String appId) {
+    this.appId = appId;
+    return this;
+  }
+
+  /**
    * Gets the user-specified version of the new workflow.
    *
    * @return the user-specified version of the new workflow.
@@ -138,6 +157,15 @@ public class NewWorkflowOptions {
    */
   public boolean isEnforceUniqueInstanceId() {
     return this.enforceUniqueInstanceId;
+  }
+
+  /**
+   * Gets the configured app ID of the app that will run the new workflow.
+   *
+   * @return the configured app ID, or null when the workflow runs on the local app.
+   */
+  public String getAppId() {
+    return this.appId;
   }
 
 }

--- a/sdk-workflows/src/test/java/io/dapr/workflows/client/DaprWorkflowClientTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/client/DaprWorkflowClientTest.java
@@ -391,6 +391,124 @@ public class DaprWorkflowClientTest {
   }
 
   @Test
+  public void scheduleNewWorkflowWithAppIdOption() {
+    String expectedName = TestWorkflow.class.getCanonicalName();
+    String expectedAppId = "targetApp";
+    NewWorkflowOptions options = new NewWorkflowOptions().setAppId(expectedAppId);
+
+    client.scheduleNewWorkflow(TestWorkflow.class, options);
+
+    ArgumentCaptor<NewOrchestrationInstanceOptions> captor = ArgumentCaptor.forClass(
+        NewOrchestrationInstanceOptions.class
+    );
+
+    verify(mockInnerClient, times(1))
+        .scheduleNewOrchestrationInstance(eq(expectedName), captor.capture());
+
+    assertEquals(expectedAppId, captor.getValue().getAppID());
+  }
+
+  @Test
+  public void terminateWorkflowWithAppId() {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+
+    client.terminateWorkflow(expectedInstanceId, null, expectedAppId);
+
+    verify(mockInnerClient, times(1)).terminate(expectedInstanceId, null, expectedAppId);
+  }
+
+  @Test
+  public void suspendResumeWorkflowWithAppId() {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+
+    client.suspendWorkflow(expectedInstanceId, "suspending workflow instance", expectedAppId);
+    client.resumeWorkflow(expectedInstanceId, "resuming workflow instance", expectedAppId);
+
+    verify(mockInnerClient, times(1)).suspendInstance(expectedInstanceId,
+        "suspending workflow instance", expectedAppId);
+    verify(mockInnerClient, times(1)).resumeInstance(expectedInstanceId,
+        "resuming workflow instance", expectedAppId);
+  }
+
+  @Test
+  public void getWorkflowStateWithAppId() {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+
+    OrchestrationMetadata expectedMetadata = mock(OrchestrationMetadata.class);
+    when(expectedMetadata.getInstanceId()).thenReturn(expectedInstanceId);
+    when(mockInnerClient.getInstanceMetadata(expectedInstanceId, true, expectedAppId))
+        .thenReturn(expectedMetadata);
+
+    WorkflowState state = client.getWorkflowState(expectedInstanceId, true, expectedAppId);
+
+    verify(mockInnerClient, times(1)).getInstanceMetadata(expectedInstanceId, true, expectedAppId);
+    assertNotEquals(state, null);
+    assertEquals(state.getWorkflowId(), expectedMetadata.getInstanceId());
+  }
+
+  @Test
+  public void waitForWorkflowStartWithAppId() throws TimeoutException {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+    Duration timeout = Duration.ofSeconds(10);
+
+    OrchestrationMetadata expectedMetadata = mock(OrchestrationMetadata.class);
+    when(expectedMetadata.getInstanceId()).thenReturn(expectedInstanceId);
+    when(mockInnerClient.waitForInstanceStart(expectedInstanceId, timeout, true, expectedAppId))
+        .thenReturn(expectedMetadata);
+
+    WorkflowState result = client.waitForWorkflowStart(expectedInstanceId, timeout, true, expectedAppId);
+
+    verify(mockInnerClient, times(1)).waitForInstanceStart(expectedInstanceId, timeout, true, expectedAppId);
+    assertNotEquals(result, null);
+    assertEquals(result.getWorkflowId(), expectedMetadata.getInstanceId());
+  }
+
+  @Test
+  public void waitForWorkflowCompletionWithAppId() throws TimeoutException {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+    Duration timeout = Duration.ofSeconds(10);
+
+    OrchestrationMetadata expectedMetadata = mock(OrchestrationMetadata.class);
+    when(expectedMetadata.getInstanceId()).thenReturn(expectedInstanceId);
+    when(mockInnerClient.waitForInstanceCompletion(expectedInstanceId, timeout, true, expectedAppId))
+        .thenReturn(expectedMetadata);
+
+    WorkflowState result = client.waitForWorkflowCompletion(expectedInstanceId, timeout, true, expectedAppId);
+
+    verify(mockInnerClient, times(1)).waitForInstanceCompletion(expectedInstanceId, timeout, true, expectedAppId);
+    assertNotEquals(result, null);
+    assertEquals(result.getWorkflowId(), expectedMetadata.getInstanceId());
+  }
+
+  @Test
+  public void raiseEventWithAppId() {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedEventName = "TestEventName";
+    Object expectedEventPayload = new Object();
+    String expectedAppId = "targetApp";
+
+    client.raiseEvent(expectedInstanceId, expectedEventName, expectedEventPayload, expectedAppId);
+
+    verify(mockInnerClient, times(1)).raiseEvent(expectedInstanceId,
+        expectedEventName, expectedEventPayload, expectedAppId);
+  }
+
+  @Test
+  public void purgeWorkflowWithAppId() {
+    String expectedInstanceId = "TestWorkflowInstanceId";
+    String expectedAppId = "targetApp";
+
+    client.purgeWorkflow(expectedInstanceId, expectedAppId);
+
+    verify(mockInnerClient, times(1)).purgeInstance(expectedInstanceId, expectedAppId);
+  }
+
+  @Test
   public void close() throws InterruptedException {
     client.close();
     verify(mockInnerClient, times(1)).close();


### PR DESCRIPTION
Adds an optional app ID to every client-level workflow operation on DaprWorkflowClient: scheduleNewWorkflow, getWorkflowState, waitForWorkflowStart, waitForWorkflowCompletion, raiseEvent, suspendWorkflow, resumeWorkflow, terminateWorkflow and purgeWorkflow. When set, the operation targets a workflow instance owned by another app in the same namespace, and the target app's WorkflowAccessPolicy decides whether it is permitted. The existing signatures stay and delegate with a null app ID, so local behaviour is unchanged.

NewWorkflowOptions gains setAppId for scheduling a workflow on another app. DurableTaskClient mirrors the same overloads, and DurableTaskGrpcClient carries the value as a TaskRouter on each request via the new buildTaskRouter helper. An older runtime ignores the field and applies the operation to the caller's own app.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
